### PR TITLE
Remove non-existing directories from `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,7 @@
   "description": "Underlyng library of executing Postman Collections (used by Newman)",
   "main": "index.js",
   "directories": {
-    "example": "example",
-    "man": "man",
+    "lib": "lib",
     "test": "test"
   },
   "scripts": {


### PR DESCRIPTION
Thanks to @jaydeep17 for his comment: [yarnpkg/yarn#739 (comment)](https://github.com/yarnpkg/yarn/issues/739#issuecomment-255598619)

This change allows installing this package (or a parent) with yarn.