### PR TITLE
Adds concept of RequesterPool to persist options

### DIFF
--- a/lib/authorizer/index.js
+++ b/lib/authorizer/index.js
@@ -1,6 +1,5 @@
 var _ = require('lodash'),
     sdk = require('postman-collection'),
-    Requester = require('../requester').Requester,
 
     AUTH_TYPE_PROP = '__auth_type',
 
@@ -73,10 +72,10 @@ _.assign(Authorizer.prototype, /** @lends Authorizer.prototype */ {
             return callback(null, true);
         }
 
-        Requester.create({
+        run.requester.create({
             type: 'http',  // @todo - how can the auth declare what type it needs?
             source: _.get(handler, AUTH_TYPE_PROP, PRE) + DOT_AUTH
-        }, run.options.requester, function (err, requester) {
+        }, function (err, requester) {
             if (err) { return callback(err); }
 
             handler.pre(context, requester, function () {
@@ -102,10 +101,10 @@ _.assign(Authorizer.prototype, /** @lends Authorizer.prototype */ {
             return callback(null, true);
         }
 
-        Requester.create({
+        run.requester.create({
             type: 'http',  // @todo - how can the auth declare what type it needs?
             source: _.get(handler, AUTH_TYPE_PROP, INIT) + DOT_AUTH
-        }, run.options.requester, function (err, requester) {
+        }, function (err, requester) {
             if (err) { return callback(err); }
 
             handler.init(context, requester, function () {
@@ -151,10 +150,10 @@ _.assign(Authorizer.prototype, /** @lends Authorizer.prototype */ {
             return callback(null, true);
         }
 
-        Requester.create({
+        run.requester.create({
             type: 'http',  // @todo - how can the auth declare what type it needs?
             source: _.get(handler, AUTH_TYPE_PROP, POST) + DOT_AUTH
-        }, run.options.requester, function (err, requester) {
+        }, function (err, requester) {
             if (err) { return callback(err); }
 
             handler.post(context, requester, function () {

--- a/lib/requester/index.js
+++ b/lib/requester/index.js
@@ -1,3 +1,4 @@
 module.exports = {
-    Requester: require('./requester').Requester
+    Requester: require('./requester').Requester,
+    RequesterPool: require('./requester-pool').RequesterPool
 };

--- a/lib/requester/requester-pool.js
+++ b/lib/requester/requester-pool.js
@@ -12,8 +12,8 @@ RequesterPool = function (options) {
         keepAlive: _.get(options, 'requester.keepAlive', true),
         cookieJar: _.get(options, 'requester.cookieJar'), // default set later in this constructor
         strictSSL: _.get(options, 'requester.strictSSL'),
-        sendBodyWithGetRequests: _.get(options, 'sendBodyWithGetRequests', false),
-        followRedirects: _.get(options, 'followRedirects', true)
+        sendBodyWithGetRequests: _.get(options, 'requester.sendBodyWithGetRequests', false),
+        followRedirects: _.get(options, 'requester.followRedirects', true)
     });
 
     // create a cookie jar if one is not provided

--- a/lib/requester/requester-pool.js
+++ b/lib/requester/requester-pool.js
@@ -1,0 +1,29 @@
+var _ = require('lodash'),
+    Requester = require('./requester').Requester,
+    RequestCookieJar = require('postman-request').jar,
+    RequesterPool; // fn
+
+RequesterPool = function (options) {
+    _.assign((this.options = {}), {
+        timeout: _.min([
+            _.get(options, 'timeout.request'),
+            _.get(options, 'timeout.global')
+        ]), // validated later inside requester
+        keepAlive: _.get(options, 'requester.keepAlive', true),
+        cookieJar: _.get(options, 'requester.cookieJar'), // default set later in this constructor
+        strictSSL: _.get(options, 'requester.strictSSL'),
+        sendBodyWithGetRequests: _.get(options, 'sendBodyWithGetRequests', false),
+        followRedirects: _.get(options, 'followRedirects', true)
+    });
+
+    // create a cookie jar if one is not provided
+    if (!this.options.cookieJar) {
+        this.options.cookieJar = RequestCookieJar();
+    }
+};
+
+RequesterPool.prototype.create = function (trace, callback) {
+    return Requester.create(trace, this.options, callback);
+};
+
+module.exports.RequesterPool = RequesterPool;

--- a/lib/requester/requester.js
+++ b/lib/requester/requester.js
@@ -3,7 +3,6 @@ var _ = require('lodash'),
     Emitter = require('events'),
     inherits = require('inherits'),
     sdk = require('postman-collection'),
-    RequestCookieJar = require('postman-request').jar,
     requests = require('./request-wrapper'),
 
     /**
@@ -72,17 +71,13 @@ var _ = require('lodash'),
  * @constructor
  */
 inherits(Requester = function (trace, options) {
-    this.options = {
-        keepAlive: _.get(options, 'keepAlive', true),
+    this.options = options || {};
 
-        // Create a cookie jar if one is not provided
-        cookieJar: options && options.cookieJar || RequestCookieJar(),
+    // protect the timeout value from being non-numeric or infinite
+    if (!_.isFinite(this.options.timeout)) {
+        this.options.timeout = undefined;
+    }
 
-        timeout: _.get(options, 'timeout'),
-        strictSSL: _.get(options, 'strictSSL'),
-        sendBodyWithGetRequests: _.get(options, 'sendBodyWithGetRequests', false),
-        followRedirects: _.get(options, 'followRedirects', true)
-    };
     this.trace = trace;
     Requester.super_.call(this);
 }, Emitter);

--- a/lib/runner/extensions/event.command.js
+++ b/lib/runner/extensions/event.command.js
@@ -7,8 +7,6 @@ var _ = require('lodash'),
     sandbox = require('postman-sandbox'),
     serialisedError = require('serialised-error'),
 
-    Requester = require('../../requester').Requester,
-
     ASSERTION_FAILURE = 'AssertionFailure',
     SAFE_CONTEXT_VARIABLES = ['environment', 'globals', 'cookies', 'data', 'request', 'response'],
 
@@ -78,11 +76,11 @@ module.exports = {
             });
 
             context.on('execution.request', function (cursor, id, requestId, request) {
-                Requester.create({
+                run.requester.create({
                     type: 'http',
                     source: 'script',  // @todo - get script type from the sandbox
                     cursor: cursor
-                }, run.options.requester, function (err, requester) {
+                }, function (err, requester) {
                     var sendId = id + '.' + requestId;
 
                     requester.on(sendId, run.triggers.io.bind(run.triggers));

--- a/lib/runner/extensions/request.command.js
+++ b/lib/runner/extensions/request.command.js
@@ -11,7 +11,7 @@ var _ = require('lodash'),
     posthelpers = require('../request-helpers-postsend'),
 
     Authorizer = require('../../authorizer').Authorizer,
-    Requester = require('../../requester').Requester,
+    RequesterPool = require('../../requester').RequesterPool,
 
     RESPONSE_DOT = 'response.',
 
@@ -50,16 +50,10 @@ var _ = require('lodash'),
 module.exports = {
     init: function (done) {
         // Request timeouts are applied by the requester, so add them to requester options (if any).
-        var self = this,
-            timeout;
+        var self = this;
 
-        timeout = _.min([
-            _.get(self.options, 'timeout.request'),
-            _.get(self.options, 'timeout.global')
-        ]);
-
-        self.options.requester = self.options.requester || {};
-        self.options.requester.timeout = _.isFinite(timeout) ? timeout : undefined;
+        // create a requester pool
+        self.requester = new RequesterPool(self.options);
 
         // Create an authorizer
         Authorizer.create(self.options.authorizer || {}, function (err, authorizer) {
@@ -143,11 +137,11 @@ module.exports = {
 
                 if (aborted) { return next(new Error('runtime: request aborted')); }
 
-                Requester.create(context.trace || {
+                self.requester.create(context.trace || {
                     type: 'http',
                     source: 'collection',
                     cursor: context.coords
-                }, self.options.requester, function (err, requester) {
+                }, function (err, requester) {
                     if (err) { return next(err); }  // this should never happen
 
                     var sendId = RESPONSE_DOT + uuid();

--- a/test/integration/sanity/cookie-handling.test.js
+++ b/test/integration/sanity/cookie-handling.test.js
@@ -14,6 +14,15 @@ describe('cookies', function () {
                         }
                     }],
                     request: 'http://postman-echo.com/cookies/set?foo=bar'
+                }, {
+                    event: [{
+                        listen: 'test',
+                        script: {
+                            type: 'text/javascript',
+                            exec: ['tests["working"] = postman.getResponseCookie("foo").value === "bar"']
+                        }
+                    }],
+                    request: 'http://postman-echo.com/cookies/get'
                 }]
             }
         }, function (err, results) {
@@ -24,10 +33,19 @@ describe('cookies', function () {
 
     it('must have run the test script successfully', function () {
         expect(testrun).be.ok();
-        expect(testrun.test.calledOnce).be.ok();
+        expect(testrun.test.calledTwice).be.ok();
 
         expect(testrun.test.getCall(0).args[0]).to.be(null);
-        expect(_.get(testrun.test.getCall(0).args[2], '0.result.tests.working')).to.be(true);
+        expect(_.find(testrun.test.getCall(0).args[2][0].result.cookies, {name: 'foo'})).to.have
+            .property('value', 'bar');
+        expect(_.get(testrun.test.getCall(0).args[2], '0.result.request.headers.reference.cookie.value')).to
+            .match(/foo=bar;/);
+
+        expect(testrun.test.getCall(1).args[0]).to.be(null);
+        expect(_.find(testrun.test.getCall(1).args[2][0].result.cookies, {name: 'foo'})).to.have
+            .property('value', 'bar');
+        expect(_.get(testrun.test.getCall(1).args[2], '0.result.request.headers.reference.cookie.value')).to
+            .match(/foo=bar;/);
     });
 
     it('must have completed the run', function () {

--- a/test/unit/authorizer-sanity.test.js
+++ b/test/unit/authorizer-sanity.test.js
@@ -5,8 +5,7 @@ var _ = require('lodash'),
     sdk = require('postman-collection');
 
 describe('authorizer sanity', function () {
-    var Authorizer = require('../../lib/authorizer/index').Authorizer,
-        Run = require('../../lib/runner/run');
+    var Authorizer = require('../../lib/authorizer/index').Authorizer;
 
     it('should expose an constructor', function () {
         expect(Authorizer).to.be.a('function');
@@ -170,7 +169,9 @@ describe('authorizer sanity', function () {
                 context = {
                     auth: new sdk.RequestAuth.types.fake()
                 };
-                run = new Run();
+                run = {
+                    requester: new (require('../../lib/requester').RequesterPool)()
+                };
                 done();
             });
         });


### PR DESCRIPTION
The premise of this PR comes from the bug where cookie jar was not persistent across requests.

Creating new instances of Requester whenever needed caused to not be able to store common stuff across requesters. This is still a temporary measure. 

For example, a reference to cookie jar could not be re-used.

Long Term: Down the line, CookieJar store would be forwarded to the request library after embedding the requester fully into `postman-request` as such, like sandbox, moving requester completely out into a separate external module.