### PR TITLE
Added content-encoding handlers

### DIFF
--- a/lib/requester/browser/request.js
+++ b/lib/requester/browser/request.js
@@ -182,6 +182,7 @@ function run_xhr(options) {
     xhr.seq_id = req_seq
     xhr.id = req_seq + ': ' + options.method + ' ' + options.uri
     xhr._id = xhr.id // I know I will type "_id" from habit all the time.
+    xhr.on = function(){}; // For compatibility with the request module
 
     if(is_cors && !supports_cors) {
         // This should never happen in our app

--- a/lib/requester/requester.js
+++ b/lib/requester/requester.js
@@ -65,7 +65,9 @@ Requester.prototype.request = function (item, cb, scope) {
             strictSSL: this.strictSSL,
             followRedirects: this.followRedirects
         }),
-        startTime = Date.now();
+        startTime = Date.now(),
+        rawResponse = '';
+
 
     return requests(requestOptions, function (err, res, resBody) {
         if (err) {
@@ -99,17 +101,34 @@ Requester.prototype.request = function (item, cb, scope) {
                 },
                 responseCookies: cookies
             },
+            contentEncoding = response.responseHeaders && response.responseHeaders['Content-Encoding'],
+            encodedData = contentEncoding && (rawResponse ? rawResponse : util.getEncodedBody(
+                response.responseBody, contentEncoding)),
             responseObj = { // @todo get rid of jsonifyResponse
                 code: response.responseCode.code,
                 header: response.responseHeaders,
                 body: responseString,
                 stream: resBody,
                 cookie: undefined, // @todo get from cookieJar and implement loading/unloading in SDK
-                responseTime: responseTime
+                responseTime: responseTime,
+                encodedData: encodedData
             };
 
         cb.call(scope || this, null, response, actualRequest, responseObj, request);
-    });
+    })
+    .on('response', function(response) {
+        if(response.headers['content-encoding']) {
+            var chunks = [];
+            response.on('data', function(chunk) {
+                chunks.push(chunk);
+            })
+            .on('end', function() {
+                chunks.forEach(function(chunk) {
+                    rawResponse += util.arrayBufferToString(chunk);
+                });
+            })
+        }
+    })
 };
 
 module.exports.Requester = Requester;

--- a/lib/requester/requester.js
+++ b/lib/requester/requester.js
@@ -66,7 +66,7 @@ Requester.prototype.request = function (item, cb, scope) {
             followRedirects: this.followRedirects
         }),
         startTime = Date.now(),
-        rawResponse = '';
+        rawResponse;
 
 
     return requests(requestOptions, function (err, res, resBody) {
@@ -101,9 +101,6 @@ Requester.prototype.request = function (item, cb, scope) {
                 },
                 responseCookies: cookies
             },
-            contentEncoding = response.responseHeaders && response.responseHeaders['Content-Encoding'],
-            encodedData = contentEncoding && (rawResponse ? rawResponse : util.getEncodedBody(
-                response.responseBody, contentEncoding)),
             responseObj = { // @todo get rid of jsonifyResponse
                 code: response.responseCode.code,
                 header: response.responseHeaders,
@@ -111,7 +108,7 @@ Requester.prototype.request = function (item, cb, scope) {
                 stream: resBody,
                 cookie: undefined, // @todo get from cookieJar and implement loading/unloading in SDK
                 responseTime: responseTime,
-                encodedData: encodedData
+                raw: rawResponse
             };
 
         cb.call(scope || this, null, response, actualRequest, responseObj, request);
@@ -123,7 +120,7 @@ Requester.prototype.request = function (item, cb, scope) {
                 chunks.push(chunk);
             })
             .on('end', function() {
-                rawResponse = util.arrayBufferToString(Buffer.concat(chunks));
+                rawResponse = Buffer.concat(chunks);
             })
         }
     })

--- a/lib/requester/requester.js
+++ b/lib/requester/requester.js
@@ -123,9 +123,7 @@ Requester.prototype.request = function (item, cb, scope) {
                 chunks.push(chunk);
             })
             .on('end', function() {
-                chunks.forEach(function(chunk) {
-                    rawResponse += util.arrayBufferToString(chunk);
-                });
+                rawResponse = util.arrayBufferToString(Buffer.concat(chunks));
             })
         }
     })

--- a/lib/requester/util.js
+++ b/lib/requester/util.js
@@ -1,6 +1,5 @@
 var _ = require('lodash'),
     sdk = require('postman-collection'),
-    pako = require('pako'),
     version = require('../../package.json').version;
 
 module.exports = {
@@ -61,11 +60,6 @@ module.exports = {
         });
         return options
     },
-
-    getEncodedBody: function(body, encoding) {
-        return body && encoding && pako[encoding] && pako[encoding](body);
-    },
-
     /**
      * Checks if a header already exists. If it does not, sets the value to whatever is passed as
      * `defaultValue`

--- a/lib/requester/util.js
+++ b/lib/requester/util.js
@@ -1,5 +1,6 @@
 var _ = require('lodash'),
     sdk = require('postman-collection'),
+    pako = require('pako'),
     version = require('../../package.json').version;
 
 module.exports = {
@@ -59,6 +60,10 @@ module.exports = {
             }
         });
         return options
+    },
+
+    getEncodedBody: function(body, encoding) {
+        return body && encoding && pako[encoding] && pako[encoding](body);
     },
 
     /**

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "crypto-js": "3.1.6",
     "lodash": "3.10.1",
     "node-uuid": "1.4.7",
-    "pako": "1.0.3",
     "postman-collection": "^0.4.6",
     "request": "^2.74.0",
     "serialised-error": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "crypto-js": "3.1.6",
     "lodash": "3.10.1",
     "node-uuid": "1.4.7",
+    "pako": "1.0.3",
     "postman-collection": "^0.4.6",
     "request": "^2.74.0",
     "serialised-error": "^1.1.2",


### PR DESCRIPTION
Experimental. But gets the correct size for encoded content `gzip` and `deflate` for both browser and node.