### PR TITLE
Added integration test for binary file upload content-length

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "inherits": "2.0.3",
     "lodash": "4.17.4",
     "postman-collection": "2.0.2",
-    "postman-request": "2.81.1-postman.1",
+    "postman-request": "2.81.1-postman.2",
     "postman-sandbox": "2.3.1-beta.1",
     "resolve-from": "3.0.0",
     "serialised-error": "1.1.2",

--- a/test/integration/sanity/file-uploads.test.js
+++ b/test/integration/sanity/file-uploads.test.js
@@ -44,7 +44,7 @@ describe('File uploads', function() {
 
     it('must have run the test script successfully', function() {
         expect(testrun).be.ok();
-        expect(testrun.test.calledOnce).be.ok();
+        expect(testrun.test.calledTwice).be.ok();
 
         expect(testrun.test.getCall(0).args[0]).to.be(null);
         expect(_.get(testrun.test.getCall(0).args[2], '0.result.tests["File contents are valid"]')).to.be(true);

--- a/test/integration/sanity/file-uploads.test.js
+++ b/test/integration/sanity/file-uploads.test.js
@@ -25,6 +25,15 @@ describe('File uploads', function() {
                             formdata: [{key: 'file', src: 'test/fixtures/upload-file.json', type: 'file'}]
                         }
                     }
+                }, {
+                    request: {
+                        url: 'https://postman-echo.com/post',
+                        method: 'POST',
+                        body: {
+                            mode: 'file',
+                            file: {src: 'test/fixtures/upload-file.json'}
+                        }
+                    }
                 }]
             }
         }, function(err, results) {
@@ -46,5 +55,18 @@ describe('File uploads', function() {
         expect(testrun.done.calledOnce).be.ok();
         expect(testrun.done.getCall(0).args[0]).to.be(null);
         expect(testrun.start.calledOnce).be.ok();
+    });
+
+    it('must have uploaded the files in binary and formdata mode correctly', function() {
+        expect(testrun).be.ok();
+        expect(testrun.request.calledTwice).to.be.ok();
+
+        expect(testrun.request.getCall(0).args[0]).to.be(null);
+        expect(_.find(testrun.request.getCall(0).args[3].headers.members, {key: 'content-length'})).to.have
+            .property('value', 253);
+
+        expect(testrun.request.getCall(1).args[0]).to.be(null);
+        expect(_.find(testrun.request.getCall(1).args[3].headers.members, {key: 'content-length'})).to.have
+            .property('value', 33);
     });
 });


### PR DESCRIPTION
To be merged after `postman-request@2.81.1-postman.2` has been released and merged into this.