### PR TITLE
Set search result to falsey value on setProxy

### DIFF
--- a/lib/requester/request-wrapper.js
+++ b/lib/requester/request-wrapper.js
@@ -82,7 +82,7 @@ var _ = require('lodash'),
      */
     setProxy = function(options, cb) {
         var url = _.get(options, 'request.url'),
-            proxyConfig = {};
+            proxyConfig;
 
         if (url && options.proxyList) {
             _.isFunction(url.toString) && (url = url.toString());


### PR DESCRIPTION
This makes sure we don't pass through the code for setting proxy when a match is not found.