### PR TITLE
Use `CertificateList` to resolve certificate if available

### DIFF
--- a/lib/requester/request-wrapper.js
+++ b/lib/requester/request-wrapper.js
@@ -148,10 +148,10 @@ var _ = require('lodash'),
             return cb(null, options);
         }
 
-        if (options.certificateManager && options.certificateManager.getCertificateContents) {
-          console.log('Using certificateManager with requester options is deprecated, use CertificateList instead.');
+        if (_.get(options, 'certificateManager.getCertificateContents')) {
+          console.warn('Using certificateManager with requester options is deprecated, use CertificateList instead.');
           // Get any certificates for this request from the certificate manager
-          options.certificateManager.getCertificateContents(request.url.getRemote(),
+          return options.certificateManager.getCertificateContents(request.url.getRemote(),
              function (err, info) {
                  _.assign(options, {
                      key: info && info.key,
@@ -161,7 +161,6 @@ var _ = require('lodash'),
                  _.set(options, 'request._._postman_certificate', _.pick(info, ['pemPath', 'keyPath']));
                  return cb(err, options);
                });
-          return;
         }
 
         if (options.certificateList && CertificateList.isCertificateList(options.certificateList)) {
@@ -171,7 +170,7 @@ var _ = require('lodash'),
                 return cb(null, options);
             }
 
-            resolveCertificateContents(certificate, options.fileResolver, function (err, info) {
+            return resolveCertificateContents(certificate, options.fileResolver, function (err, info) {
                 if (err) {
                     return cb(null, options);
                 }
@@ -183,7 +182,6 @@ var _ = require('lodash'),
                 _.set(options, 'request.certificate', certificate);
                 return cb(null, options);
             });
-            return;
         }
 
         return cb(null, options);

--- a/lib/requester/request-wrapper.js
+++ b/lib/requester/request-wrapper.js
@@ -13,6 +13,10 @@ var _ = require('lodash'),
     S_ERROR = 'error',
     S_TIMEOUT = 'timeout',
 
+    ERROR_INVALID_FILE_PATH = 'Invalid path to certificate files',
+
+    CertificateList = require('postman-collection').CertificateList,
+
     /**
      * Tries to make a TCP connection to the given host and port. If successful, the connection is immediately
      * destroyed.
@@ -86,10 +90,47 @@ var _ = require('lodash'),
               options.proxy = proxyConfig.server.toString(),
               options.tunnel = proxyConfig.tunnel;
               _.set(options, 'request._._postman_proxy', proxyConfig);
+              _.set(options, 'request.proxyConfig', proxyConfig);
             }
             return cb(null, options);
         }
         cb(null, options);
+    },
+
+    /**
+     * Resolves the content of a certificate from the file system,
+     * using the current file resolver.
+     *
+     * @param certificate The certificate to resolve
+     * @param resolver The file resolver to use
+     * @param cb Callback once resolve is done
+     */
+    resolveCertificateContents = function(certificate, resolver, cb) {
+        var keyPath = _.get(certificate, 'key.src'),
+            certPath = _.get(certificate, 'cert.src'),
+            keyData,
+            certData;
+
+        if (!_.isString(keyPath) || !_.isString(certPath)) {
+            cb(ERROR_INVALID_FILE_PATH);
+        }
+
+        async.waterfall([
+            function (next) {
+                resolver.readFile(keyPath, next);
+            },
+            function (keyData, next) {
+              resolver.readFile(certPath, function (err, certData) {
+                  next(err, keyData, certData)
+              });
+            }
+        ], function (err, keyData, certData) {
+            cb(err, {
+                key: keyData.toString(),
+                cert: certData.toString(),
+                passphrase: certificate.passphrase
+            });
+        });
     },
 
     /**
@@ -103,21 +144,49 @@ var _ = require('lodash'),
         var request = options.request,
             isSSL = _.startsWith(request.url.protocol, 'https');
 
-        if (!isSSL || !(options.certificateManager && options.certificateManager.getCertificateContents)) {
+        if (!isSSL) {
             return cb(null, options);
         }
 
-        // Get any certificates for this request from the certificate manager
-        options.certificateManager.getCertificateContents(request.url.getRemote(),
-            function (err, info) {
-                _.assign(options, {
+        if (options.certificateManager && options.certificateManager.getCertificateContents) {
+          console.log('Using certificateManager with requester options is deprecated, use CertificateList instead.');
+          // Get any certificates for this request from the certificate manager
+          options.certificateManager.getCertificateContents(request.url.getRemote(),
+             function (err, info) {
+                 _.assign(options, {
+                     key: info && info.key,
+                     cert: info && info.pem,
+                     passphrase: info && info.passphrase
+                 });
+                 _.set(options, 'request._._postman_certificate', _.pick(info, ['pemPath', 'keyPath']));
+                 return cb(err, options);
+               });
+          return;
+        }
+
+        if (options.certificateList && CertificateList.isCertificateList(options.certificateList)) {
+            var certificate = options.certificateList.resolveOne(request.url);
+
+            if (_.isEmpty(certificate)) {
+                return cb(null, options);
+            }
+
+            resolveCertificateContents(certificate, options.fileResolver, function (err, info) {
+                if (err) {
+                    return cb(null, options);
+                }
+                _.extend(options, {
                     key: info && info.key,
-                    cert: info && info.pem,
+                    cert: info && info.cert,
                     passphrase: info && info.passphrase
                 });
-                _.set(options, 'request._._postman_certificate', _.pick(info, ['pemPath', 'keyPath']));
-                return cb(err, options);
+                _.set(options, 'request.certificate', certificate);
+                return cb(null, options);
             });
+            return;
+        }
+
+        return cb(null, options);
     };
 
 module.exports = function (options, callback) {

--- a/lib/requester/request-wrapper.js
+++ b/lib/requester/request-wrapper.js
@@ -13,7 +13,8 @@ var _ = require('lodash'),
     S_ERROR = 'error',
     S_TIMEOUT = 'timeout',
 
-    ERROR_INVALID_FILE_PATH = 'Invalid path to certificate files',
+    ERROR_MISSING_CERT_PATH = 'Path to certificate file is missing',
+    ERROR_MISSING_KEY_PATH = 'Path to private key file is missing',
 
     CertificateList = require('postman-collection').CertificateList,
 
@@ -107,27 +108,32 @@ var _ = require('lodash'),
      */
     resolveCertificateContents = function(certificate, resolver, cb) {
         var keyPath = _.get(certificate, 'key.src'),
-            certPath = _.get(certificate, 'cert.src'),
-            keyData,
-            certData;
+            certPath = _.get(certificate, 'cert.src');
 
-        if (!_.isString(keyPath) || !_.isString(certPath)) {
-            cb(ERROR_INVALID_FILE_PATH);
+        if (!_.isString(keyPath)) {
+            return cb(ERROR_MISSING_KEY_PATH);
         }
 
-        async.waterfall([
-            function (next) {
-                resolver.readFile(keyPath, next);
-            },
-            function (keyData, next) {
-              resolver.readFile(certPath, function (err, certData) {
-                  next(err, keyData, certData)
-              });
+        if (!_.isString(certPath)) {
+            returncb(ERROR_MISSING_CERT_PATH);
+        }
+
+        async.mapValues([keyPath, certPath], function (value, key, cb) {
+          resolver.readFile(value, cb);
+        }, function (err, fileContents) {
+            var keyFileContents,
+                certFileContents;
+
+            if (err) {
+                return cb(err);
             }
-        ], function (err, keyData, certData) {
+
+            keyFileContents = fileContents[keyPath],
+            certFileContents = fileContents[certPath];
+
             cb(err, {
-                key: keyData.toString(),
-                cert: certData.toString(),
+                key: keyFileContents,
+                cert: certFileContents,
                 passphrase: certificate.passphrase
             });
         });
@@ -142,36 +148,42 @@ var _ = require('lodash'),
      */
     setCertificate = function (options, cb) {
         var request = options.request,
-            isSSL = _.startsWith(request.url.protocol, 'https');
+            isSSL = _.startsWith(request.url.protocol, 'https'),
+            hasDeprecatedCertificateManager = _.get(options, 'certificateManager.getCertificateContents'),
+            hasCertificateList = options.certificateList && CertificateList.isCertificateList(options.certificateList);
 
-        if (!isSSL) {
+        // exit if protocol is not https
+        // or both certificateManager and certificateList are missing
+        if (!isSSL || !(hasCertificateList || hasDeprecatedCertificateManager)) {
             return cb(null, options);
         }
 
-        if (_.get(options, 'certificateManager.getCertificateContents')) {
-          console.warn('Using certificateManager with requester options is deprecated, use CertificateList instead.');
-          // Get any certificates for this request from the certificate manager
-          return options.certificateManager.getCertificateContents(request.url.getRemote(),
-             function (err, info) {
-                 _.assign(options, {
-                     key: info && info.key,
-                     cert: info && info.pem,
-                     passphrase: info && info.passphrase
+        // find certificate using deprecated certificateManager
+        if (hasDeprecatedCertificateManager) {
+            console.warn('Using certificateManager with requester options is deprecated, use CertificateList instead.');
+            // Get any certificates for this request from the certificate manager
+            options.certificateManager.getCertificateContents(request.url.getRemote(),
+               function (err, info) {
+                     _.assign(options, {
+                         key: info && info.key,
+                         cert: info && info.pem,
+                         passphrase: info && info.passphrase
+                     });
+                     _.set(options, 'request._._postman_certificate', _.pick(info, ['pemPath', 'keyPath']));
+                     cb(err, options);
                  });
-                 _.set(options, 'request._._postman_certificate', _.pick(info, ['pemPath', 'keyPath']));
-                 return cb(err, options);
-               });
-        }
-
-        if (options.certificateList && CertificateList.isCertificateList(options.certificateList)) {
+        } else {
+            // find certificate using certificateList
             var certificate = options.certificateList.resolveOne(request.url);
 
             if (_.isEmpty(certificate)) {
                 return cb(null, options);
             }
 
-            return resolveCertificateContents(certificate, options.fileResolver, function (err, info) {
+            resolveCertificateContents(certificate, options.fileResolver, function (err, info) {
                 if (err) {
+                    // Log error to users and proceed with next steps
+                    console.error(err);
                     return cb(null, options);
                 }
                 _.extend(options, {
@@ -179,12 +191,11 @@ var _ = require('lodash'),
                     cert: info && info.cert,
                     passphrase: info && info.passphrase
                 });
-                _.set(options, 'request.certificate', certificate);
-                return cb(null, options);
+
+                options.request.certificate = certificate;
+                cb(null, options);
             });
         }
-
-        return cb(null, options);
     };
 
 module.exports = function (options, callback) {

--- a/lib/requester/request-wrapper.js
+++ b/lib/requester/request-wrapper.js
@@ -111,11 +111,11 @@ var _ = require('lodash'),
             certPath = _.get(certificate, 'cert.src');
 
         if (!_.isString(keyPath)) {
-            return cb(ERROR_MISSING_KEY_PATH);
+            return cb(new Error(ERROR_MISSING_KEY_PATH));
         }
 
         if (!_.isString(certPath)) {
-            returncb(ERROR_MISSING_CERT_PATH);
+            returncb(new Error(ERROR_MISSING_CERT_PATH));
         }
 
         async.mapValues([keyPath, certPath], function (value, key, cb) {

--- a/lib/requester/request-wrapper.js
+++ b/lib/requester/request-wrapper.js
@@ -90,7 +90,7 @@ var _ = require('lodash'),
               options.proxy = proxyConfig.server.toString(),
               options.tunnel = proxyConfig.tunnel;
               _.set(options, 'request._._postman_proxy', proxyConfig);
-              _.set(options, 'request.proxyConfig', proxyConfig);
+              _.set(options, 'request.proxy', proxyConfig);
             }
             return cb(null, options);
         }

--- a/lib/requester/requester.js
+++ b/lib/requester/requester.js
@@ -46,6 +46,7 @@ var requests = require('./request-wrapper'),
         this.timeout = _.has(options, 'timeout') ? options.timeout : undefined;
         this.fileResolver = _.get(options, 'fileResolver');
         this.strictSSL = _.get(options, 'strictSSL');
+        this.certificateList = _.get(options, 'certificateList');
         this.certificateManager = _.get(options, 'certificateManager');
         this.proxyList = _.get(options, 'proxyList');
         this.followRedirects = _.has(options, 'followRedirects') ? options.followRedirects : true;
@@ -71,8 +72,10 @@ Requester.prototype.request = function (item, cb, scope) {
         startTime = Date.now();
 
     requestOptions.request = request;
+    requestOptions.certificateList = this.certificateList;
     requestOptions.certificateManager = this.certificateManager;
     requestOptions.proxyList = this.proxyList;
+    requestOptions.fileResolver = this.fileResolver;
 
     return requests(requestOptions, function (err, res, resBody) {
         if (err) { return cb.call(scope || this, err); }

--- a/test/integration/sanity/certificate.test.js
+++ b/test/integration/sanity/certificate.test.js
@@ -1,0 +1,82 @@
+describe('certificates', function () {
+    var fs = require('fs'),
+        path = require('path'),
+        CertificateList = require('postman-collection').CertificateList,
+        https = require('https'),
+
+        certificateId = 'test-certificate',
+        HTTPS_RESPONSE = 'hello world\n',
+
+        server,
+        testrun;
+
+    before(function (done) {
+        var port = 9090,
+            certDataPath = path.join(__dirname, '..', '..', 'integration-legacy', 'data'),
+            clientKeyPath = path.join(certDataPath, 'client1-key.pem'),
+            clientCertPath = path.join(certDataPath, 'client1-crt.pem'),
+
+            serverKeyPath = path.join(certDataPath, 'server-key.pem'),
+            serverCertPath = path.join(certDataPath, 'server-crt.pem'),
+            serverCaPath = path.join(certDataPath, 'ca-crt.pem'),
+
+            certificateList = new CertificateList({}, [{
+                id: certificateId,
+                matches: ['https://localhost:' + port + '/*'],
+                key: {src: clientKeyPath},
+                cert: {src: clientCertPath}
+            }]);
+
+        server = https.createServer({
+            key: fs.readFileSync(serverKeyPath),
+            cert: fs.readFileSync(serverCertPath),
+            ca: fs.readFileSync(serverCaPath),
+            requestCert: true
+        });
+
+        server.on('request', function (req, res) {
+            res.writeHead(200, {'Content-Type': 'text/plain', 'x-postman-https': 'true'});
+            res.end(HTTPS_RESPONSE);
+        });
+
+        server.listen(port, 'localhost');
+
+        this.run({
+            collection: {
+                item: {
+                    request: 'https://localhost:' + port + '/'
+                }
+            },
+            requester: {
+                certificateList: certificateList,
+                fileResolver: fs,
+                strictSSL: false
+            }
+        }, function (err, results) {
+            testrun = results;
+            done(err);
+        });
+    });
+
+    it('must have started and completed the test run', function () {
+        expect(testrun).be.ok();
+        expect(testrun.done.calledOnce).be.ok();
+        expect(testrun.start.calledOnce).be.ok();
+    });
+
+    it('must receive response from https server', function () {
+        var response = testrun.request.getCall(0).args[2];
+
+        expect(response.text()).to.eql(HTTPS_RESPONSE);
+    });
+
+    it('must have certificate attached to request', function () {
+        var request = testrun.request.getCall(0).args[3].toJSON();
+
+        expect(request.certificate.id).to.eql(certificateId);
+    });
+
+    after(function () {
+        server.close();
+    });
+});

--- a/test/integration/sanity/proxy-http.test.js
+++ b/test/integration/sanity/proxy-http.test.js
@@ -4,15 +4,16 @@ describe('proxy', function () {
         proxy = require('http-proxy'),
 
         server,
-        testrun;
+        testrun,
+        port = 9090,
+        proxyServer = 'http://localhost:' + port;
 
     before(function (done) {
-        var port = 9090,
-            proxyList = new ProxyConfigList({}, [{
-                match: '*://postman-echo.com/*',
-                server: 'http://localhost:' + port,
-                tunnel: false
-            }]);
+        var proxyList = new ProxyConfigList({}, [{
+            match: '*://postman-echo.com/*',
+            server: proxyServer,
+            tunnel: false
+        }]);
 
         server = new proxy.createProxyServer({
             target: 'http://postman-echo.com',
@@ -44,9 +45,12 @@ describe('proxy', function () {
     });
 
     it('must receive response from the proxy', function () {
-        var response = testrun.request.getCall(0).args[2].json();
+        var response = testrun.request.getCall(0).args[2].json(),
+            request = testrun.request.getCall(0).args[3];
 
         expect(testrun.request.calledOnce).be.ok(); // one request
+        // proxy info added back to request
+        expect(request.proxy.server.toString()).to.eql(proxyServer);
         expect(_.get(response, 'headers.x-postman-proxy')).to.be('true');
     });
 


### PR DESCRIPTION
  1. Uses `CertificateList` to resolve for a certificate.
  2. Adds proxy information back to request.

Depends on [postman-collection#288](https://github.com/postmanlabs/postman-collection/pull/288) and [postman-collection#286](https://github.com/postmanlabs/postman-collection/pull/286)