### PR TITLE
ensure that correct sent headers are bubbled up from the request

### DIFF
--- a/lib/requester/requester.js
+++ b/lib/requester/requester.js
@@ -120,9 +120,7 @@ Requester.prototype.request = function (item, cb, scope) {
         _.forOwn(legacyRequest.headers, function (value, key) {
             // todo: this should also be done in the request utils, so that it's appropriately updated there,
             // and there's a clear separation between what we added vs what Node added.
-            if (!request.headers.one(key)) {
-                request.addHeader({ key: key, value: value });
-            }
+            request.upsertHeader({ key: key, value: value });
         });
 
         cb.call(scope || this, null, legacyResponse, legacyRequest, response, request);


### PR DESCRIPTION
`postman-request` sometimes changes headers. 

For example, if the content type is set to `formdata`, and the request already contains a `content-type` header set to `something`, it will be replaced with `multipart/formdata` + boundary. This behavior is good, and expected.

These changes made by `postman-request` were not being bubbled up from runtime before. This change ensures that they are.