### PR TITLE
Using VariableScope instead of normal objects for Environment and Globals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Postman Runtime Changelog
 
+#### Unreleased
+* [Breaking] Changed the runtime API to receive a VariableScope instead of plain object
+
 #### 2.5.2 (September 21, 2016)
 * Updated version of `postman-collection`, which contains bugfixes for AWS Auth and file uploads
 
@@ -51,7 +54,7 @@
 
 #### 2.2.5 (July 30, 2016)
 * Added support for exposing "responseCookies" array and "getResponseCookie" function in the sandbox
-* Fixed file handling behavior, now the runner will ignore files (with a warning) if no fileResolver is provided 
+* Fixed file handling behavior, now the runner will ignore files (with a warning) if no fileResolver is provided
 
 #### 2.2.4 (July 29, 2016)
 * Fixed a bug that caused non-file form data to be ignored

--- a/lib/runner/extensions/event.command.js
+++ b/lib/runner/extensions/event.command.js
@@ -184,14 +184,18 @@ module.exports = {
                     },
                     // while passing value of ctx, we directly use payload.ctx and not make a local copy to ensure we
                     // have the live copy
-                    globals: _.cloneDeep(payload.context)
+                    globals: preProcessContext(payload.context, track)
                 }, function (err, result) {
                      // electron IPC does not bubble errors to the browser process, so we serialize it here.
                     err && (err = serialisedError(err, true));
 
                     // if it is defined that certain variables are to be synced back to result, we do the same
                     track && result && result.globals && track.forEach(function (variable) {
-                        _.isObject(result.globals[variable]) &&
+                        if (!_.isObject(result.globals[variable])) { return; }
+
+                        // ensure that variablescope is treated accordingly
+                        _.isFunction(payload.context[variable].syncVariablesFrom) ?
+                            payload.context[variable].syncVariablesFrom(result.globals[variable]) :
                             util.syncObject(payload.context[variable], result.globals[variable]);
                     });
 

--- a/lib/runner/extensions/event.command.js
+++ b/lib/runner/extensions/event.command.js
@@ -7,6 +7,21 @@ var _ = require('lodash'),
 
     ASSERTION_FAILURE = 'AssertionFailure',
 
+    preProcessContext = function (context, trackables) {
+        if (!(trackables && trackables.length)) {
+            return _.cloneDeep(context);
+        }
+
+        var shadowContext = _.cloneDeep(_.omit(context, trackables));
+
+        _.forEach(trackables, function (key) {
+            shadowContext[key] = _.isFunction(context[key].syncVariablesTo) ? context[key].syncVariablesTo({}) :
+                _.cloneDeep(context[key]);
+        });
+
+        return shadowContext;
+    },
+
     postProcessContext = function (globals) {  // This function determines whether the event needs to abort
         var tests = globals && globals.tests,
             failures,

--- a/lib/runner/extensions/request.command.js
+++ b/lib/runner/extensions/request.command.js
@@ -128,6 +128,7 @@ module.exports = {
          */
         request: function (payload, next) {
             // @todo - resolve variables in a more graceful way
+            // @todo - no need to sync vatiables when SDK starts supporting resolution from scope directly
             var item = new sdk.Item(payload.item.toObjectResolved(null,
                 [payload.data, payload.environment.syncVariablesTo({}), payload.globals.syncVariablesTo({})])),
 

--- a/lib/runner/extensions/request.command.js
+++ b/lib/runner/extensions/request.command.js
@@ -119,8 +119,8 @@ module.exports = {
          * @param {Object} payload
          * @param {Item} payload.item
          * @param {Object} payload.data
-         * @param {Object} payload.globals
-         * @param {Object} payload.environment
+         * @param {VariableScope} payload.globals
+         * @param {VariableScope} payload.environment
          * @param {Cursor} payload.coords
          * @param {Function} next
          *
@@ -129,7 +129,7 @@ module.exports = {
         request: function (payload, next) {
             // @todo - resolve variables in a more graceful way
             var item = new sdk.Item(payload.item.toObjectResolved(null,
-                [payload.data, payload.environment, payload.globals])),
+                [payload.data, payload.environment.syncVariablesTo({}), payload.globals.syncVariablesTo({})])),
 
                 abortOnError = _.has(payload, 'abortOnError') ? payload.abortOnError : this.options.abortOnError,
                 self = this;

--- a/lib/runner/extensions/waterfall.command.js
+++ b/lib/runner/extensions/waterfall.command.js
@@ -1,5 +1,6 @@
 var _ = require('lodash'),
     Cursor = require('../cursor'),
+    VariableScope = require('postman-collection').VariableScope,
 
     prepareLookupHash,
     extractSNR;
@@ -57,8 +58,8 @@ module.exports = {
         _.isArray(state.globals) && (state.globals = _(state.globals).indexBy('key').mapValues('value').value());
 
         // sanitise state object
-        !_.isObject(state.environment) && (state.environment = {});
-        !_.isObject(state.globals) && (state.globals = {});
+        state.environment = new VariableScope(state.environment);
+        state.globals = new VariableScope(state.globals);
 
         // ensure that the items and iteration data set is in place
         !_.isArray(state.items) && (state.items = []);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postman-runtime",
-  "version": "2.5.4",
+  "version": "2.5.4-beta.1",
   "description": "Underlyng library of executing Postman Collections (used by Newman)",
   "main": "index.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "http-reasons": "0.1.0",
     "lodash": "3.10.1",
     "node-uuid": "1.4.7",
-    "postman-collection": "0.5.2",
+    "postman-collection": "0.5.3-beta.1",
     "postman-request": "2.74.1-postman.2",
     "resolve-from": "2.0.0",
     "serialised-error": "1.1.2",

--- a/test/integration/sanity/query-parameters.test.js
+++ b/test/integration/sanity/query-parameters.test.js
@@ -8,7 +8,9 @@ describe('query parameters', function () {
                     {request: 'http://httpbin.org/get?a=обязательный&c=d'}
                 ]
             },
-            environment: {testVar: 'test-var-value'}
+            environment: {
+                values: [{key: 'testVar', value: 'test-var-value'}]
+            }
         }, function (err, results) {
             testrun = results;
             done(err);

--- a/test/integration/sanity/simple-sanity.test.js
+++ b/test/integration/sanity/simple-sanity.test.js
@@ -6,7 +6,9 @@ describe('sanity test', function () {
             collection: {
                 item: {request: 'https://echo.getpostman.com/get?testvar={{testVar}}'}
             },
-            environment: {testVar: 'test-var-value'}
+            environment: {
+                values: [{key: 'testVar', value: 'test-var-value'}]
+            }
         }, function (err, results) {
             testrun = results;
             done(err);

--- a/test/integration/sanity/url-sanity-before-request.test.js
+++ b/test/integration/sanity/url-sanity-before-request.test.js
@@ -19,7 +19,7 @@ describe('url sanity test', function () {
                 }
             },
             globals: {
-                url: 'http://httpbin.org'
+                values: [{key: 'url', value: 'http://httpbin.org'}]
             }
         }, function (err, results) {
             testrun = results;


### PR DESCRIPTION
**This is a breaking API. So, merge it when you're ready to release v3.**

- this PR now expects globals and environments to be either sent as `VariableScope` or as in a format that `VariableScope` recognises

- this PR tries to do minimal change while enabling this feature and as such, code might appear hacky. the changes are contained within event and request commands