### PR TITLE
Properly update to postman-sandbox v2.x (tests and all)

### DIFF
--- a/lib/runner/extensions/event.command.js
+++ b/lib/runner/extensions/event.command.js
@@ -177,20 +177,20 @@ module.exports = {
                     err && (err = serialisedError(err, true));
 
                     // if it is defined that certain variables are to be synced back to result, we do the same
-                    track && result && result.globals && track.forEach(function (variable) {
-                        if (!(_.isObject(result.globals[variable]) && result.globals[variable])) { return; }
+                    track && result && track.forEach(function (variable) {
+                        if (!(_.isObject(result[variable]) && result[variable])) { return; }
 
                         // ensure that variablescope is treated accordingly
                         // @todo find a better way to not sync entire scope, but receive changes and update the existing
                         // scope using that
                         if (_.isFunction(payload.context[variable].syncVariablesFrom)) {
                             payload.context[variable].clear();
-                            _.each(result.globals[variable].values, function (def) {
+                            _.each(result[variable].values, function (def) {
                                 payload.context[variable].values.add(def);
                             });
                         }
                         else {
-                            util.syncObject(payload.context[variable], result.globals[variable]);
+                            util.syncObject(payload.context[variable], result[variable]);
                         }
                     });
 

--- a/lib/runner/extensions/event.command.js
+++ b/lib/runner/extensions/event.command.js
@@ -178,7 +178,7 @@ module.exports = {
 
                     // if it is defined that certain variables are to be synced back to result, we do the same
                     track && result && track.forEach(function (variable) {
-                        if (!(_.isObject(result[variable]) && result[variable])) { return; }
+                        if (!(_.isObject(result[variable]) && payload.context[variable])) { return; }
 
                         // ensure that variablescope is treated accordingly
                         // @todo find a better way to not sync entire scope, but receive changes and update the existing

--- a/lib/runner/extensions/event.command.js
+++ b/lib/runner/extensions/event.command.js
@@ -52,7 +52,7 @@ module.exports = {
         }
 
         sandbox.createContext(_.merge({
-            debug: true
+            // debug: true
         }, run.options.host), function (err, context) {
             if (err) { return done(err); }
             // store the host in run object for future use and move on
@@ -162,7 +162,7 @@ module.exports = {
 
                 // finally execute the script
                 this.host.execute(event, {
-                    debug: true,
+                    // debug: true,
                     timeout: payload.scriptTimeout,
                     cursor: cursor,
                     context: _.pick(payload.context, SAFE_CONTEXT_VARIABLES),

--- a/lib/runner/extensions/event.command.js
+++ b/lib/runner/extensions/event.command.js
@@ -8,8 +8,8 @@ var _ = require('lodash'),
     ASSERTION_FAILURE = 'AssertionFailure',
     SAFE_CONTEXT_VARIABLES = ['environment', 'globals', 'cookies', 'data', 'request', 'response'],
 
-    postProcessContext = function (globals) {  // This function determines whether the event needs to abort
-        var tests = globals && globals.tests,
+    postProcessContext = function (execution) {  // This function determines whether the event needs to abort
+        var tests = execution && execution.tests,
             failures,
             error;
 
@@ -52,7 +52,7 @@ module.exports = {
         }
 
         sandbox.createContext(_.merge({
-            // debug: true
+            debug: true
         }, run.options.host), function (err, context) {
             if (err) { return done(err); }
             // store the host in run object for future use and move on
@@ -162,7 +162,7 @@ module.exports = {
 
                 // finally execute the script
                 this.host.execute(event, {
-                    // debug: true,
+                    debug: true,
                     timeout: payload.scriptTimeout,
                     cursor: cursor,
                     context: _.pick(payload.context, SAFE_CONTEXT_VARIABLES),
@@ -196,7 +196,7 @@ module.exports = {
 
                     // Get the failures. If there was an error running the script itself, that takes precedence
                     if (!err && (abortOnFailure || stopOnFailure)) {
-                        err = postProcessContext(result.globals);
+                        err = postProcessContext(result);
                     }
                     // now that this script is done executing, we trigger the event and move to the next script
                     this.triggers.script(err || null, cursor, result, script, event, item);

--- a/lib/runner/extensions/waterfall.command.js
+++ b/lib/runner/extensions/waterfall.command.js
@@ -32,9 +32,9 @@ extractSNR = function (executions, previous) {
     var snr = previous || {};
 
     _.isArray(executions) && executions.forEach(function (execution) {
-        _.has(_.get(execution, 'result.masked'), 'nextRequest') && (
+        _.has(_.get(execution, 'result.return'), 'nextRequest') && (
             (snr.defined = true),
-            (snr.value = execution.result.masked.nextRequest)
+            (snr.value = execution.result.return.nextRequest)
         );
     });
 

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "lodash3": "3.10.1",
     "postman-collection": "1.1.0",
     "postman-request": "2.80.1-postman.1",
-    "postman-sandbox": "2.0.0-beta.3",
+    "postman-sandbox": "2.0.0-beta.4",
     "resolve-from": "2.0.0",
     "serialised-error": "1.1.2",
     "uuid": "3.0.1"

--- a/test/integration-legacy/abort-on-error-request-spec.test.js
+++ b/test/integration-legacy/abort-on-error-request-spec.test.js
@@ -221,7 +221,7 @@ describe('Option', function () {
                             expect(result.error).to.be(undefined);
 
                             var scriptResult = results[0];
-                            expect(scriptResult.result.masked.scriptType).to.eql('test');
+                            expect(scriptResult.result.target).to.eql('test');
                         });
                     },
                     beforeRequest: function (err, cursor, request, item) {

--- a/test/integration-legacy/abort-on-error-script-spec.test.js
+++ b/test/integration-legacy/abort-on-error-script-spec.test.js
@@ -221,7 +221,7 @@ describe('Option', function () {
                             expect(result.error).to.be(undefined);
 
                             var scriptResult = results[0];
-                            expect(scriptResult.result.masked.scriptType).to.eql('test');
+                            expect(scriptResult.result.target).to.eql('test');
                         });
                     },
                     beforeRequest: function (err, cursor, request, item) {

--- a/test/integration-legacy/abort-on-failure-script-spec.test.js
+++ b/test/integration-legacy/abort-on-failure-script-spec.test.js
@@ -202,7 +202,7 @@ describe('Option', function () {
                             expect(cursor.ref).to.eql(runStore.ref);
 
                             var scriptResult = results[0];
-                            expect(scriptResult.result.masked.scriptType).to.eql('test');
+                            expect(scriptResult.result.target).to.eql('test');
                         });
                     },
                     beforeRequest: function (err, cursor, request, item) {

--- a/test/integration-legacy/delay-spec.test.js
+++ b/test/integration-legacy/delay-spec.test.js
@@ -220,7 +220,7 @@ describe('Option', function () {
                             expect(result.error).to.be(undefined);
 
                             var scriptResult = results[0];
-                            expect(scriptResult.result.masked.scriptType).to.eql('test');
+                            expect(scriptResult.result.target).to.eql('test');
                         });
                     },
                     beforeRequest: function (err, cursor, request, item) {

--- a/test/integration-legacy/requester-spec.test.js
+++ b/test/integration-legacy/requester-spec.test.js
@@ -3305,9 +3305,9 @@ describe('Requester', function () {
                             expect(scriptResult.error).to.be(undefined);
                             expect(scriptResult.result.target).to.eql('test');
 
-                            expect(scriptResult.result.globals.tests).to.be.ok();
+                            expect(scriptResult.result.tests).to.be.ok();
 
-                            _.forOwn(scriptResult.result.globals.tests, function (result, test) {
+                            _.forOwn(scriptResult.result.tests, function (result, test) {
                                 expect(result).to.be.ok();
                             });
                         });

--- a/test/integration-legacy/requester-spec.test.js
+++ b/test/integration-legacy/requester-spec.test.js
@@ -176,7 +176,7 @@ describe('Requester', function () {
                             expect(result.error).to.be(undefined);
 
                             var scriptResult = results[0];
-                            expect(scriptResult.result.masked.scriptType).to.eql('test');
+                            expect(scriptResult.result.target).to.eql('test');
                         });
                     },
                     beforeRequest: function (err, cursor, request, item) {
@@ -383,7 +383,7 @@ describe('Requester', function () {
                             expect(result.error).to.be(undefined);
 
                             var scriptResult = results[0];
-                            expect(scriptResult.result.masked.scriptType).to.eql('test');
+                            expect(scriptResult.result.target).to.eql('test');
                         });
                     },
                     beforeRequest: function (err, cursor, request, item) {
@@ -3303,7 +3303,7 @@ describe('Requester', function () {
 
                             var scriptResult = results[0];
                             expect(scriptResult.error).to.be(undefined);
-                            expect(scriptResult.result.masked.scriptType).to.eql('test');
+                            expect(scriptResult.result.target).to.eql('test');
 
                             expect(scriptResult.result.globals.tests).to.be.ok();
 
@@ -3521,7 +3521,7 @@ describe('Requester', function () {
                             expect(result.error).to.be(undefined);
 
                             var scriptResult = results[0];
-                            expect(scriptResult.result.masked.scriptType).to.eql('test');
+                            expect(scriptResult.result.target).to.eql('test');
                         });
                     },
                     beforeRequest: function (err, cursor, request, item) {

--- a/test/integration-legacy/runner-spec.test.js
+++ b/test/integration-legacy/runner-spec.test.js
@@ -226,7 +226,7 @@ describe('Runner', function () {
                             expect(result.error).to.be(undefined);
 
                             var scriptResult = results[0];
-                            expect(scriptResult.result.masked.scriptType).to.eql('test');
+                            expect(scriptResult.result.target).to.eql('test');
                         });
                     },
                     beforeRequest: function (err, cursor, request, item) {

--- a/test/integration-legacy/stop-on-error-multiple-iterations-spec.test.js
+++ b/test/integration-legacy/stop-on-error-multiple-iterations-spec.test.js
@@ -181,7 +181,7 @@ describe('Option', function () {
                             expect(cursor.ref).to.eql(runStore.ref);
 
                             var scriptResult = results[0];
-                            expect(scriptResult.result.masked.scriptType).to.eql('test');
+                            expect(scriptResult.result.target).to.eql('test');
 
                             if (cursor.iteration === 1 && item.name === 'First Request') {
                                 expect(scriptResult.error).to.have.property('message', 'fail');

--- a/test/integration-legacy/stop-on-error-request-spec.test.js
+++ b/test/integration-legacy/stop-on-error-request-spec.test.js
@@ -240,7 +240,7 @@ describe('Option', function () {
                             expect(result.error).to.be(undefined);
 
                             var scriptResult = results[0];
-                            expect(scriptResult.result.masked.scriptType).to.eql('test');
+                            expect(scriptResult.result.target).to.eql('test');
 
                             // This should never be called for the
                             // second request.

--- a/test/integration-legacy/stop-on-error-script-spec.test.js
+++ b/test/integration-legacy/stop-on-error-script-spec.test.js
@@ -228,7 +228,7 @@ describe('Option', function () {
                             expect(result.error).to.be(undefined);
 
                             var scriptResult = results[0];
-                            expect(scriptResult.result.masked.scriptType).to.eql('test');
+                            expect(scriptResult.result.target).to.eql('test');
 
                             // Since pre-request throws an error in the second
                             // iteration, this should never be called for the

--- a/test/integration-legacy/stop-on-failure-spec.test.js
+++ b/test/integration-legacy/stop-on-failure-spec.test.js
@@ -200,7 +200,7 @@ describe('Option', function () {
                             expect(cursor.ref).to.eql(runStore.ref);
 
                             var scriptResult = results[0];
-                            expect(scriptResult.result.masked.scriptType).to.eql('test');
+                            expect(scriptResult.result.target).to.eql('test');
                         });
                     },
                     beforeRequest: function (err, cursor, request, item) {
@@ -481,7 +481,7 @@ describe('Option', function () {
                             expect(result.error).to.be(undefined);
 
                             var scriptResult = results[0];
-                            expect(scriptResult.result.masked.scriptType).to.eql('test');
+                            expect(scriptResult.result.target).to.eql('test');
 
                             // Since pre-request throws an error in the second
                             // iteration, this should never be called for the
@@ -791,7 +791,7 @@ describe('Option', function () {
                             expect(result.error).to.be(undefined);
 
                             var scriptResult = results[0];
-                            expect(scriptResult.result.masked.scriptType).to.eql('test');
+                            expect(scriptResult.result.target).to.eql('test');
 
                             // Since pre-request throws an error in the second
                             // iteration, this should never be called for the

--- a/test/integration-legacy/uvm-spec.test.js
+++ b/test/integration-legacy/uvm-spec.test.js
@@ -502,9 +502,9 @@ describe('UVM', function () {
 
                             var scriptResult = results[0];
                             expect(scriptResult.result.target).to.eql('test');
-                            expect(scriptResult.result.globals.tests).to.be.ok();
+                            expect(scriptResult.result.tests).to.be.ok();
 
-                            _.forOwn(scriptResult.result.globals.tests, function (result, test) {
+                            _.forOwn(scriptResult.result.tests, function (result, test) {
                                 expect(result).to.be.ok();
                             });
                         });

--- a/test/integration-legacy/uvm-spec.test.js
+++ b/test/integration-legacy/uvm-spec.test.js
@@ -501,7 +501,7 @@ describe('UVM', function () {
                             expect(result.error).to.be(undefined);
 
                             var scriptResult = results[0];
-                            expect(scriptResult.result.masked.scriptType).to.eql('test');
+                            expect(scriptResult.result.target).to.eql('test');
                             expect(scriptResult.result.globals.tests).to.be.ok();
 
                             _.forOwn(scriptResult.result.globals.tests, function (result, test) {
@@ -739,7 +739,7 @@ describe('UVM', function () {
                                 expect(result).to.be.ok();
                             });
 
-                            expect(scriptResult.result.masked.scriptType).to.eql('test');
+                            expect(scriptResult.result.target).to.eql('test');
                         });
                     },
                     beforeRequest: function (err, cursor, request, item) {
@@ -962,7 +962,7 @@ describe('UVM', function () {
                                 expect(result).to.be.ok();
                             });
 
-                            expect(scriptResult.result.masked.scriptType).to.eql('test');
+                            expect(scriptResult.result.target).to.eql('test');
                         });
                     },
                     beforeRequest: function (err, cursor, request, item) {

--- a/test/integration/sanity/case-insen-header-sandbox.test.js
+++ b/test/integration/sanity/case-insen-header-sandbox.test.js
@@ -29,7 +29,7 @@ describe('Case insensitive sandbox headers', function () {
         expect(testrun.test.calledOnce).be.ok();
 
         expect(testrun.test.getCall(0).args[0]).to.be(null);
-        expect(_.get(testrun.test.getCall(0).args[2], '0.result.globals.tests.["Case-insensitive header checking"]'))
+        expect(_.get(testrun.test.getCall(0).args[2], '0.result.tests.["Case-insensitive header checking"]'))
             .to.be(true);
     });
 

--- a/test/integration/sanity/clear-vars-sandbox.test.js
+++ b/test/integration/sanity/clear-vars-sandbox.test.js
@@ -77,24 +77,24 @@ describe('Clear vars sandbox', function () {
             var first = testrun.test.getCall(0);
 
             expect(first.args[0]).to.be(null);
-            expect(_.get(first.args[2], '0.result.globals.globals.values')).to.eql([]);
-            expect(_.get(first.args[2], '0.result.globals.environment.values')).to.eql([]);
+            expect(_.get(first.args[2], '0.result.globals.values')).to.eql([]);
+            expect(_.get(first.args[2], '0.result.environment.values')).to.eql([]);
         });
 
         it('should correctly clear environments and globals in the test run 2', function () {
             var second = testrun.test.getCall(1);
 
             expect(second.args[0]).to.be(null);
-            expect(_.get(second.args[2], '0.result.globals.globals.values')).to.eql([]);
-            expect(_.get(second.args[2], '0.result.globals.environment.values')).to.eql([]);
+            expect(_.get(second.args[2], '0.result.globals.values')).to.eql([]);
+            expect(_.get(second.args[2], '0.result.environment.values')).to.eql([]);
         });
 
         it('should correctly clear environments and globals in the test run 3', function () {
             var third = testrun.test.getCall(2);
 
             expect(third.args[0]).to.be(null);
-            expect(_.get(third.args[2], '0.result.globals.globals.values')).to.eql([]);
-            expect(_.get(third.args[2], '0.result.globals.environment.values')).to.eql([]);
+            expect(_.get(third.args[2], '0.result.globals.values')).to.eql([]);
+            expect(_.get(third.args[2], '0.result.environment.values')).to.eql([]);
         });
     });
 

--- a/test/integration/sanity/cookie-handling.test.js
+++ b/test/integration/sanity/cookie-handling.test.js
@@ -27,7 +27,7 @@ describe('cookies', function () {
         expect(testrun.test.calledOnce).be.ok();
 
         expect(testrun.test.getCall(0).args[0]).to.be(null);
-        expect(_.get(testrun.test.getCall(0).args[2], '0.result.globals.tests.working')).to.be(true);
+        expect(_.get(testrun.test.getCall(0).args[2], '0.result.tests.working')).to.be(true);
     });
 
     it('must have completed the run', function () {

--- a/test/integration/sanity/file-uploads.test.js
+++ b/test/integration/sanity/file-uploads.test.js
@@ -38,7 +38,7 @@ describe('File uploads', function() {
         expect(testrun.test.calledOnce).be.ok();
 
         expect(testrun.test.getCall(0).args[0]).to.be(null);
-        expect(_.get(testrun.test.getCall(0).args[2], '0.result.globals.tests["File contents are valid"]')).to.be(true);
+        expect(_.get(testrun.test.getCall(0).args[2], '0.result.tests["File contents are valid"]')).to.be(true);
     });
 
     it('must have completed the run', function() {

--- a/test/integration/sanity/multi-value-data.test.js
+++ b/test/integration/sanity/multi-value-data.test.js
@@ -34,7 +34,7 @@ describe('Multi value data', function() {
         expect(testrun.test.calledOnce).be.ok();
 
         expect(testrun.test.getCall(0).args[0]).to.be(null);
-        expect(_.get(testrun.test.getCall(0).args[2], '0.result.globals.tests.working')).to.be(true);
+        expect(_.get(testrun.test.getCall(0).args[2], '0.result.tests.working')).to.be(true);
     });
 
     it('must have completed the run', function() {

--- a/test/integration/sanity/request-name-script.test.js
+++ b/test/integration/sanity/request-name-script.test.js
@@ -48,7 +48,7 @@ describe('request name scripts', function() {
         expect(testrun.prerequest.calledOnce).be.ok();
 
         expect(testrun.test.getCall(0).args[0]).to.be(null);
-        expect(_.get(testrun.test.getCall(0).args[2], '0.result.globals.tests.working')).to.be(true);
+        expect(_.get(testrun.test.getCall(0).args[2], '0.result.tests.working')).to.be(true);
     });
 
     it('must have completed the run', function() {

--- a/test/integration/sanity/sandbox-libraries.test.js
+++ b/test/integration/sanity/sandbox-libraries.test.js
@@ -203,7 +203,7 @@ describe('Sandbox libraries', function() {
         expect(testrun.test.callCount).be(11);
 
         expect(testrun.test.getCall(0).args[0]).to.be(null);
-        expect(_.get(testrun.test.getCall(0).args[2], '0.result.globals.tests')).to.eql({
+        expect(_.get(testrun.test.getCall(0).args[2], '0.result.tests')).to.eql({
             xml2Json: true,
             GetResponseHeader: true,
             GetResponseCookie: true,
@@ -215,7 +215,7 @@ describe('Sandbox libraries', function() {
         });
 
         expect(testrun.test.getCall(1).args[0]).to.be(null);
-        expect(_.get(testrun.test.getCall(1).args[2], '0.result.globals.tests')).to.eql({
+        expect(_.get(testrun.test.getCall(1).args[2], '0.result.tests')).to.eql({
             'Status code is 200': true,
             'Correct GUID': true,
             'Correct Random': true,
@@ -228,17 +228,17 @@ describe('Sandbox libraries', function() {
 
         _.range(2, 8).forEach(function(index) { // generates a range [2, 7], and checks the tests on those indices
             expect(testrun.test.getCall(index).args[0]).to.be(null);
-            expect(_.get(testrun.test.getCall(index).args[2], '0.result.globals.tests["Status code is 200"]')).to.be(true);
+            expect(_.get(testrun.test.getCall(index).args[2], '0.result.tests["Status code is 200"]')).to.be(true);
         });
 
         expect(testrun.test.getCall(8).args[0]).to.be(null);
-        expect(_.get(testrun.test.getCall(8).args[2], '0.result.globals.tests["Correct auth header"]')).to.be(true);
+        expect(_.get(testrun.test.getCall(8).args[2], '0.result.tests["Correct auth header"]')).to.be(true);
 
         expect(testrun.test.getCall(9).args[0]).to.be(null);
-        expect(_.get(testrun.test.getCall(9).args[2], '0.result.globals.tests.Authenticated')).to.be(true);
+        expect(_.get(testrun.test.getCall(9).args[2], '0.result.tests.Authenticated')).to.be(true);
 
         expect(testrun.test.getCall(10).args[0]).to.be(null);
-        expect(_.get(testrun.test.getCall(10).args[2], '0.result.globals.tests')).to.eql({});
+        expect(_.get(testrun.test.getCall(10).args[2], '0.result.tests')).to.eql({});
     });
 
     it('must have completed the run', function() {

--- a/test/integration/sanity/sandbox-test-object.test.js
+++ b/test/integration/sanity/sandbox-test-object.test.js
@@ -39,7 +39,7 @@ describe('sandbox test for `undefined` test values', function () {
     });
 
     it('must have run the test script, and replaced `undefined` with `false`', function () {
-        var tests = _.get(testrun.test.getCall(0), 'args[2][0].result.globals.tests');
+        var tests = _.get(testrun.test.getCall(0), 'args[2][0].result.tests');
         expect(tests).to.eql({
             undefined: false,  // this was set to undefined in the test script, but should be changed to false here.
             true: true,

--- a/test/integration/sanity/sugar-js.test.js
+++ b/test/integration/sanity/sugar-js.test.js
@@ -50,7 +50,7 @@ describe('Sugar.js', function() {
         expect(testrun.test.calledOnce).be.ok();
 
         expect(testrun.test.getCall(0).args[0]).to.be(null);
-        expect(_.get(testrun.test.getCall(0).args[2], '0.result.globals.tests')).to.eql({
+        expect(_.get(testrun.test.getCall(0).args[2], '0.result.tests')).to.eql({
             'Array prototype none': true,
             'Array prototype any': true,
             'Array prototype average': true,

--- a/test/integration/sanity/v2-regression.test.js
+++ b/test/integration/sanity/v2-regression.test.js
@@ -60,16 +60,16 @@ describe('V2 regressions', function() {
         expect(testrun.test.calledThrice).be.ok();
 
         expect(testrun.test.getCall(0).args[0]).to.be(null);
-        expect(_.get(testrun.test.getCall(0).args[2], '0.result.globals.tests')).to.eql({
+        expect(_.get(testrun.test.getCall(0).args[2], '0.result.tests')).to.eql({
             'Status code is 200': true,
             'foo1 cookie is present in the response body': true
         });
 
         expect(testrun.test.getCall(1).args[0]).to.be(null);
-        expect(_.get(testrun.test.getCall(1).args[2], '0.result.globals.tests["Status code is 200"]')).to.be(true);
+        expect(_.get(testrun.test.getCall(1).args[2], '0.result.tests["Status code is 200"]')).to.be(true);
 
         expect(testrun.test.getCall(2).args[0]).to.be(null);
-        expect(_.get(testrun.test.getCall(2).args[2], '0.result.globals.tests')).to.eql({
+        expect(_.get(testrun.test.getCall(2).args[2], '0.result.tests')).to.eql({
             'Status code is 200': true,
             'Disabled header is absent': true
         });

--- a/test/integration/sanity/var-overrides.test.js
+++ b/test/integration/sanity/var-overrides.test.js
@@ -92,7 +92,7 @@ describe('Variable overrides', function() {
         expect(testrun.test.calledTwice).be.ok();
 
         expect(testrun.test.getCall(0).args[0]).to.be(null);
-        expect(_.get(testrun.test.getCall(0).args[2], '0.result.globals.tests')).to.eql({
+        expect(_.get(testrun.test.getCall(0).args[2], '0.result.tests')).to.eql({
             'Content-Type is present': true,
             testGlobalSetFromPRScript: true,
             'Read global var correctly': true,
@@ -102,7 +102,7 @@ describe('Variable overrides', function() {
         });
 
         expect(testrun.test.getCall(1).args[0]).to.be(null);
-        expect(_.get(testrun.test.getCall(1).args[2], '0.result.globals.tests')).to.eql({
+        expect(_.get(testrun.test.getCall(1).args[2], '0.result.tests')).to.eql({
             'Read global var correctly': true,
             'Read env var correctly': true,
             'Read data var correctly': true


### PR DESCRIPTION
* updated postProcessContext to process test failures correctly from the new execution object
* updated set next request logic to account for the new execution object

* fixed tests