### PR TITLE
ensure that we don't override content type if one is already given

### DIFF
--- a/lib/requester/browser/request.js
+++ b/lib/requester/browser/request.js
@@ -128,7 +128,11 @@ function request(options, callback) {
         }
         if((new RegExp(METHODS_WITH_BODY.join('|'), 'i')).test(options.method)){
             var encoding = (options.encoding || 'application/x-www-form-urlencoded').toLowerCase();
-            options.headers['content-type'] = encoding;
+
+            if (!options.headers['content-type'] && !options.headers['Content-Type']) {
+                options.headers['content-type'] = encoding;
+            }
+
             switch(encoding){
                 case 'application/x-www-form-urlencoded':
                     options.body = serialize(options.form).replace(/%20/g, "+");


### PR DESCRIPTION
This fixes a bug which causes duplicate content type to be added sometimes.