### PR TITLE
Fix issue in setting certificate file contents

### DIFF
--- a/lib/requester/request-wrapper.js
+++ b/lib/requester/request-wrapper.js
@@ -115,11 +115,11 @@ var _ = require('lodash'),
         }
 
         if (!_.isString(certPath)) {
-            returncb(new Error(ERROR_MISSING_CERT_PATH));
+            return cb(new Error(ERROR_MISSING_CERT_PATH));
         }
 
-        async.mapValues([keyPath, certPath], function (value, key, cb) {
-          resolver.readFile(value, cb);
+        async.mapValues({key: keyPath, cert: certPath}, function (value, key, callback) {
+            resolver.readFile(value, callback);
         }, function (err, fileContents) {
             var keyFileContents,
                 certFileContents;
@@ -128,8 +128,8 @@ var _ = require('lodash'),
                 return cb(err);
             }
 
-            keyFileContents = fileContents[keyPath],
-            certFileContents = fileContents[certPath];
+            keyFileContents = fileContents.key,
+            certFileContents = fileContents.cert;
 
             cb(err, {
                 key: keyFileContents,

--- a/test/integration/sanity/certificate.test.js
+++ b/test/integration/sanity/certificate.test.js
@@ -5,7 +5,6 @@ describe('certificates', function () {
         https = require('https'),
 
         certificateId = 'test-certificate',
-        HTTPS_RESPONSE = 'hello world\n',
 
         server,
         testrun;
@@ -35,8 +34,14 @@ describe('certificates', function () {
         });
 
         server.on('request', function (req, res) {
-            res.writeHead(200, {'Content-Type': 'text/plain', 'x-postman-https': 'true'});
-            res.end(HTTPS_RESPONSE);
+            if (req.client.authorized) {
+                res.writeHead(200, {'Content-Type': 'text/plain'});
+                res.end('authorized\n');
+            }
+            else {
+                res.writeHead(401, {'Content-Type': 'text/plain'});
+                res.end('unauthorized\n');
+            }
         });
 
         server.listen(port, 'localhost');
@@ -67,7 +72,7 @@ describe('certificates', function () {
     it('must receive response from https server', function () {
         var response = testrun.request.getCall(0).args[2];
 
-        expect(response.text()).to.eql(HTTPS_RESPONSE);
+        expect(response.text()).to.eql('authorized\n');
     });
 
     it('must have certificate attached to request', function () {


### PR DESCRIPTION
  1. Fix typo in error handling
  2. Fix usage of `async.mapValues`
  3. Fix tests to fail if certificate is invalid