### PR TITLE
Used _.includes in blackisting the headers

### DIFF
--- a/lib/requester/browser/request.js
+++ b/lib/requester/browser/request.js
@@ -61,9 +61,9 @@ function request(options, callback) {
     options.callback = callback
     options.method = options.method || 'GET';
     options.headers = _.reduce(options.headers || {}, function (accumulator, value, key) {
-        !BLACKLISTED_HEADERS[key.toLowerCase()] && (accumulator[key] = value);
+        !_.includes(BLACKLISTED_HEADERS, key.toLowerCase()) && (accumulator[key] = value);
         return accumulator;
-    });
+    }, {});
     options.body    = options.body || null
     options.timeout = options.timeout || request.DEFAULT_TIMEOUT
 


### PR DESCRIPTION
Headers were not sent when we have host in the headers list.