### PR TITLE
Set the tunnel value from the type of request URL

### DIFF
--- a/lib/requester/request-wrapper.js
+++ b/lib/requester/request-wrapper.js
@@ -81,7 +81,9 @@ var _ = require('lodash'),
 
         if ((proxyConfig = _.get(request, 'proxy'))) {
             options.proxy = proxyConfig.getProxyUrl(request.url);
-            options.tunnel = proxyConfig.tunnel;
+            // TODO: Use tri-state var for tunnel in SDK and update here
+            // for now determine the tunnel value from the URL unless explicitly set to true
+            options.tunnel = proxyConfig.tunnel ? true : _.startsWith(request.url, 'https://');
         }
         cb(null, request, options);
     },


### PR DESCRIPTION
Unless the value of tunnel is explicitly set to true, determine it from the type of request URL
If the URL is secure (https) set the tunnel value to true

#### This is being done coz:
In the App, we want to support a single global proxy server definition which can support both http and https requests.
If we don't do this then users won't be able to use the global proxy if their proxy server does not support tunnel for HTTP requests