### PR TITLE
ensure that we bubble up sdk instances, not serialized POJOs

### DIFF
--- a/lib/runner/extensions/event.command.js
+++ b/lib/runner/extensions/event.command.js
@@ -1,4 +1,5 @@
 var _ = require('lodash'),
+    sdk = require('postman-collection'),
     async = require('async'),
     serialisedError = require('serialised-error'),
 
@@ -198,6 +199,13 @@ module.exports = {
                     if (!err && (abortOnFailure || stopOnFailure)) {
                         err = postProcessContext(result);
                     }
+
+                    // Ensure that we have SDK instances, not serialized plain objects.
+                    result && result.environment && (result.environment = new sdk.VariableScope(result.environment));
+                    result && result.globals && (result.globals = new sdk.VariableScope(result.globals));
+                    result && result.request && (result.request = new sdk.Request(result.request));
+                    result && result.response && (result.response = new sdk.Response(result.response));
+
                     // now that this script is done executing, we trigger the event and move to the next script
                     this.triggers.script(err || null, cursor, result, script, event, item);
 

--- a/lib/runner/extensions/event.command.js
+++ b/lib/runner/extensions/event.command.js
@@ -201,6 +201,7 @@ module.exports = {
                     }
 
                     // Ensure that we have SDK instances, not serialized plain objects.
+                    // @todo - should this be handled by the sandbox?
                     result && result.environment && (result.environment = new sdk.VariableScope(result.environment));
                     result && result.globals && (result.globals = new sdk.VariableScope(result.globals));
                     result && result.request && (result.request = new sdk.Request(result.request));

--- a/test/integration/sanity/clear-vars-sandbox.test.js
+++ b/test/integration/sanity/clear-vars-sandbox.test.js
@@ -77,24 +77,24 @@ describe('Clear vars sandbox', function () {
             var first = testrun.test.getCall(0);
 
             expect(first.args[0]).to.be(null);
-            expect(_.get(first.args[2], '0.result.globals.values')).to.eql([]);
-            expect(_.get(first.args[2], '0.result.environment.values')).to.eql([]);
+            expect(_.invoke(first.args[2], '0.result.globals.values.all')).to.eql([]);
+            expect(_.invoke(first.args[2], '0.result.environment.values.all')).to.eql([]);
         });
 
         it('should correctly clear environments and globals in the test run 2', function () {
             var second = testrun.test.getCall(1);
 
             expect(second.args[0]).to.be(null);
-            expect(_.get(second.args[2], '0.result.globals.values')).to.eql([]);
-            expect(_.get(second.args[2], '0.result.environment.values')).to.eql([]);
+            expect(_.invoke(second.args[2], '0.result.globals.values.all')).to.eql([]);
+            expect(_.invoke(second.args[2], '0.result.environment.values.all')).to.eql([]);
         });
 
         it('should correctly clear environments and globals in the test run 3', function () {
             var third = testrun.test.getCall(2);
 
             expect(third.args[0]).to.be(null);
-            expect(_.get(third.args[2], '0.result.globals.values')).to.eql([]);
-            expect(_.get(third.args[2], '0.result.environment.values')).to.eql([]);
+            expect(_.invoke(third.args[2], '0.result.globals.values.all')).to.eql([]);
+            expect(_.invoke(third.args[2], '0.result.environment.values.all')).to.eql([]);
         });
     });
 

--- a/test/integration/sanity/malformed.test.js
+++ b/test/integration/sanity/malformed.test.js
@@ -26,8 +26,8 @@ describe('malformation', function () {
         expect(testrun).be.ok();
         var result = _.get(testrun.test.getCall(0).args[2], '0.result', {});
 
-        expect(_.get(result, 'globals.values')).to.eql([]);
-        expect(_.get(result, 'environment.values')).to.eql([]);
+        expect(_.invoke(result, 'globals.values.all')).to.eql([]);
+        expect(_.invoke(result, 'environment.values.all')).to.eql([]);
     });
 
     it('must have completed the run', function () {

--- a/test/integration/sanity/script-result.test.js
+++ b/test/integration/sanity/script-result.test.js
@@ -12,10 +12,10 @@ describe('script result format', function() {
                         // ensure that we run something for test and pre-req scripts
                         event: [{
                             listen: 'prerequest',
-                            script: { exec: ';' },
+                            script: {exec: ';'}
                         }, {
                             listen: 'test',
-                            script: { exec: 'tests.worked = true;' },
+                            script: {exec: 'tests.worked = true;'}
                         }],
                         request: 'https://postman-echo.com/get'
                     }
@@ -149,7 +149,7 @@ describe('script result format', function() {
                         // ensure that we run something for test and pre-req scripts
                         event: [{
                             listen: 'prerequest',
-                            script: { exec: 'postman.setNextRequest("some-req-name");' },
+                            script: {exec: 'postman.setNextRequest("some-req-name");'}
                         }],
                         request: 'https://postman-echo.com/get'
                     }

--- a/test/integration/sanity/script-result.test.js
+++ b/test/integration/sanity/script-result.test.js
@@ -1,0 +1,188 @@
+var sdk = require('postman-collection');
+
+describe('script result format', function() {
+    describe('sanity checks', function () {
+        var testrun;
+
+        before(function(done) {
+            this.run({
+                requester: {followRedirects: false},
+                collection: {
+                    item: {
+                        // ensure that we run something for test and pre-req scripts
+                        event: [{
+                            listen: 'prerequest',
+                            script: { exec: ';' },
+                        }, {
+                            listen: 'test',
+                            script: { exec: 'tests.worked = true;' },
+                        }],
+                        request: 'https://postman-echo.com/get'
+                    }
+                }
+            }, function(err, results) {
+                testrun = results;
+                done(err);
+            });
+        });
+
+        it('must have sent the request successfully', function() {
+            expect(testrun).be.ok();
+            expect(testrun.request.calledOnce).be.ok();
+
+            expect(testrun.request.getCall(0).args[0]).to.be(null);
+        });
+
+        it('must have triggered the script event twice', function () {
+            expect(testrun.script.calledTwice).to.be.ok();
+        });
+
+        it('must have set the right targets in the result', function () {
+            var prerequest = testrun.script.firstCall.args[2],
+                test = testrun.script.secondCall.args[2];
+
+            expect(prerequest.target).to.be('prerequest');
+            expect(test.target).to.be('test');
+        });
+
+        it('must have provided variable-scope objects in the events', function () {
+            var prerequest = testrun.script.firstCall.args[2],
+                test = testrun.script.secondCall.args[2];
+
+            expect(sdk.VariableScope.isVariableScope(prerequest.environment)).to.be(true);
+            expect(sdk.VariableScope.isVariableScope(prerequest.globals)).to.be(true);
+
+            expect(sdk.VariableScope.isVariableScope(test.environment)).to.be(true);
+            expect(sdk.VariableScope.isVariableScope(test.globals)).to.be(true);
+        });
+
+        it('must have request in the result object', function () {
+            var prerequest = testrun.script.firstCall.args[2],
+                test = testrun.script.secondCall.args[2];
+
+            expect(sdk.Request.isRequest(prerequest.request)).to.be(true);
+            expect(sdk.Request.isRequest(test.request)).to.be(true);
+        });
+
+        it('must have the cursor in the result', function () {
+            var prerequest = testrun.script.firstCall.args[2],
+                test = testrun.script.secondCall.args[2];
+
+            expect(prerequest).to.have.property('cursor');
+            expect(test).to.have.property('cursor');
+
+            expect(prerequest.cursor).to.be.an('object');
+            expect(test.cursor).to.be.an('object');
+        });
+
+        it('must have data variables in the result', function () {
+            var prerequest = testrun.script.firstCall.args[2],
+                test = testrun.script.secondCall.args[2];
+
+            expect(prerequest).to.have.property('data');
+            expect(test).to.have.property('data');
+
+            expect(prerequest.data).to.eql({});
+            expect(test.data).to.eql({});
+        });
+
+        it('must have cookies in the result', function () {
+            var prerequest = testrun.script.firstCall.args[2],
+                test = testrun.script.secondCall.args[2];
+
+            expect(prerequest).to.have.property('cookies');
+            expect(test).to.have.property('cookies');
+
+            expect(prerequest.cookies).to.eql([]); // @todo - should this be present in the pre-request script?
+
+            // the test script must have a cookie
+            expect(test.cookies).to.be.an('array');
+            expect(test.cookies).to.have.length(1);
+        });
+
+        it('must have test results in the result', function () {
+            var prerequest = testrun.script.firstCall.args[2],
+                test = testrun.script.secondCall.args[2];
+
+            expect(prerequest).to.have.property('tests');
+            expect(test).to.have.property('tests');
+
+            expect(prerequest.tests).to.eql({}); // @todo - should this be present in the pre-request script?
+
+            // the test script must have a cookie
+            expect(test.tests).to.be.an('object');
+            expect(test.tests).to.have.property('worked', true);
+        });
+
+        it('must have empty return object', function () {
+            var prerequest = testrun.script.firstCall.args[2],
+                test = testrun.script.secondCall.args[2];
+
+            expect(prerequest.return).to.eql({});
+            expect(test.return).to.eql({});
+        });
+
+        it('must have a response in the test script result', function () {
+            var test = testrun.script.secondCall.args[2];
+
+            expect(test).to.have.property('response');
+
+            expect(sdk.Response.isResponse(test.response)).to.be(true);
+        });
+
+        it('must have completed the run', function() {
+            expect(testrun).be.ok();
+            expect(testrun.done.calledOnce).be.ok();
+            expect(testrun.done.getCall(0).args[0]).to.be(null);
+            expect(testrun.start.calledOnce).be.ok();
+        });
+    });
+
+    describe('next request in pre-request script', function () {
+        var testrun;
+
+        before(function(done) {
+            this.run({
+                requester: {followRedirects: false},
+                collection: {
+                    item: {
+                        // ensure that we run something for test and pre-req scripts
+                        event: [{
+                            listen: 'prerequest',
+                            script: { exec: 'postman.setNextRequest("some-req-name");' },
+                        }],
+                        request: 'https://postman-echo.com/get'
+                    }
+                }
+            }, function(err, results) {
+                testrun = results;
+                done(err);
+            });
+        });
+
+        it('must have sent the request successfully', function() {
+            expect(testrun).be.ok();
+            expect(testrun.request.calledOnce).be.ok();
+
+            expect(testrun.request.getCall(0).args[0]).to.be(null);
+        });
+
+        it('must have triggered the script event once', function () {
+            expect(testrun.script.calledOnce).to.be.ok();
+        });
+
+        it('must have a return object in the pre-request result', function () {
+            var prerequest = testrun.script.firstCall.args[2];
+
+            expect(prerequest.return).to.be.ok();
+            expect(prerequest.return).to.have.property('nextRequest', 'some-req-name');
+        });
+
+        it('must have completed the run', function() {
+            expect(testrun).be.ok();
+            expect(testrun.done.calledOnce).be.ok();
+            expect(testrun.done.getCall(0).args[0]).to.be(null);
+            expect(testrun.start.calledOnce).be.ok();
+        });
+    });
+});


### PR DESCRIPTION
Ensures that the Script Results are consistent with the rest of the SDK events API.