### PR TITLE
do not try to set blacklisted headers on Chrome

### DIFF
--- a/lib/requester/browser/request.js
+++ b/lib/requester/browser/request.js
@@ -21,6 +21,7 @@ request.log = {
 
 var METHODS_WITH_BODY = ['POST', 'PUT', 'PATCH', 'OPTIONS', 'DELETE'];
 var DEFAULT_TIMEOUT = 3 * 60 * 1000 // 3 minutes
+var BLACKLISTED_HEADERS = ['host', 'user-agent'];
 
 //
 // request
@@ -64,7 +65,10 @@ function request(options, callback) {
 
     options.callback = callback
     options.method = options.method || 'GET';
-    options.headers = options.headers || {};
+    options.headers = _.reduce(options.headers || {}, function (accumulator, value, key) {
+        !BLACKLISTED_HEADERS[key.toLowerCase()] && (accumulator[key] = value);
+        return accumulator;
+    });
     options.body    = options.body || null
     options.timeout = options.timeout || request.DEFAULT_TIMEOUT
 


### PR DESCRIPTION
This ensures that the Chrome does not spew out warnings/errors about setting Host and User-Agent headers, which ensures that Sentry does not get flooded.

There is no impact/change to the functionality.