### PR TITLE
Add `_request_id` to trace to uniquely identify requests

### DIFF
--- a/lib/runner/extensions/event.command.js
+++ b/lib/runner/extensions/event.command.js
@@ -76,13 +76,14 @@ module.exports = {
             });
 
             context.on('execution.request', function (cursor, id, requestId, request) {
+                var sendId = id + '.' + requestId;
+
                 run.requester.create({
                     type: 'http',
+                    _request_id: sendId,
                     source: 'script', // @todo - get script type from the sandbox
                     cursor: cursor
                 }, function (err, requester) { // eslint-disable-line handle-callback-err
-                    var sendId = id + '.' + requestId;
-
                     requester.on(sendId, run.triggers.io.bind(run.triggers));
 
                     return requester.request(sendId, new sdk.Request(request), function (err, res) {

--- a/lib/runner/extensions/request.command.js
+++ b/lib/runner/extensions/request.command.js
@@ -140,7 +140,8 @@ module.exports = {
                 self.requester.create(context.trace || {
                     type: 'http',
                     source: 'collection',
-                    cursor: context.coords
+                    cursor: context.coords,
+                    _request_id: context.coords.ref
                 }, function (err, requester) {
                     if (err) { return next(err); } // this should never happen
 

--- a/test/integration/request-flow/requests-from-sandbox.test.js
+++ b/test/integration/request-flow/requests-from-sandbox.test.js
@@ -1,3 +1,5 @@
+var _ = require('lodash');
+
 describe('requests from sandbox', function() {
     describe('sanity checks', function () {
         var testrun,
@@ -61,6 +63,7 @@ describe('requests from sandbox', function() {
 
             expect(trace).to.have.property('type', 'http');
             expect(trace).to.have.property('source', 'script');
+            expect(trace).to.have.property('_request_id');
         });
 
         it('should have sent the second request as a part of the collection run', function () {
@@ -228,6 +231,17 @@ describe('requests from sandbox', function() {
             expect(assertion).to.have.property('passed', true);
             expect(assertion).to.have.property('error', null);
             expect(assertion).to.have.property('index', 1);
+        });
+
+        it('should propagate unique request id in `_request_id`', function () {
+            var i = 0,
+                requestIds = [];
+
+            for (i = 0; i < testrun.io.callCount; i++) {
+                requestIds.push(testrun.io.getCall(i).args[2]._request_id);
+            }
+
+            expect(_.uniq(requestIds)).to.have.length(testrun.io.callCount);
         });
 
         it('must have completed the run', function() {


### PR DESCRIPTION
This PR adds `_request_id` to trace for each request that is triggered from `script` and `collection`. 

This allows to uniquely identify individual requests even when the `cursor` is still the same.

`_request_id` is not added to requests triggered from `Authorizer` yet. @shamasis should we create new ids for intermediate requests sent by `Authorizer`, or is there any other identifier we can use?
