### PR TITLE
Add Visual Studio Code .vscode to ignore lists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,7 @@ Thumbs.db
 
 # Prevent IDE stuff
 .idea
-
+.vscode
 
 # PROJECT
 # =======

--- a/.npmignore
+++ b/.npmignore
@@ -15,7 +15,7 @@ Thumbs.db
 
 # Prevent IDE stuff
 .idea
-
+.vscode
 
 # PROJECT
 # =======


### PR DESCRIPTION
As JetBrains IDEs use .idea for IDE specific settings, Visual Studio Code uses .vscode.

These two one-line changes just add add .vscode to the .gitignore and .npmignore lists.