### PR TITLE
Don't send empty request bodies

### DIFF
--- a/lib/requester/util.js
+++ b/lib/requester/util.js
@@ -110,9 +110,10 @@ module.exports = {
         var options,
             mode = _.get(request, 'body.mode'),
             body = _.get(request, 'body'),
+            empty = request.body && request.body.isEmpty && request.body.isEmpty(),
             content;
 
-        if (!mode || !body[mode]) {
+        if (empty || !mode || !body[mode]) {
             return;
         }
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "crypto-js": "3.1.6",
     "lodash": "3.10.1",
     "node-uuid": "1.4.7",
-    "postman-collection": "0.4.1",
+    "postman-collection": "0.4.3",
     "request": "2.72.0",
     "serialised-error": "1.1.2",
     "tv4": "1.2.7",

--- a/test/integration/requester-spec.test.js
+++ b/test/integration/requester-spec.test.js
@@ -83,7 +83,7 @@ describe('Requester', function () {
                             testables.started = true;
                         });
                     },
-                    beforeIteration: function (err, cursor){
+                    beforeIteration: function (err, cursor) {
                         check(function () {
                             expect(err).to.be(null);
 
@@ -288,7 +288,7 @@ describe('Requester', function () {
                             testables.started = true;
                         });
                     },
-                    beforeIteration: function (err, cursor){
+                    beforeIteration: function (err, cursor) {
                         check(function () {
                             expect(err).to.be(null);
 
@@ -404,6 +404,610 @@ describe('Requester', function () {
 
                             expect(response.code).to.be(200);
                             expect(request).to.be.ok();
+                        });
+                    },
+                    done: function (err) {
+                        check(function () {
+                            expect(err).to.be(null);
+                            mochaDone();
+                        });
+                    }
+                });
+            });
+        });
+    });
+
+    describe('Empty Request body', function () {
+        it('should not send the request body if it is empty in the raw mode', function (mochaDone) {
+            var runner = new runtime.Runner(),
+                rawCollection = {
+                    "variables": [],
+                    "info": {
+                        "name": "EmptyRawBody",
+                        "_postman_id": "d6f7bb29-2258-4e1b-9576-b2315cf5b77e",
+                        "schema": "https://schema.getpostman.com/json/collection/v2.0.0/collection.json"
+                    },
+                    "item": [
+                        {
+                            "id": "bf0a6006-c987-253a-525d-9f6be7071210",
+                            "name": "First Request",
+                            "request": {
+                                "url": "http://echo.getpostman.com/post",
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": ""
+                                }
+                            }
+                        }
+                    ]
+                },
+                collection = new sdk.Collection(rawCollection),
+                testables = {
+                    iterationsStarted: [],
+                    iterationsComplete: [],
+                    itemsStarted: {},
+                    itemsComplete: {}
+                },  // populate during the run, and then perform tests on it, at the end.
+
+                /**
+                 * Since each callback runs in a separate callstack, this helper function
+                 * ensures that any errors are forwarded to mocha
+                 *
+                 * @param func
+                 */
+                check = function (func) {
+                    try {
+                        func();
+                    }
+                    catch (e) {
+                        mochaDone(e);
+                    }
+                };
+
+            runner.run(collection, {
+                iterationCount: 1,
+                requester: {
+                    followRedirects: false
+                }
+            }, function (err, run) {
+                var runStore = {};  // Used for validations *during* the run. Cursor increments, etc.
+
+                expect(err).to.be(null);
+                run.start({
+                    start: function (err, cursor) {
+                        check(function () {
+                            expect(err).to.be(null);
+                            expect(cursor).to.have.property('position', 0);
+                            expect(cursor).to.have.property('iteration', 0);
+                            expect(cursor).to.have.property('length', 1);
+                            expect(cursor).to.have.property('cycles', 1);
+                            expect(cursor).to.have.property('eof', false);
+                            expect(cursor).to.have.property('empty', false);
+                            expect(cursor).to.have.property('bof', true);
+                            expect(cursor).to.have.property('cr', false);
+                            expect(cursor).to.have.property('ref');
+
+                            // Set this to true, and verify at the end, so that the test will fail even if this
+                            // callback is never called.
+                            testables.started = true;
+                        });
+                    },
+                    beforeIteration: function (err, cursor) {
+                        check(function () {
+                            expect(err).to.be(null);
+
+                            testables.iterationsStarted.push(cursor.iteration);
+                            runStore.iteration = cursor.iteration;
+                        });
+                    },
+                    iteration: function (err, cursor) {
+                        check(function () {
+                            expect(err).to.be(null);
+                            expect(cursor.iteration).to.eql(runStore.iteration);
+
+                            testables.iterationsComplete.push(cursor.iteration);
+                        });
+                    },
+                    beforeItem: function (err, cursor, item) {
+                        check(function () {
+                            expect(err).to.be(null);
+
+                            testables.itemsStarted[cursor.iteration] = testables.itemsStarted[cursor.iteration] || [];
+                            testables.itemsStarted[cursor.iteration].push(item);
+                            runStore.position = cursor.position;
+                            runStore.ref = cursor.ref;
+                        });
+                    },
+                    item: function (err, cursor, item) {
+                        check(function () {
+                            expect(err).to.be(null);
+                            expect(cursor.position).to.eql(runStore.position);
+                            expect(cursor.ref).to.eql(runStore.ref);
+
+                            testables.itemsComplete[cursor.iteration] = testables.itemsComplete[cursor.iteration] || [];
+                            testables.itemsComplete[cursor.iteration].push(item);
+                        });
+                    },
+                    beforePrerequest: function (err, cursor, events, item) {
+                        check(function () {
+                            expect(err).to.be(null);
+
+                            // Sanity
+                            expect(cursor.iteration).to.eql(runStore.iteration);
+                            expect(cursor.position).to.eql(runStore.position);
+                            expect(cursor.ref).to.eql(runStore.ref);
+
+                            expect(events.length).to.be(0);
+                        });
+                    },
+                    prerequest: function (err, cursor, results, item) {
+                        check(function () {
+                            expect(err).to.be(null);
+
+                            // Sanity
+                            expect(cursor.iteration).to.eql(runStore.iteration);
+                            expect(cursor.position).to.eql(runStore.position);
+                            expect(cursor.ref).to.eql(runStore.ref);
+
+                            // This collection has no pre-request scripts
+                            expect(results).to.be.empty();
+                        });
+                    },
+                    beforeTest: function (err, cursor, events, item) {
+                        check(function () {
+                            expect(err).to.be(null);
+
+                            // Sanity
+                            expect(cursor.iteration).to.eql(runStore.iteration);
+                            expect(cursor.position).to.eql(runStore.position);
+                            expect(cursor.ref).to.eql(runStore.ref);
+
+                            // This collection has no pre-request scripts
+                            expect(events).to.be.empty();
+                        });
+                    },
+                    test: function (err, cursor, results, item) {
+                        check(function () {
+                            expect(err).to.be(null);
+
+                            // Sanity
+                            expect(cursor.iteration).to.eql(runStore.iteration);
+                            expect(cursor.position).to.eql(runStore.position);
+                            expect(cursor.ref).to.eql(runStore.ref);
+                            expect(results).to.be.empty();
+                        });
+                    },
+                    beforeRequest: function (err, cursor, request, item) {
+                        check(function () {
+                            expect(err).to.be(null);
+
+                            // Sanity
+                            expect(cursor.iteration).to.eql(runStore.iteration);
+                            expect(cursor.position).to.eql(runStore.position);
+                            expect(cursor.ref).to.eql(runStore.ref);
+                        });
+                    },
+                    request: function (err, cursor, response, request, item) {
+                        check(function () {
+                            expect(err).to.be(null);
+
+                            expect(request.url.toString()).to.be.ok();
+
+                            // Sanity
+                            expect(cursor.iteration).to.eql(runStore.iteration);
+                            expect(cursor.position).to.eql(runStore.position);
+                            expect(cursor.ref).to.eql(runStore.ref);
+
+                            expect(response.code).to.be(200);
+                            expect(request).to.be.ok();
+
+                            var body = JSON.parse(response.body);
+                            expect(body.args).to.be.empty();
+                            expect(body.data).to.be.empty();
+                            expect(body.files).to.be.empty();
+                            expect(body.form).to.be.empty();
+                        });
+                    },
+                    done: function (err) {
+                        check(function () {
+                            expect(err).to.be(null);
+                            mochaDone();
+                        });
+                    }
+                });
+            });
+        });
+
+        it('should not send the request body if it is empty in the urlencoded mode', function (mochaDone) {
+            var runner = new runtime.Runner(),
+                rawCollection = {
+                    "variables": [],
+                    "info": {
+                        "name": "EmptyRawBody",
+                        "_postman_id": "d6f7bb29-2258-4e1b-9576-b2315cf5b77e",
+                        "schema": "https://schema.getpostman.com/json/collection/v2.0.0/collection.json"
+                    },
+                    "item": [
+                        {
+                            "id": "bf0a6006-c987-253a-525d-9f6be7071210",
+                            "name": "First Request",
+                            "request": {
+                                "url": "http://echo.getpostman.com/post",
+                                "method": "POST",
+                                "body": {
+                                    "mode": "urlencoded",
+                                    "urlencoded": []
+                                }
+                            }
+                        }
+                    ]
+                },
+                collection = new sdk.Collection(rawCollection),
+                testables = {
+                    iterationsStarted: [],
+                    iterationsComplete: [],
+                    itemsStarted: {},
+                    itemsComplete: {}
+                },  // populate during the run, and then perform tests on it, at the end.
+
+                /**
+                 * Since each callback runs in a separate callstack, this helper function
+                 * ensures that any errors are forwarded to mocha
+                 *
+                 * @param func
+                 */
+                check = function (func) {
+                    try {
+                        func();
+                    }
+                    catch (e) {
+                        mochaDone(e);
+                    }
+                };
+
+            runner.run(collection, {
+                iterationCount: 1,
+                requester: {
+                    followRedirects: false
+                }
+            }, function (err, run) {
+                var runStore = {};  // Used for validations *during* the run. Cursor increments, etc.
+
+                expect(err).to.be(null);
+                run.start({
+                    start: function (err, cursor) {
+                        check(function () {
+                            expect(err).to.be(null);
+                            expect(cursor).to.have.property('position', 0);
+                            expect(cursor).to.have.property('iteration', 0);
+                            expect(cursor).to.have.property('length', 1);
+                            expect(cursor).to.have.property('cycles', 1);
+                            expect(cursor).to.have.property('eof', false);
+                            expect(cursor).to.have.property('empty', false);
+                            expect(cursor).to.have.property('bof', true);
+                            expect(cursor).to.have.property('cr', false);
+                            expect(cursor).to.have.property('ref');
+
+                            // Set this to true, and verify at the end, so that the test will fail even if this
+                            // callback is never called.
+                            testables.started = true;
+                        });
+                    },
+                    beforeIteration: function (err, cursor) {
+                        check(function () {
+                            expect(err).to.be(null);
+
+                            testables.iterationsStarted.push(cursor.iteration);
+                            runStore.iteration = cursor.iteration;
+                        });
+                    },
+                    iteration: function (err, cursor) {
+                        check(function () {
+                            expect(err).to.be(null);
+                            expect(cursor.iteration).to.eql(runStore.iteration);
+
+                            testables.iterationsComplete.push(cursor.iteration);
+                        });
+                    },
+                    beforeItem: function (err, cursor, item) {
+                        check(function () {
+                            expect(err).to.be(null);
+
+                            testables.itemsStarted[cursor.iteration] = testables.itemsStarted[cursor.iteration] || [];
+                            testables.itemsStarted[cursor.iteration].push(item);
+                            runStore.position = cursor.position;
+                            runStore.ref = cursor.ref;
+                        });
+                    },
+                    item: function (err, cursor, item) {
+                        check(function () {
+                            expect(err).to.be(null);
+                            expect(cursor.position).to.eql(runStore.position);
+                            expect(cursor.ref).to.eql(runStore.ref);
+
+                            testables.itemsComplete[cursor.iteration] = testables.itemsComplete[cursor.iteration] || [];
+                            testables.itemsComplete[cursor.iteration].push(item);
+                        });
+                    },
+                    beforePrerequest: function (err, cursor, events, item) {
+                        check(function () {
+                            expect(err).to.be(null);
+
+                            // Sanity
+                            expect(cursor.iteration).to.eql(runStore.iteration);
+                            expect(cursor.position).to.eql(runStore.position);
+                            expect(cursor.ref).to.eql(runStore.ref);
+
+                            expect(events.length).to.be(0);
+                        });
+                    },
+                    prerequest: function (err, cursor, results, item) {
+                        check(function () {
+                            expect(err).to.be(null);
+
+                            // Sanity
+                            expect(cursor.iteration).to.eql(runStore.iteration);
+                            expect(cursor.position).to.eql(runStore.position);
+                            expect(cursor.ref).to.eql(runStore.ref);
+
+                            // This collection has no pre-request scripts
+                            expect(results).to.be.empty();
+                        });
+                    },
+                    beforeTest: function (err, cursor, events, item) {
+                        check(function () {
+                            expect(err).to.be(null);
+
+                            // Sanity
+                            expect(cursor.iteration).to.eql(runStore.iteration);
+                            expect(cursor.position).to.eql(runStore.position);
+                            expect(cursor.ref).to.eql(runStore.ref);
+
+                            // This collection has no pre-request scripts
+                            expect(events).to.be.empty();
+                        });
+                    },
+                    test: function (err, cursor, results, item) {
+                        check(function () {
+                            expect(err).to.be(null);
+
+                            // Sanity
+                            expect(cursor.iteration).to.eql(runStore.iteration);
+                            expect(cursor.position).to.eql(runStore.position);
+                            expect(cursor.ref).to.eql(runStore.ref);
+                            expect(results).to.be.empty();
+                        });
+                    },
+                    beforeRequest: function (err, cursor, request, item) {
+                        check(function () {
+                            expect(err).to.be(null);
+
+                            // Sanity
+                            expect(cursor.iteration).to.eql(runStore.iteration);
+                            expect(cursor.position).to.eql(runStore.position);
+                            expect(cursor.ref).to.eql(runStore.ref);
+                        });
+                    },
+                    request: function (err, cursor, response, request, item) {
+                        check(function () {
+                            expect(err).to.be(null);
+
+                            expect(request.url.toString()).to.be.ok();
+
+                            // Sanity
+                            expect(cursor.iteration).to.eql(runStore.iteration);
+                            expect(cursor.position).to.eql(runStore.position);
+                            expect(cursor.ref).to.eql(runStore.ref);
+
+                            expect(response.code).to.be(200);
+                            expect(request).to.be.ok();
+
+                            var body = JSON.parse(response.body);
+                            expect(body.args).to.be.empty();
+                            expect(body.data).to.be.empty();
+                            expect(body.files).to.be.empty();
+                            expect(body.form).to.be.empty();
+                        });
+                    },
+                    done: function (err) {
+                        check(function () {
+                            expect(err).to.be(null);
+                            mochaDone();
+                        });
+                    }
+                });
+            });
+        });
+        it('should not send the request body if it is empty in the formdata mode', function (mochaDone) {
+            var runner = new runtime.Runner(),
+                rawCollection = {
+                    "variables": [],
+                    "info": {
+                        "name": "EmptyRawBody",
+                        "_postman_id": "d6f7bb29-2258-4e1b-9576-b2315cf5b77e",
+                        "schema": "https://schema.getpostman.com/json/collection/v2.0.0/collection.json"
+                    },
+                    "item": [
+                        {
+                            "id": "bf0a6006-c987-253a-525d-9f6be7071210",
+                            "name": "First Request",
+                            "request": {
+                                "url": "http://echo.getpostman.com/post",
+                                "method": "POST",
+                                "body": {
+                                    "mode": "formdata",
+                                    "formdata": []
+                                }
+                            }
+                        }
+                    ]
+                },
+                collection = new sdk.Collection(rawCollection),
+                testables = {
+                    iterationsStarted: [],
+                    iterationsComplete: [],
+                    itemsStarted: {},
+                    itemsComplete: {}
+                },  // populate during the run, and then perform tests on it, at the end.
+
+                /**
+                 * Since each callback runs in a separate callstack, this helper function
+                 * ensures that any errors are forwarded to mocha
+                 *
+                 * @param func
+                 */
+                check = function (func) {
+                    try {
+                        func();
+                    }
+                    catch (e) {
+                        mochaDone(e);
+                    }
+                };
+
+            runner.run(collection, {
+                iterationCount: 1,
+                requester: {
+                    followRedirects: false
+                }
+            }, function (err, run) {
+                var runStore = {};  // Used for validations *during* the run. Cursor increments, etc.
+
+                expect(err).to.be(null);
+                run.start({
+                    start: function (err, cursor) {
+                        check(function () {
+                            expect(err).to.be(null);
+                            expect(cursor).to.have.property('position', 0);
+                            expect(cursor).to.have.property('iteration', 0);
+                            expect(cursor).to.have.property('length', 1);
+                            expect(cursor).to.have.property('cycles', 1);
+                            expect(cursor).to.have.property('eof', false);
+                            expect(cursor).to.have.property('empty', false);
+                            expect(cursor).to.have.property('bof', true);
+                            expect(cursor).to.have.property('cr', false);
+                            expect(cursor).to.have.property('ref');
+
+                            // Set this to true, and verify at the end, so that the test will fail even if this
+                            // callback is never called.
+                            testables.started = true;
+                        });
+                    },
+                    beforeIteration: function (err, cursor) {
+                        check(function () {
+                            expect(err).to.be(null);
+
+                            testables.iterationsStarted.push(cursor.iteration);
+                            runStore.iteration = cursor.iteration;
+                        });
+                    },
+                    iteration: function (err, cursor) {
+                        check(function () {
+                            expect(err).to.be(null);
+                            expect(cursor.iteration).to.eql(runStore.iteration);
+
+                            testables.iterationsComplete.push(cursor.iteration);
+                        });
+                    },
+                    beforeItem: function (err, cursor, item) {
+                        check(function () {
+                            expect(err).to.be(null);
+
+                            testables.itemsStarted[cursor.iteration] = testables.itemsStarted[cursor.iteration] || [];
+                            testables.itemsStarted[cursor.iteration].push(item);
+                            runStore.position = cursor.position;
+                            runStore.ref = cursor.ref;
+                        });
+                    },
+                    item: function (err, cursor, item) {
+                        check(function () {
+                            expect(err).to.be(null);
+                            expect(cursor.position).to.eql(runStore.position);
+                            expect(cursor.ref).to.eql(runStore.ref);
+
+                            testables.itemsComplete[cursor.iteration] = testables.itemsComplete[cursor.iteration] || [];
+                            testables.itemsComplete[cursor.iteration].push(item);
+                        });
+                    },
+                    beforePrerequest: function (err, cursor, events, item) {
+                        check(function () {
+                            expect(err).to.be(null);
+
+                            // Sanity
+                            expect(cursor.iteration).to.eql(runStore.iteration);
+                            expect(cursor.position).to.eql(runStore.position);
+                            expect(cursor.ref).to.eql(runStore.ref);
+
+                            expect(events.length).to.be(0);
+                        });
+                    },
+                    prerequest: function (err, cursor, results, item) {
+                        check(function () {
+                            expect(err).to.be(null);
+
+                            // Sanity
+                            expect(cursor.iteration).to.eql(runStore.iteration);
+                            expect(cursor.position).to.eql(runStore.position);
+                            expect(cursor.ref).to.eql(runStore.ref);
+
+                            // This collection has no pre-request scripts
+                            expect(results).to.be.empty();
+                        });
+                    },
+                    beforeTest: function (err, cursor, events, item) {
+                        check(function () {
+                            expect(err).to.be(null);
+
+                            // Sanity
+                            expect(cursor.iteration).to.eql(runStore.iteration);
+                            expect(cursor.position).to.eql(runStore.position);
+                            expect(cursor.ref).to.eql(runStore.ref);
+
+                            // This collection has no pre-request scripts
+                            expect(events).to.be.empty();
+                        });
+                    },
+                    test: function (err, cursor, results, item) {
+                        check(function () {
+                            expect(err).to.be(null);
+
+                            // Sanity
+                            expect(cursor.iteration).to.eql(runStore.iteration);
+                            expect(cursor.position).to.eql(runStore.position);
+                            expect(cursor.ref).to.eql(runStore.ref);
+                            expect(results).to.be.empty();
+                        });
+                    },
+                    beforeRequest: function (err, cursor, request, item) {
+                        check(function () {
+                            expect(err).to.be(null);
+
+                            // Sanity
+                            expect(cursor.iteration).to.eql(runStore.iteration);
+                            expect(cursor.position).to.eql(runStore.position);
+                            expect(cursor.ref).to.eql(runStore.ref);
+                        });
+                    },
+                    request: function (err, cursor, response, request, item) {
+                        check(function () {
+                            expect(err).to.be(null);
+
+                            expect(request.url.toString()).to.be.ok();
+
+                            // Sanity
+                            expect(cursor.iteration).to.eql(runStore.iteration);
+                            expect(cursor.position).to.eql(runStore.position);
+                            expect(cursor.ref).to.eql(runStore.ref);
+
+                            expect(response.code).to.be(200);
+                            expect(request).to.be.ok();
+
+                            var body = JSON.parse(response.body);
+                            expect(body.args).to.be.empty();
+                            expect(body.data).to.be.empty();
+                            expect(body.files).to.be.empty();
+                            expect(body.form).to.be.empty();
                         });
                     },
                     done: function (err) {

--- a/test/system/nsp.test.js
+++ b/test/system/nsp.test.js
@@ -35,7 +35,7 @@ describe('nsp', function () {
         // if you are changing the version here, most probably you are better of removing the exclusion in first place.
         // remove the exclusion and check if nsp passes, else update the version here
         it('on excluded package\'s version change must reconsider removing exclusion', function () {
-            expect(pkg.dependencies).to.have.property('postman-collection', '0.4.1');
+            expect(pkg.dependencies).to.have.property('postman-collection', '0.4.3');
         });
     });
 });


### PR DESCRIPTION
Currently, if the request body is empty, runtime still adds a header for form-data (the form-data boundary).

This PR fixes this.