### PR TITLE
fixed handling of duplicate url-encoded bodies in the browser requester

### DIFF
--- a/lib/requester/browser/request.js
+++ b/lib/requester/browser/request.js
@@ -87,7 +87,14 @@ function request(options, callback) {
         var str = [];
         for(var p in obj)
             if (obj.hasOwnProperty(p)) {
-                str.push(encodeURIComponent(p) + "=" + encodeURIComponent(obj[p]));
+                if (_.isArray(obj[p])) {
+                    _.each(obj[p], function (value) {
+                        str.push(encodeURIComponent(p) + "=" + encodeURIComponent(value));
+                    });
+                }
+                else {
+                    str.push(encodeURIComponent(p) + "=" + encodeURIComponent(obj[p]));
+                }
             }
         return str.join("&");
     }


### PR DESCRIPTION
This ensures that the browser correctly sends duplicate urlencoded body parameters