### PR TITLE
Added integration tests that fetch latest newman and run test with runtime replaced in it.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,8 @@
 > This repository has not yet been updated with code and tests for production use.
 >
 > If you are looking to execute collections, you should bee using [Newman](https://github.com/postmanlabs/newman)
+
+## Development Notes
+
+- `npm run test`: Runs lint, system, unit and integration tests of runtime
+- `npm run test-integration-newman`: This command runs tests of newman with the under-development variant of runtime

--- a/npm/test-integration-newman.js
+++ b/npm/test-integration-newman.js
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+require('shelljs/global');
+require('colors');
+
+var path = require('path'),
+    async = require('async'),
+    tmp = require('tmp');
+
+module.exports = function (exit) {
+    // banner line
+    console.log('Running newman integration tests...'.yellow.bold);
+
+    tmp.dir(function (err, dir, cleanup) {
+        if (err || dir.length < 4) {
+            console.error(err);
+            return exit(1);
+        }
+
+        var installDir = path.join('node_modules', 'newman');
+
+        pushd(dir);
+        async.waterfall([
+            function (next) {
+                console.log(('Setting up integration package at ' + dir).green);
+                exec('npm i newman --loglevel error', function (code, out, err) {
+                    next(code !== 0 ? err : null);
+                });
+            },
+            function (next) {
+                console.log(('Installing dev dependencies of newman at ' + installDir).green);
+                pushd(installDir);
+                exec('npm i . --loglevel error', function (code, out, err) {
+                    popd();
+                    next(code !== 0 ? err : null);
+                });
+            },
+            function (next) {
+                console.log(('Migrating local runtime to ' + installDir).green);
+                pushd(installDir);
+                exec('npm i ' + path.join(__dirname, '..') + ' --loglevel error', function (code, out, err) {
+                    popd();
+                    next(code !== 0 ? err : null);
+                });
+            },
+            function (next) {
+                console.log('Running newman tests...'.green);
+                pushd(installDir);
+                // @todo figure out a way to bypass packity
+                exec('npm run test-unit && npm run test-integration && npm run test-cli', function (code, out, err) {
+                    popd();
+                    next(code !== 0 ? err : null);
+                });
+            }
+        ], function (err) {
+            popd();
+            rm('-rf', path.join(dir, '*'));
+            cleanup();
+            err && console.error(err);
+            exit(err ? 1 : 0);
+        });
+    });
+};
+
+// ensure we run this script exports if this is a direct stdin.tty run
+!module.parent && module.exports(exit);

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test-lint": "node npm/test-lint.js",
     "test-unit": "node npm/test-unit.js",
     "test-integration": "node npm/test-integration.js",
+    "test-integration-newman": "node npm/test-integration-newman.js",
     "build-docs": "node npm/build-docs.js",
     "build-wiki": "node npm/build-wiki.js",
     "publish-docs": "node npm/build-docs.js",
@@ -56,7 +57,8 @@
     "postman-jsdoc-theme": "0.0.2",
     "recursive-readdir": "2.0.0",
     "shelljs": "0.7.3",
-    "sinon": "1.17.6"
+    "sinon": "1.17.6",
+    "tmp": "0.0.31"
   },
   "browser": {
     "./lib/requester/request-wrapper.js": "./lib/requester/browser/request.js",


### PR DESCRIPTION
This PR adds a new test command: `npm run test-integration-newman`.

This is not executed as part of npm test and instead it is meant to be executed on demand