### PR TITLE
Set tunnel to true only for https URLs

### DIFF
--- a/lib/requester/request-wrapper.js
+++ b/lib/requester/request-wrapper.js
@@ -81,7 +81,10 @@ var _ = require('lodash'),
 
         if ((proxyConfig = _.get(request, 'proxy'))) {
             options.proxy = proxyConfig.getProxyUrl(request.url);
-            options.tunnel = proxyConfig.tunnel;
+            // TODO: figure out why tunnel is not working with http request
+            // and without tunnel why https is not working
+            // When this is fixed, App needs to show option to configure tunnel
+            options.tunnel = _.startsWith(request.url, 'https://');
         }
         cb(null, request, options);
     },


### PR DESCRIPTION
Ideally, tunnel should also work with http URLs ~and~
~HTTPS should also work without tunnel~

But since this is not working and the reason is not known, we will be using tunnel for only https URLs for now

Also, the tunnel option from App will be removed until this is fixed