### PR TITLE
Queue `pm.sendRequest` through `request` command

### DIFF
--- a/lib/runner/extensions/event.command.js
+++ b/lib/runner/extensions/event.command.js
@@ -75,23 +75,6 @@ module.exports = {
                 run.triggers.assertion.apply(run.triggers, arguments);
             });
 
-            context.on('execution.request', function (cursor, id, requestId, request) {
-                run.requester.create({
-                    type: 'http',
-                    source: 'script', // @todo - get script type from the sandbox
-                    cursor: cursor
-                }, function (err, requester) { // eslint-disable-line handle-callback-err
-                    var sendId = id + '.' + requestId;
-
-                    requester.on(sendId, run.triggers.io.bind(run.triggers));
-
-                    return requester.request(sendId, new sdk.Request(request), function (err, res) {
-                        context.dispatch('execution.response.' + id, requestId, err, res);
-                        requester.dispose();
-                    });
-                });
-            });
-
             done();
         });
     },
@@ -194,6 +177,27 @@ module.exports = {
                         !assertion.passed && assertionFailed.push(assertion.name);
                     });
 
+                var run = this;
+
+                this.host.on('execution.request', function (cursor, id, requestId, request) {
+                    // clone cursor and add source
+                    var cursorWithSource = _.clone(cursor);
+
+                    cursorWithSource.source = 'script'; // @todo - get script type from the sandbox
+
+                    run.immediate('request', {
+                        item: new sdk.Item({
+                            request: request
+                        }),
+                        globals: payload.context.globals,
+                        environment: payload.context.environment,
+                        data: payload.context.data,
+                        coords: cursorWithSource
+                    }, function (err, nextPayload) {
+                        run.host.dispatch('execution.response.' + id, requestId, err, nextPayload && nextPayload.response);
+                    });
+                });
+
                 // finally execute the script
                 this.host.execute(event, {
                     id: executionId,
@@ -208,6 +212,7 @@ module.exports = {
                         _itemName: item.name
                     }
                 }, function (err, result) {
+                    this.host.removeAllListeners('execution.request');
                     this.host.removeAllListeners('execution.assertion.' + executionId);
                     this.host.removeAllListeners('execution.error.' + executionId);
 

--- a/lib/runner/extensions/event.command.js
+++ b/lib/runner/extensions/event.command.js
@@ -177,26 +177,28 @@ module.exports = {
                         !assertion.passed && assertionFailed.push(assertion.name);
                     });
 
-                var run = this;
-
                 this.host.on('execution.request', function (cursor, id, requestId, request) {
                     // clone cursor and add source
-                    var cursorWithSource = _.clone(cursor);
+                    var cursorWithSource = _.clone(cursor),
+                        tempItem = new sdk.Item({
+                            request: request
+                        });
 
+                    tempItem.setParent(item);
                     cursorWithSource.source = 'script'; // @todo - get script type from the sandbox
 
-                    run.immediate('request', {
-                        item: new sdk.Item({
-                            request: request
-                        }),
+                    this.immediate('request', {
+                        item: tempItem,
                         globals: payload.context.globals,
                         environment: payload.context.environment,
                         data: payload.context.data,
                         coords: cursorWithSource
-                    }).done(function (err, nextPayload) {
-                        run.host.dispatch('execution.response.' + id, requestId, err, nextPayload && nextPayload.response);
+                    }).done(function (err, result) {
+                        this.host.dispatch('execution.response.' + id, requestId, err, result && result.response);
+                    }).catch(function (err) {
+                        this.host.dispatch('execution.response.' + id, requestId, err);
                     });
-                });
+                }.bind(this));
 
                 // finally execute the script
                 this.host.execute(event, {

--- a/lib/runner/extensions/event.command.js
+++ b/lib/runner/extensions/event.command.js
@@ -256,7 +256,7 @@ module.exports = {
 
                         tempItem.setParent(item);
 
-                        cursorWithSource.source = 'script'; // @todo - get script type from the sandbox
+                        cursorWithSource._source = 'script'; // @todo - get script type from the sandbox
 
                         this.immediate('request', {
                             item: tempItem,

--- a/lib/runner/extensions/event.command.js
+++ b/lib/runner/extensions/event.command.js
@@ -193,8 +193,8 @@ module.exports = {
                         environment: payload.context.environment,
                         data: payload.context.data,
                         coords: cursorWithSource
-                    }).done(function (err, result) {
-                        this.host.dispatch('execution.response.' + id, requestId, err, result && result.response);
+                    }).done(function (result) {
+                        this.host.dispatch('execution.response.' + id, requestId, null, result && result.response);
                     }).catch(function (err) {
                         this.host.dispatch('execution.response.' + id, requestId, err);
                     });

--- a/lib/runner/extensions/event.command.js
+++ b/lib/runner/extensions/event.command.js
@@ -177,7 +177,7 @@ module.exports = {
                         !assertion.passed && assertionFailed.push(assertion.name);
                     });
 
-                this.host.on('execution.request', function (cursor, id, requestId, request) {
+                this.host.on('execution.request.' + executionId, function (cursor, id, requestId, request) {
                     // clone cursor and add source
                     var cursorWithSource = _.clone(cursor),
                         tempItem = new sdk.Item({
@@ -214,7 +214,7 @@ module.exports = {
                         _itemName: item.name
                     }
                 }, function (err, result) {
-                    this.host.removeAllListeners('execution.request');
+                    this.host.removeAllListeners('execution.request.' + executionId);
                     this.host.removeAllListeners('execution.assertion.' + executionId);
                     this.host.removeAllListeners('execution.error.' + executionId);
 

--- a/lib/runner/extensions/event.command.js
+++ b/lib/runner/extensions/event.command.js
@@ -192,7 +192,10 @@ module.exports = {
                         globals: payload.context.globals,
                         environment: payload.context.environment,
                         data: payload.context.data,
-                        coords: cursorWithSource
+                        coords: cursorWithSource,
+                        // abortOnError is set to true to make sure
+                        // request command bubbles errors so we can pass it on to the callback
+                        abortOnError: true
                     }).done(function (result) {
                         this.host.dispatch('execution.response.' + id, requestId, null, result && result.response);
                     }).catch(function (err) {

--- a/lib/runner/extensions/event.command.js
+++ b/lib/runner/extensions/event.command.js
@@ -193,7 +193,7 @@ module.exports = {
                         environment: payload.context.environment,
                         data: payload.context.data,
                         coords: cursorWithSource
-                    }, function (err, nextPayload) {
+                    }).done(function (err, nextPayload) {
                         run.host.dispatch('execution.response.' + id, requestId, err, nextPayload && nextPayload.response);
                     });
                 });

--- a/lib/runner/extensions/event.command.js
+++ b/lib/runner/extensions/event.command.js
@@ -10,6 +10,11 @@ var _ = require('lodash'),
     ASSERTION_FAILURE = 'AssertionFailure',
     SAFE_CONTEXT_VARIABLES = ['environment', 'globals', 'cookies', 'data', 'request', 'response'],
 
+    EXECUTION_REQUEST_EVENT_BASE = 'execution.request.',
+    EXECUTION_RESPONSE_EVENT_BASE = 'execution.response.',
+    EXECUTION_ASSERTION_EVENT_BASE = 'execution.assertion.',
+    EXECUTION_ERROR_EVENT_BASE = 'execution.error.',
+
     postProcessContext = function (execution, failures) { // function determines whether the event needs to abort
         var tests = execution && execution.tests,
             error;
@@ -173,11 +178,11 @@ module.exports = {
                 // add event listener to trap all assertion events, but only if needed. to avoid needlessly accumulate
                 // stuff in memory.
                 (abortOnFailure || stopOnFailure) &&
-                    this.host.on('execution.assertion.' + executionId, function (cursor, assertion) {
+                    this.host.on(EXECUTION_ASSERTION_EVENT_BASE + executionId, function (cursor, assertion) {
                         !assertion.passed && assertionFailed.push(assertion.name);
                     });
 
-                this.host.on('execution.request.' + executionId, function (cursor, id, requestId, request) {
+                this.host.on(EXECUTION_REQUEST_EVENT_BASE + executionId, function (cursor, id, requestId, request) {
                     // clone cursor and add source
                     var cursorWithSource = _.clone(cursor),
                         tempItem = new sdk.Item({
@@ -197,9 +202,13 @@ module.exports = {
                         // request command bubbles errors so we can pass it on to the callback
                         abortOnError: true
                     }).done(function (result) {
-                        this.host.dispatch('execution.response.' + id, requestId, null, result && result.response);
+                        this.host.dispatch(
+                            EXECUTION_RESPONSE_EVENT_BASE + id,
+                            requestId, null,
+                            result && result.response
+                        );
                     }).catch(function (err) {
-                        this.host.dispatch('execution.response.' + id, requestId, err);
+                        this.host.dispatch(EXECUTION_RESPONSE_EVENT_BASE + id, requestId, err);
                     });
                 }.bind(this));
 
@@ -217,9 +226,9 @@ module.exports = {
                         _itemName: item.name
                     }
                 }, function (err, result) {
-                    this.host.removeAllListeners('execution.request.' + executionId);
-                    this.host.removeAllListeners('execution.assertion.' + executionId);
-                    this.host.removeAllListeners('execution.error.' + executionId);
+                    this.host.removeAllListeners(EXECUTION_REQUEST_EVENT_BASE + executionId);
+                    this.host.removeAllListeners(EXECUTION_ASSERTION_EVENT_BASE + executionId);
+                    this.host.removeAllListeners(EXECUTION_ERROR_EVENT_BASE + executionId);
 
                     // electron IPC does not bubble errors to the browser process, so we serialize it here.
                     err && (err = serialisedError(err, true));

--- a/lib/runner/extensions/request.command.js
+++ b/lib/runner/extensions/request.command.js
@@ -81,6 +81,7 @@ module.exports = {
          * @param {VariableScope} payload.globals
          * @param {VariableScope} payload.environment
          * @param {Cursor} payload.coords
+         * @param {Boolean} payload.abortOnError
          * @param {Function} next
          *
          * @todo  validate payload

--- a/lib/runner/extensions/request.command.js
+++ b/lib/runner/extensions/request.command.js
@@ -39,6 +39,11 @@ var _ = require('lodash'),
         // so that we can make any changes we need there, without mutating the collection.
         context.item = context.item || new sdk.Item(payload.item.toJSON());
 
+        if (!_.get(payload, 'coords.httpRequestId')) {
+            context.coords = _.clone(payload.coords);
+            _.set(context, 'coords.httpRequestId', uuid());
+        }
+
         // in order to ensure that variable resolution works correctly, we set the __parent property,
         // so that the SDK can locate the VariableList in the collection.
         parent = payload.item.parent();
@@ -110,7 +115,7 @@ module.exports = {
 
                 // Helper function which calls the beforeRequest trigger ()
                 beforeRequest = function (err) {
-                    !replayed && self.triggers.beforeRequest(err, payload.coords, item.request, payload.item, {
+                    !replayed && self.triggers.beforeRequest(err, context.coords, item.request, payload.item, {
                         abort: function () {
                             !aborted && xhr && xhr.abort();
                             aborted = true;
@@ -120,7 +125,7 @@ module.exports = {
 
                 // Helper function to call the afterRequest trigger.
                 afterRequest = function (err, response, request, cookies) {
-                    self.triggers.request(err, payload.coords, response, request, payload.item, cookies);
+                    self.triggers.request(err, context.coords, response, request, payload.item, cookies);
                 };
 
                 // Ensure that this is called.
@@ -139,7 +144,7 @@ module.exports = {
 
                 self.requester.create(context.trace || {
                     type: 'http',
-                    source: 'collection',
+                    source: context.coords.source || 'collection',
                     cursor: context.coords
                 }, function (err, requester) {
                     if (err) { return next(err); } // this should never happen

--- a/lib/runner/extensions/request.command.js
+++ b/lib/runner/extensions/request.command.js
@@ -39,9 +39,9 @@ var _ = require('lodash'),
         // so that we can make any changes we need there, without mutating the collection.
         context.item = context.item || new sdk.Item(payload.item.toJSON());
 
-        if (!_.get(payload, 'coords.httpRequestId')) {
+        if (!_.get(payload, 'coords._httpId')) {
             context.coords = _.clone(payload.coords);
-            _.set(context, 'coords.httpRequestId', uuid());
+            _.set(context, 'coords._httpId', uuid());
         }
 
         // in order to ensure that variable resolution works correctly, we set the __parent property,
@@ -145,7 +145,7 @@ module.exports = {
 
                 self.requester.create(context.trace || {
                     type: 'http',
-                    source: context.coords.source || 'collection',
+                    source: context.coords._source || 'collection',
                     cursor: context.coords
                 }, function (err, requester) {
                     if (err) { return next(err); } // this should never happen

--- a/lib/runner/instruction.js
+++ b/lib/runner/instruction.js
@@ -7,6 +7,9 @@
 var _ = require('lodash'),
     Timings = require('./timings'),
 
+    arrayProtoSlice = Array.prototype.slice,
+    arrayProtoUnshift = Array.prototype.unshift,
+
     pool; // function
 
 /**
@@ -117,46 +120,54 @@ pool = function (processors) {
     Instruction.prototype.execute = function(callback, scope) {
         !scope && (scope = this);
 
-        var args = _.clone(this.in),
+        var params = _.clone(this.in),
             sealed = false,
 
-            doneAndSpread = function (args) {
+            doneAndSpread = function (err) {
                 if (sealed) {
-                    console.log('__postmanruntime_fatal_debug: instruction.execute callback called twice');
+                    console.error('__postmanruntime_fatal_debug: instruction.execute callback called twice');
                     return;
                 }
                 sealed = true;
-                Array.prototype.unshift.call(args, scope);
+                this.timings.record('end');
+
+                var args = arrayProtoSlice.call(arguments);
+                arrayProtoUnshift.call(args, scope);
+
+                if (err) { // in case it errored, we do not process any thenables
+                    _.isArray(this._catch) && _.invokeMap(this._catch, _.apply, scope, arguments);
+                }
+                else {
+                    // call all the `then` stuff and then the main callback
+                    _.isArray(this._done) && _.invokeMap(this._done, _.apply, scope, _.tail(arguments));
+                }
+
                 setTimeout(callback.bind.apply(callback, args), 0);
-            };
+            }.bind(this);
 
         // add two additional arguments at the end of the arguments saved - i.e. the payload and a function to call the
         // callback asynchronously
-        args.push(this.payload, function (err) {
-            this.timings.record('end');
-
-            // in case it errored, we do not process any thenables
-            if (!err) { // @todo - to be decided whether this remains the behaviour post .catch
-                // call all the `then` stuff and then the main callback
-                _.isArray(this._done) && _.invokeMap(this._done, _.apply, scope, _.tail(arguments));
-            }
-
-            return doneAndSpread(arguments);
-        }.bind(this));
+        params.push(this.payload, doneAndSpread);
 
         this.timings.record('start');
 
         // run the processor in a try block to avoid causing stalled runs
         try {
-            this._processor.apply(scope, args);
+            this._processor.apply(scope, params);
         }
         catch (e) {
-            doneAndSpread([e]);
+            doneAndSpread(e);
         }
     };
 
     Instruction.prototype.done = function (callback) {
         (this._done || (this._done = [])).push(callback);
+        return this;
+    };
+
+    Instruction.prototype.catch = function (callback) {
+        (this._catch || (this._catch = [])).push(callback);
+        return this;
     };
 
     Instruction.clear = function () {

--- a/lib/runner/run.js
+++ b/lib/runner/run.js
@@ -131,7 +131,9 @@ _.assign(Run.prototype, {
     _schedule: function (action, payload, args, immediate) {
         var instruction = this.pool.create(action, payload, args);
         // based on whether the immediate flag is set, add to the top or bottom of the instruction queue.
-        return (this.pool[immediate ? 'unshift' : 'push'](instruction), instruction);
+        (immediate ? this.pool.unshift : this.pool.push)(instruction);
+
+        return instruction;
     },
 
     _process: function (callback) {
@@ -140,25 +142,14 @@ _.assign(Run.prototype, {
 
         // if there is nothing to process, exit
         if (!instruction) {
-            this._traceEnd(); // end the trace before exiting function
-            return callback(null, this.state.cursor.current());
+            callback(null, this.state.cursor.current());
+            return;
         }
 
-        // ensure that the trace is started
-        this._trace(instruction);
         instruction.execute(function (err) {
-            if (err) {
-                this._traceEnd(err);
-                return callback(err, this.state.cursor.current());
-            }
-
-            this._process(callback); // process recursively if stop is not called
+            return err ? callback(err, this.state.cursor.current()) : this._process(callback); // process recursively
         }, this);
-    },
-
-    // debugging functions for later internal use
-    _trace: function () { }, // eslint-disable-line
-    _traceEnd: function () { delete this.triggers; } // eslint-disable-line
+    }
 });
 
 _.assign(Run, {

--- a/lib/runner/run.js
+++ b/lib/runner/run.js
@@ -68,6 +68,15 @@ _.assign(Run.prototype, {
         return this._schedule(action, payload, _.slice(arguments, 2), true);
     },
 
+    immediate: function (action, payload, callback) {
+        var scope = this,
+            instruction = this.pool.create(action, payload, _.slice(arguments, 3));
+        setImmediate(function () {
+            instruction.execute(callback, scope);
+        });
+        return instruction;
+    },
+
     /**
      * @param {Function|Object} callback
      */

--- a/lib/runner/run.js
+++ b/lib/runner/run.js
@@ -68,12 +68,23 @@ _.assign(Run.prototype, {
         return this._schedule(action, payload, _.slice(arguments, 2), true);
     },
 
-    immediate: function (action, payload, callback) {
+    // eslint-disable-next-line jsdoc/check-param-names
+    /**
+     * @param {String} action
+     * @param {Object} payload
+     * @param {*} [args...]
+     */
+    immediate: function (action, payload) {
         var scope = this,
-            instruction = this.pool.create(action, payload, _.slice(arguments, 3));
-        setImmediate(function () {
-            instruction.execute(callback, scope);
-        });
+            instruction = this.pool.create(action, payload, _.slice(arguments, 2));
+
+        // we directly execute this instruction instead od queueing it.
+        setTimeout(function () {
+            // we do not have callback, hence we send _.noop. we could have had made callback in .execute optional, but
+            // that would suppress design-time bugs in majority use-case and hence we avoided the same.
+            instruction.execute(_.noop, scope);
+        }, 0);
+
         return instruction;
     },
 

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "lodash": "4.17.4",
     "postman-collection": "2.1.0",
     "postman-request": "2.81.1-postman.2",
-    "postman-sandbox": "2.3.1-beta.1",
+    "postman-sandbox": "2.3.1-beta.3",
     "resolve-from": "3.0.0",
     "serialised-error": "1.1.2",
     "uuid": "3.1.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postman-runtime",
-  "version": "6.2.6-beta.1",
+  "version": "6.2.6-beta.2",
   "description": "Underlyng library of executing Postman Collections (used by Newman)",
   "main": "index.js",
   "directories": {

--- a/test/integration/request-flow/requests-from-sandbox.test.js
+++ b/test/integration/request-flow/requests-from-sandbox.test.js
@@ -37,8 +37,8 @@ describe('requests from sandbox', function() {
             expect(testrun.io.calledTwice).to.be(true);
         });
 
-        it('should have called the request event once', function () {
-            expect(testrun.request.calledOnce).to.be(true);
+        it('should have called the request event twice', function () {
+            expect(testrun.request.calledTwice).to.be(true);
         });
 
         it('should have the same cursor id for both the io events', function () {
@@ -149,8 +149,8 @@ describe('requests from sandbox', function() {
             expect(testrun.io.calledThrice).to.be(true);
         });
 
-        it('should have called the request event once', function () {
-            expect(testrun.request.calledOnce).to.be(true);
+        it('should have called the request event thrice', function () {
+            expect(testrun.request.calledThrice).to.be(true);
         });
 
         it('should have the same cursor id for all the io events', function () {
@@ -276,8 +276,8 @@ describe('requests from sandbox', function() {
             expect(testrun.io.calledTwice).to.be(true);
         });
 
-        it('should have called the request event once', function () {
-            expect(testrun.request.calledOnce).to.be(true);
+        it('should have called the request event twice', function () {
+            expect(testrun.request.calledTwice).to.be(true);
         });
 
         it('should have the same cursor id for both the io events', function () {

--- a/test/integration/request-flow/requests-from-sandbox.test.js
+++ b/test/integration/request-flow/requests-from-sandbox.test.js
@@ -1,5 +1,5 @@
 describe('requests from sandbox', function() {
-    describe('sanity checks', function () {
+    describe('single .sendRequest', function () {
         var testrun,
             sandboxRequestUrl = 'postman-echo.com/get?sandbox=true';
 
@@ -14,7 +14,7 @@ describe('requests from sandbox', function() {
                                 exec: `
                                 var sdk = require('postman-collection'),
                                     myreq = new sdk.Request('${sandboxRequestUrl}');
-                                
+
                                 pm.sendRequest(myreq, function(err, _response) {
                                     pm.test('request was sent from sandbox', function () {
                                         pm.expect(_response).to.have.property('code', 200);
@@ -114,21 +114,21 @@ describe('requests from sandbox', function() {
                                 exec: `
                                 var sdk = require('postman-collection'),
                                     req1 = new sdk.Request('${sandboxRequestUrl1}');
-                                
+
                                 pm.sendRequest(req1, function(err, response1) {
                                     pm.test('${testname1}', function () {
                                         pm.expect(response1).to.have.property('code', 200);
                                         pm.expect(response1).to.have.property('status', 'OK');
-                                        
+
                                         pm.expect(response1.json().args).to.have.property('n', '1');
                                     });
-                                    
+
                                     var req2 = new sdk.Request('${sandboxRequestUrl2}');
                                     pm.sendRequest(req2, function (err, response2) {
                                         pm.test('${testname2}', function () {
                                             pm.expect(response2).to.have.property('code', 200);
                                             pm.expect(response2).to.have.property('status', 'OK');
-                                            
+
                                             pm.expect(response2.json().args).to.have.property('n', '2');
                                         });
                                     });
@@ -253,7 +253,7 @@ describe('requests from sandbox', function() {
                                 exec: `
                                 var sdk = require('postman-collection'),
                                     myreq = new sdk.Request('${sandboxRequestUrl}');
-                                
+
                                 pm.sendRequest(myreq, function(err, _response) {
                                     pm.test('request did not complete', function () {
                                         pm.expect(err).to.have.property('code', 'ENOTFOUND');


### PR DESCRIPTION
Queue `pm.sendRequest` through `request` command instead of sending the request over directly. This handles variable, proxy, and certificate resolution.