### PR TITLE
ensure that 'false' is casted to a string when using postman api

### DIFF
--- a/lib/uvm/browser/sandbox-bus-start.js
+++ b/lib/uvm/browser/sandbox-bus-start.js
@@ -252,7 +252,8 @@
                 return insensitiveHeaders[headerString.toLowerCase()];
             } : undefined,
             setEnvironmentVariable: function (key, value) {
-                value && value.toString && (typeof value.toString === 'function') && (value = value.toString());
+                (value === false || value)
+                    && value.toString && (typeof value.toString === 'function') && (value = value.toString());
                 environment[key] = value;
             },
             getEnvironmentVariable: function (key) {
@@ -272,7 +273,8 @@
                 return globals[key];
             },
             setGlobalVariable: function (key, value) {
-                value && value.toString && (typeof value.toString === 'function') && (value = value.toString());
+                (value === false || value)
+                    && value.toString && (typeof value.toString === 'function') && (value = value.toString());
                 globals[key] = value;
             },
             clearGlobalVariables: function () {

--- a/lib/uvm/browser/sandbox-bus-start.js
+++ b/lib/uvm/browser/sandbox-bus-start.js
@@ -252,8 +252,8 @@
                 return insensitiveHeaders[headerString.toLowerCase()];
             } : undefined,
             setEnvironmentVariable: function (key, value) {
-                (value === false || value)
-                    && value.toString && (typeof value.toString === 'function') && (value = value.toString());
+                (value === false || value) &&
+                    value.toString && (typeof value.toString === 'function') && (value = value.toString());
                 environment[key] = value;
             },
             getEnvironmentVariable: function (key) {
@@ -273,8 +273,8 @@
                 return globals[key];
             },
             setGlobalVariable: function (key, value) {
-                (value === false || value)
-                    && value.toString && (typeof value.toString === 'function') && (value = value.toString());
+                (value === false || value) &&
+                    value.toString && (typeof value.toString === 'function') && (value = value.toString());
                 globals[key] = value;
             },
             clearGlobalVariables: function () {

--- a/lib/uvm/postman-api.js
+++ b/lib/uvm/postman-api.js
@@ -34,8 +34,8 @@
                 return insensitiveHeaders[headerString.toLowerCase()];
             } : undefined,
             setEnvironmentVariable: function (key, value) {
-                (value === false || value)
-                    && value.toString && (typeof value.toString === 'function') && (value = value.toString());
+                (value === false || value) &&
+                    value.toString && (typeof value.toString === 'function') && (value = value.toString());
                 environment[key] = value;
             },
             getEnvironmentVariable: function (key) {
@@ -55,8 +55,8 @@
                 return globals[key];
             },
             setGlobalVariable: function (key, value) {
-                (value === false || value)
-                    && value.toString && (typeof value.toString === 'function') && (value = value.toString());
+                (value === false || value) &&
+                    value.toString && (typeof value.toString === 'function') && (value = value.toString());
                 globals[key] = value;
             },
             clearGlobalVariables: function () {

--- a/lib/uvm/postman-api.js
+++ b/lib/uvm/postman-api.js
@@ -34,7 +34,8 @@
                 return insensitiveHeaders[headerString.toLowerCase()];
             } : undefined,
             setEnvironmentVariable: function (key, value) {
-                value && value.toString && (typeof value.toString === 'function') && (value = value.toString());
+                (value === false || value)
+                    && value.toString && (typeof value.toString === 'function') && (value = value.toString());
                 environment[key] = value;
             },
             getEnvironmentVariable: function (key) {
@@ -54,7 +55,8 @@
                 return globals[key];
             },
             setGlobalVariable: function (key, value) {
-                value && value.toString && (typeof value.toString === 'function') && (value = value.toString());
+                (value === false || value)
+                    && value.toString && (typeof value.toString === 'function') && (value = value.toString());
                 globals[key] = value;
             },
             clearGlobalVariables: function () {


### PR DESCRIPTION
A flawed check for value caused the value to not be set as a string if it is `false`. That is now corrected.