### PR TITLE
Fix minor issues in NTLM and Oauth-2

### DIFF
--- a/lib/authorizer/ntlm.js
+++ b/lib/authorizer/ntlm.js
@@ -158,14 +158,14 @@ module.exports = {
      * @param {AuthHandlerInterface~authSignHookCallback} done
      */
     sign: function (auth, request, done) {
+        var ntlmHeader = auth.get(NTLM_HEADER);
+
         request.removeHeader(AUTHORIZATION, {ignoreCase: true});
-        if (auth.get(NTLM_HEADER)) {
-            request.addHeader({
-                key: AUTHORIZATION,
-                value: auth.get(NTLM_HEADER),
-                system: true
-            });
-        }
+        ntlmHeader && request.addHeader({
+            key: AUTHORIZATION,
+            value: ntlmHeader,
+            system: true
+        });
         return done();
     }
 };

--- a/lib/authorizer/oauth2.js
+++ b/lib/authorizer/oauth2.js
@@ -1,5 +1,5 @@
 var HEADER = 'header',
-    URL = 'url',
+    QUERY_PARAMS = 'queryParams',
     BEARER = 'bearer',
     AUTHORIZATION = 'Authorization',
     ACCESS_TOKEN = 'access_token',
@@ -86,7 +86,7 @@ module.exports = {
 
         // @TODO Add support for HMAC
         if (params.tokenType === BEARER) {
-            if (params.addTokenTo === URL) {
+            if (params.addTokenTo === QUERY_PARAMS) {
                 request.addQueryParams({
                     key: ACCESS_TOKEN,
                     value: params.accessToken

--- a/test/unit/auth-handlers.test.js
+++ b/test/unit/auth-handlers.test.js
@@ -495,7 +495,7 @@ describe('Auth Handler:', function () {
             });
         });
 
-        it('should sign the request by adding the token to the URL', function () {
+        it('should sign the request by adding the token to the query params', function () {
             var clonedRequestObj,
                 request,
                 auth,
@@ -503,7 +503,7 @@ describe('Auth Handler:', function () {
                 handler;
 
             clonedRequestObj = _.cloneDeep(requestObj);
-            clonedRequestObj.auth.oauth2.addTokenTo = 'url';
+            clonedRequestObj.auth.oauth2.addTokenTo = 'queryParams';
 
             request = new Request(clonedRequestObj);
             auth = request.auth;


### PR DESCRIPTION
1. remove redundant `get` operation
2. update a parameter name from `url` to `queryParams`