### PR TITLE
ensure XHR compatible url-encoding of parameters

### DIFF
--- a/lib/requester/util.js
+++ b/lib/requester/util.js
@@ -30,6 +30,10 @@ module.exports = {
         options.jar = defaultOpts.cookieJar || true;
         options.timeout = defaultOpts.timeout;
         options.gzip = true;
+
+        // Ensures that "request" creates URL encoded formdata or querystring as
+        // foo=bar&foo=baz instead of foo[0]=bar&foo[1]=baz
+        options.useQuerystring = true;
         options.strictSSL = defaultOpts.strictSSL;
 
         //keeping the same convention as Newman


### PR DESCRIPTION
Ensures that "request" creates URL encoded formdata or querystring as
```
foo=bar&foo=baz
``` 
instead of 
```
foo[0]=bar&foo[1]=baz
``` 