### PR TITLE
Make sure empty Urls do not break runs

### DIFF
--- a/lib/requester/requester.js
+++ b/lib/requester/requester.js
@@ -101,7 +101,7 @@ _.extend(Requester.prototype, /** @lends Requester.prototype */ {
         // at this point the request could have come from collection, auth or sandbox
         // we can't trust the integrity of this request
         // bail out if request url is empty
-        if (!(request && request.url && request.url.toString())) {
+        if (!(request && request.url && request.url.toString && request.url.toString())) {
             error = new Error('runtime:extenstions~request: request url is empty');
             this.emit(id, error, this.trace.cursor, this.trace, undefined, request);
             return callback(error, undefined, request);

--- a/lib/requester/requester.js
+++ b/lib/requester/requester.js
@@ -92,10 +92,24 @@ _.extend(Requester.prototype, /** @lends Requester.prototype */ {
      * @param {Function} callback
      */
     request: function (id, request, callback) {
-        var self = this,
-            cookieJar = self.options.cookieJar,
-            requestOptions = util.getRequestOptions(request, self.options),
-            startTime = Date.now();
+        var error,
+            self = this,
+            cookieJar,
+            requestOptions,
+            startTime;
+
+        // at this point the request could have come from collection, auth or sandbox
+        // we can't trust the integrity of this request
+        // bail out if request url is empty
+        if (!(request && request.url && request.url.toString())) {
+            error = new Error('runtime:extenstions~request: request url is empty');
+            this.emit(id, error, this.trace.cursor, this.trace, undefined, request);
+            return callback(error, undefined, request);
+        }
+
+        cookieJar = self.options.cookieJar;
+        requestOptions = util.getRequestOptions(request, self.options);
+        startTime = Date.now();
 
         return requests(request, requestOptions, function (err, res, resBody) {
             if (err) {

--- a/test/integration/sanity/url-sanity-before-request.test.js
+++ b/test/integration/sanity/url-sanity-before-request.test.js
@@ -1,52 +1,85 @@
 describe('url', function () {
-    var testrun;
+    describe('with variables', function () {
+        var testrun;
 
-    before(function (done) {
-        this.run({
-            collection: {
-                item: {
-                    request: {
-                        url: {
-                            host: ['{{url}}'],
-                            path: [':verb'],
-                            variable: [{
-                                value: 'get',
-                                id: 'verb'
-                            }]
-                        },
-                        method: 'GET'
+        before(function (done) {
+            this.run({
+                collection: {
+                    item: {
+                        request: {
+                            url: {
+                                host: ['{{url}}'],
+                                path: [':verb'],
+                                variable: [{
+                                    value: 'get',
+                                    id: 'verb'
+                                }]
+                            },
+                            method: 'GET'
+                        }
                     }
+                },
+                globals: {
+                    values: [{key: 'url', value: 'http://postman-echo.com'}]
                 }
-            },
-            globals: {
-                values: [{key: 'url', value: 'http://postman-echo.com'}]
-            }
-        }, function (err, results) {
-            testrun = results;
-            done(err);
+            }, function (err, results) {
+                testrun = results;
+                done(err);
+            });
+        });
+
+        it('must have started and completed the test run', function () {
+            expect(testrun).be.ok();
+            expect(testrun.done.calledOnce).be.ok();
+            expect(testrun.start.calledOnce).be.ok();
+        });
+
+        it('must parse the url after variable resolution and path variable resolution', function () {
+            var request = testrun.beforeRequest.getCall(0).args[2];
+
+            expect(testrun.beforeRequest.calledOnce).be.ok(); // one request
+            expect(request).be.ok();
+            expect(request.url.host).to.not.match(/^http:\/\/.*/);
+            expect(request.url.toString()).eql('http://postman-echo.com/get');
+            expect(request.method).be('GET');
+        });
+
+        it('must receive response with status code 200 OK', function () {
+            var response = testrun.request.getCall(0).args[2];
+
+            expect(testrun.request.calledOnce).be.ok(); // one request
+            expect(response.code).to.be(200);
         });
     });
 
-    it('must have started and completed the test run', function () {
-        expect(testrun).be.ok();
-        expect(testrun.done.calledOnce).be.ok();
-        expect(testrun.start.calledOnce).be.ok();
-    });
+    describe('empty', function () {
+        var testrun;
 
-    it('must parse the url after variable resolution and path variable resolution', function () {
-        var request = testrun.beforeRequest.getCall(0).args[2];
+        before(function(done) {
+            this.run({
+                collection: {
+                    item: {
+                        request: {}
+                    }
+                }
+            }, function(err, results) {
+                testrun = results;
+                done(err);
+            });
+        });
 
-        expect(testrun.beforeRequest.calledOnce).be.ok(); // one request
-        expect(request).be.ok();
-        expect(request.url.host).to.not.match(/^http:\/\/.*/);
-        expect(request.url.toString()).eql('http://postman-echo.com/get');
-        expect(request.method).be('GET');
-    });
+        it('should have called request event once', function () {
+            var emptyUrlErrorMessage = 'runtime:extenstions~request: request url is empty';
 
-    it('must receive response with status code 200 OK', function () {
-        var response = testrun.request.getCall(0).args[2];
+            expect(testrun.request.callCount).to.eql(1);
+            expect(testrun.request.getCall(0).args[0].message).to.eql(emptyUrlErrorMessage);
+        });
 
-        expect(testrun.request.calledOnce).be.ok(); // one request
-        expect(response.code).to.be(200);
+        it('must have completed the run', function() {
+            expect(testrun).be.ok();
+            expect(testrun.done.calledOnce).be.ok();
+            expect(testrun.done.getCall(0).args[0]).to.be(null);
+            expect(testrun.start.calledOnce).be.ok();
+        });
     });
 });


### PR DESCRIPTION
`util.getRequestOptions` internally called `url.getHost` which errored out for empty host. `url.getHost` should not have errored in the first place, raised a [PR](https://github.com/postmanlabs/postman-collection/pull/443) for that as well.

Plus it doesn't make sense to proceed with `requester.request` when the `url` is empty. Hence added a bail out for this case.