### PR TITLE
Allow updation of user properties when the value is empty string

### DIFF
--- a/lib/authorizer/auth-interface.js
+++ b/lib/authorizer/auth-interface.js
@@ -1,4 +1,5 @@
 var _ = require('lodash'),
+    EMPTY = '',
     createAuthInterface;
 
 /**
@@ -70,7 +71,7 @@ createAuthInterface = function (auth) {
                 }
 
                 // Update if the param is a system property or an empty user property (null, undefined or empty string)
-                if (param.system || param.value === '' || _.isNil(param.value) || _.isNaN(param.value)) {
+                if (param.system || param.value === EMPTY || _.isNil(param.value) || _.isNaN(param.value)) {
                     return param.update({key: key, value: value, system: true});
                 }
             });

--- a/lib/authorizer/auth-interface.js
+++ b/lib/authorizer/auth-interface.js
@@ -63,21 +63,15 @@ createAuthInterface = function (auth) {
 
             parameters = auth.parameters();
             _.forEach(modifiedParams, function (value, key) {
-                var param;
-                // if auth has the param already then update it only when it's a sytem property
-                if ((param = parameters.one(key))) {
-                    if (param.system) {
-                        param.set(value);
-                    }
-                    else if (param.value === '') {
-                        param.system = true;
-                        param.set(value);
-                    }
+                var param = parameters.one(key);
+
+                if (!param) {
+                    return parameters.add({key: key, value: value, system: true});
                 }
-                // when param is missing then just add a new param to the variableList
-                // do not use append/insert since they don't typecast the item being added
-                else {
-                    parameters.add({key: key, value: value, system: true});
+
+                // Update if the param is a system property or an empty user property
+                if (param.system || !param.value) {
+                    return param.update({key: key, value: value, system: true});
                 }
             });
 

--- a/lib/authorizer/auth-interface.js
+++ b/lib/authorizer/auth-interface.js
@@ -66,7 +66,13 @@ createAuthInterface = function (auth) {
                 var param;
                 // if auth has the param already then update it only when it's a sytem property
                 if ((param = parameters.one(key))) {
-                    param.system && param.set(value);
+                    if (param.system) {
+                        param.set(value);
+                    }
+                    else if (param.value === '') {
+                        param.system = true;
+                        param.set(value);
+                    }
                 }
                 // when param is missing then just add a new param to the variableList
                 // do not use append/insert since they don't typecast the item being added

--- a/lib/authorizer/auth-interface.js
+++ b/lib/authorizer/auth-interface.js
@@ -69,8 +69,8 @@ createAuthInterface = function (auth) {
                     return parameters.add({key: key, value: value, system: true});
                 }
 
-                // Update if the param is a system property or an empty user property
-                if (param.system || !param.value) {
+                // Update if the param is a system property or an empty user property (null, undefined or empty string)
+                if (param.system || param.value === '' || _.isNil(param.value) || _.isNaN(param.value)) {
                     return param.update({key: key, value: value, system: true});
                 }
             });

--- a/test/unit/auth-interface.test.js
+++ b/test/unit/auth-interface.test.js
@@ -7,6 +7,7 @@ const USER = 'batman',
     NONCE = 'abcd',
     CREDENTIALS = [
         {key: 'nonce', value: NONCE},
+        {key: 'realm', value: ''},
         {key: 'user', value: USER, system: true},
         {key: 'pass', value: PASS, system: true}
     ],
@@ -29,7 +30,7 @@ describe('AuthInterface', function () {
     it('get with multiple keys should return object', function () {
         var fakeAuth = new sdk.RequestAuth(fakeAuthObj),
             authInterface = createAuthInterface(fakeAuth);
-        expect(authInterface.get(['user', 'pass', 'nonce', 'joker'])).to.eql(
+        expect(authInterface.get(['user', 'pass', 'realm', 'nonce', 'joker'])).to.eql(
             new sdk.VariableList(null, CREDENTIALS).toObject()
         );
     });
@@ -76,7 +77,7 @@ describe('AuthInterface', function () {
         expect(authInterface.get('nonce')).to.be(NONCE);
     });
 
-    it('should not update user parameters', function () {
+    it('should not update non-empty user parameters', function () {
         var fakeAuth = new sdk.RequestAuth(fakeAuthObj),
             authInterface = createAuthInterface(fakeAuth),
             newNonce = 'xyz';
@@ -88,6 +89,19 @@ describe('AuthInterface', function () {
         authInterface.set({'nonce': newNonce});
         expect(authInterface.get('nonce')).not.to.be(newNonce);
         expect(authInterface.get('nonce')).to.be(NONCE);
+    });
+
+    it('should update user parameters if they are empty', function () {
+        var fakeAuth = new sdk.RequestAuth(fakeAuthObj),
+            authInterface = createAuthInterface(fakeAuth),
+            newRealm = 'xyz';
+
+        authInterface.set('realm', newRealm);
+        expect(authInterface.get('realm')).to.be(newRealm);
+
+        newRealm = 'abc';
+        authInterface.set({'realm': newRealm});
+        expect(authInterface.get('realm')).to.be(newRealm);
     });
 
     it('new params should be added with system:true', function () {

--- a/test/unit/auth-interface.test.js
+++ b/test/unit/auth-interface.test.js
@@ -6,6 +6,9 @@ var sdk = require('postman-collection'),
 const USER = 'batman',
     PASS = 'christian bale',
     NONCE = 'abcd',
+    EMPTY = '',
+    XYZ = 'xyz',
+    ABC = 'abc',
     CREDENTIALS = [
         {key: 'nonce', value: NONCE},
         {key: 'user', value: USER, system: true},
@@ -78,33 +81,36 @@ describe('AuthInterface', function () {
     });
 
     it('should not update non-empty user parameters', function () {
-        var fakeAuth = new sdk.RequestAuth(fakeAuthObj),
-            authInterface = createAuthInterface(fakeAuth),
-            newNonce = 'xyz';
+        var fakeAuthObj,
+            fakeAuth,
+            authInterface,
+            valuesToTestWith = ['foo', false, 0];
 
-        authInterface.set('nonce', newNonce);
-        expect(authInterface.get('nonce')).not.to.be(newNonce);
-        expect(authInterface.get('nonce')).to.be(NONCE);
-
-        authInterface.set({'nonce': newNonce});
-        expect(authInterface.get('nonce')).not.to.be(newNonce);
-        expect(authInterface.get('nonce')).to.be(NONCE);
+        _.forEach(valuesToTestWith, function (value) {
+            fakeAuthObj = {type: 'fake', 'fake': [{key: 'something', value: value}]};
+            fakeAuth = new sdk.RequestAuth(fakeAuthObj);
+            authInterface = createAuthInterface(fakeAuth);
+            authInterface.set('something', XYZ);
+            expect(authInterface.get('something')).to.be(value);
+            authInterface.set({'something': XYZ});
+            expect(authInterface.get('something')).to.be(value);
+        });
     });
 
     it('should update user parameters with falsy value', function () {
         var fakeAuthObj,
             fakeAuth,
             authInterface,
-            valuesToTestWith = ['', null, undefined, false, 0];
+            valuesToTestWith = [EMPTY, null, undefined, NaN];
 
         _.forEach(valuesToTestWith, function (value) {
             fakeAuthObj = {type: 'fake', 'fake': [{key: 'something', value: value}]};
             fakeAuth = new sdk.RequestAuth(fakeAuthObj);
             authInterface = createAuthInterface(fakeAuth);
-            authInterface.set('something', 'xyz');
-            expect(authInterface.get('something')).to.be('xyz');
-            authInterface.set({'something': 'abc'});
-            expect(authInterface.get('something')).to.be('abc');
+            authInterface.set('something', XYZ);
+            expect(authInterface.get('something')).to.be(XYZ);
+            authInterface.set({'something': ABC});
+            expect(authInterface.get('something')).to.be(ABC);
         });
     });
 

--- a/test/unit/auth-interface.test.js
+++ b/test/unit/auth-interface.test.js
@@ -1,5 +1,6 @@
 var sdk = require('postman-collection'),
     expect = require('expect.js'),
+    _ = require('lodash'),
     createAuthInterface = require('../../lib/authorizer/auth-interface');
 
 const USER = 'batman',
@@ -7,7 +8,6 @@ const USER = 'batman',
     NONCE = 'abcd',
     CREDENTIALS = [
         {key: 'nonce', value: NONCE},
-        {key: 'realm', value: ''},
         {key: 'user', value: USER, system: true},
         {key: 'pass', value: PASS, system: true}
     ],
@@ -30,7 +30,7 @@ describe('AuthInterface', function () {
     it('get with multiple keys should return object', function () {
         var fakeAuth = new sdk.RequestAuth(fakeAuthObj),
             authInterface = createAuthInterface(fakeAuth);
-        expect(authInterface.get(['user', 'pass', 'realm', 'nonce', 'joker'])).to.eql(
+        expect(authInterface.get(['user', 'pass', 'nonce', 'joker'])).to.eql(
             new sdk.VariableList(null, CREDENTIALS).toObject()
         );
     });
@@ -91,17 +91,21 @@ describe('AuthInterface', function () {
         expect(authInterface.get('nonce')).to.be(NONCE);
     });
 
-    it('should update user parameters if they are empty', function () {
-        var fakeAuth = new sdk.RequestAuth(fakeAuthObj),
-            authInterface = createAuthInterface(fakeAuth),
-            newRealm = 'xyz';
+    it('should update user parameters with falsy value', function () {
+        var fakeAuthObj,
+            fakeAuth,
+            authInterface,
+            valuesToTestWith = ['', null, undefined, false, 0];
 
-        authInterface.set('realm', newRealm);
-        expect(authInterface.get('realm')).to.be(newRealm);
-
-        newRealm = 'abc';
-        authInterface.set({'realm': newRealm});
-        expect(authInterface.get('realm')).to.be(newRealm);
+        _.forEach(valuesToTestWith, function (value) {
+            fakeAuthObj = {type: 'fake', 'fake': [{key: 'something', value: value}]};
+            fakeAuth = new sdk.RequestAuth(fakeAuthObj);
+            authInterface = createAuthInterface(fakeAuth);
+            authInterface.set('something', 'xyz');
+            expect(authInterface.get('something')).to.be('xyz');
+            authInterface.set({'something': 'abc'});
+            expect(authInterface.get('something')).to.be('abc');
+        });
     });
 
     it('new params should be added with system:true', function () {


### PR DESCRIPTION
This will also convert the property to system property (will add system: true)

This is needed for 2 reasons
 - App sets the parameters as empty string which are not set by the user
 - Exported collections have parameters as empty string