### PR TITLE
Support qop, clientNonce, nonceCount and opaque fields

### DIFF
--- a/lib/authorizer/digest.js
+++ b/lib/authorizer/digest.js
@@ -47,7 +47,7 @@ var crypto = require('crypto-js'),
 
 /**
  * Generates a random string of given length
- *
+ * @todo Move this to util.js. After moving use that for hawk auth too
  * @param {Number} length
  */
 function randomString (length) {

--- a/lib/authorizer/digest.js
+++ b/lib/authorizer/digest.js
@@ -1,4 +1,5 @@
 var crypto = require('crypto-js'),
+    _ = require('lodash'),
 
     EMPTY = '',
     ONE = '00000001',
@@ -116,7 +117,9 @@ module.exports = {
             authHeader;
 
         code = response && response.code;
-        authHeader = response && response.headers.one('www-authenticate');
+        authHeader = response && response.headers.find(function (property) {
+            return (property.key.toLowerCase() === 'www-authenticate') && (_.startsWith(property.value, 'Digest'));
+        });
 
         // If code is forbidden or unauthorized, and an auth header exists,
         // we can extract the realm & the nonce, and replay the request.

--- a/lib/authorizer/digest.js
+++ b/lib/authorizer/digest.js
@@ -4,8 +4,40 @@ var crypto = require('crypto-js'),
     EMPTY = '',
     ONE = '00000001',
     DISABLE_RETRY_REQUEST = 'disableRetryRequest',
+    WWW_AUTHENTICATE = 'www-authenticate',
+    DIGEST_PREFIX = 'Digest ',
+    QOP = 'qop',
+    AUTH = 'auth',
+    COLON = ':',
+    QUOTE = '"',
+    AUTH_INT = 'auth-int',
+    AUTHORIZATION = 'Authorization',
+    MD5_SESS = 'MD5-sess',
     ASCII_SOURCE = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789',
     ASCII_SOURCE_LENGTH = ASCII_SOURCE.length,
+    USERNAME_EQUALS = 'username="',
+    REALM_EQUALS = 'realm="',
+    NONCE_EQUALS = 'nonce="',
+    URI_EQUALS = 'uri="',
+    ALGORITHM_EQUALS = 'algorithm="',
+    CNONCE_EQUALS = 'cnonce="',
+    RESPONSE_EQUALS = 'response="',
+    OPAQUE_EQUALS = 'opaque="',
+    QOP_EQUALS = 'qop=',
+    NC_EQUALS = 'nc=',
+    AUTH_PARAMETERS = [
+        'algorithm',
+        'username',
+        'realm',
+        'password',
+        'method',
+        'nonce',
+        'nonceCount',
+        'clientNonce',
+        'opaque',
+        'qop',
+        'uri'
+    ],
 
     nonceRegex = /nonce="([^"]*)"/,
     realmRegex = /realm="([^"]*)"/,
@@ -42,6 +74,19 @@ _extractField = function (string, regexp) {
     var match = string.match(regexp);
     return match ? match[1] : EMPTY;
 };
+
+/**
+ * Returns the 'www-authenticate' header for Digest auth. Since a server can suport more than more auth-scheme,
+ * there can be more than one header with the same key. So need to loop over and check each one.
+ *
+ * @param {VariableList} headers
+ * @private
+ */
+function _getDigestAuthHeader (headers) {
+    return headers.find(function (property) {
+        return (property.key.toLowerCase() === WWW_AUTHENTICATE) && (_.startsWith(property.value, DIGEST_PREFIX));
+    });
+}
 
 
 /**
@@ -105,7 +150,7 @@ module.exports = {
      * @param {AuthHandlerInterface~authPostHookCallback} done
      */
     post: function (auth, response, done) {
-        if (auth.get(DISABLE_RETRY_REQUEST)) {
+        if (auth.get(DISABLE_RETRY_REQUEST) || !response) {
             return done(null, true);
         }
 
@@ -116,10 +161,8 @@ module.exports = {
             opaque,
             authHeader;
 
-        code = response && response.code;
-        authHeader = response && response.headers.find(function (property) {
-            return (property.key.toLowerCase() === 'www-authenticate') && (_.startsWith(property.value, 'Digest'));
-        });
+        code = response.code;
+        authHeader = _getDigestAuthHeader(response.headers);
 
         // If code is forbidden or unauthorized, and an auth header exists,
         // we can extract the realm & the nonce, and replay the request.
@@ -131,13 +174,11 @@ module.exports = {
             opaque = _extractField(authHeader.value, opaqueRegex);
 
             auth.set({nonce: nonce, realm: realm});
-            opaque && (auth.set('opaque', opaque));
-            // we give pref to the value provided by user and then the server
-            // @todo this means user can't clear the qop value (we will always take the value from the server)
-            !auth.get('qop') && qop && (auth.set('qop', qop));
+            opaque && (auth.set({opaque: opaque}));
+            qop && (auth.set({qop: qop}));
 
-            if (auth.get('qop')) {
-                auth.set({'clientNonce': randomString(8), 'nonceCount': ONE});
+            if (auth.get(QOP)) {
+                auth.set({clientNonce: randomString(8), nonceCount: ONE});
             }
 
             return done(null, false);
@@ -186,51 +227,51 @@ module.exports = {
             reqDigest,
             headerParams;
 
-        if (algorithm === 'MD5-sess') {
-            A0 = crypto.MD5(username + ':' + realm + ':' + password).toString();
-            A1 = A0 + ':' + nonce + ':' + clientNonce;
+        if (algorithm === MD5_SESS) {
+            A0 = crypto.MD5(username + COLON + realm + COLON + password).toString();
+            A1 = A0 + COLON + nonce + COLON + clientNonce;
         }
         else {
-            A1 = username + ':' + realm + ':' + password;
+            A1 = username + COLON + realm + COLON + password;
         }
 
-        if (qop === 'auth-int') {
-            A2 = method + ':' + uri + ':' + crypto.MD5(params.body);
+        if (qop === AUTH_INT) {
+            A2 = method + COLON + uri + COLON + crypto.MD5(params.body);
         }
         else {
-            A2 = method + ':' + uri;
+            A2 = method + COLON + uri;
         }
         hashA1 = crypto.MD5(A1).toString();
         hashA2 = crypto.MD5(A2).toString();
 
-        if (qop === 'auth' || qop === 'auth-int') {
-            reqDigest = crypto.MD5([hashA1, nonce, nonceCount, clientNonce, qop, hashA2].join(':')).toString();
+        if (qop === AUTH || qop === AUTH_INT) {
+            reqDigest = crypto.MD5([hashA1, nonce, nonceCount, clientNonce, qop, hashA2].join(COLON)).toString();
         }
         else {
-            reqDigest = crypto.MD5([hashA1, nonce, hashA2].join(':')).toString();
+            reqDigest = crypto.MD5([hashA1, nonce, hashA2].join(COLON)).toString();
         }
 
-        headerParams = ['username="' + username + '"',
-            'realm="' + realm + '"',
-            'nonce="' + nonce + '"',
-            'uri="' + uri + '"'
+        headerParams = [USERNAME_EQUALS + username + QUOTE,
+            REALM_EQUALS + realm + QUOTE,
+            NONCE_EQUALS + nonce + QUOTE,
+            URI_EQUALS + uri + QUOTE
         ];
 
-        algorithm && headerParams.push('algorithm="' + algorithm + '"');
+        algorithm && headerParams.push(ALGORITHM_EQUALS + algorithm + QUOTE);
 
-        if (qop === 'auth' || qop === 'auth-int') {
-            headerParams.push('qop=' + qop);
+        if (qop === AUTH || qop === AUTH_INT) {
+            headerParams.push(QOP_EQUALS + qop);
         }
 
-        if (qop === 'auth' || qop === 'auth-int' || algorithm === 'MD5-sess') {
-            nonceCount && headerParams.push('nc=' + nonceCount);
-            headerParams.push('cnonce="' + clientNonce + '"');
+        if (qop === AUTH || qop === AUTH_INT || algorithm === MD5_SESS) {
+            nonceCount && headerParams.push(NC_EQUALS + nonceCount);
+            headerParams.push(CNONCE_EQUALS + clientNonce + QUOTE);
         }
 
-        headerParams.push('response="' + reqDigest + '"');
-        opaque && headerParams.push('opaque="' + opaque + '"');
+        headerParams.push(RESPONSE_EQUALS + reqDigest + QUOTE);
+        opaque && headerParams.push(OPAQUE_EQUALS + opaque + QUOTE);
 
-        return 'Digest ' + headerParams.join(', ');
+        return DIGEST_PREFIX + headerParams.join(', ');
     },
 
     /**
@@ -242,25 +283,13 @@ module.exports = {
      */
     sign: function (auth, request, done) {
         var header,
-            params = auth.get([
-                'algorithm',
-                'username',
-                'realm',
-                'password',
-                'method',
-                'nonce',
-                'nonceCount',
-                'clientNonce',
-                'opaque',
-                'qop',
-                'uri'
-            ]);
+            params = auth.get(AUTH_PARAMETERS);
 
         if (!params.username || !params.realm) {
             return done(); // Nothing to do if required parameters are not present.
         }
 
-        request.removeHeader('Authorization', {ignoreCase: true});
+        request.removeHeader(AUTHORIZATION, {ignoreCase: true});
 
         params.method = request.method;
         params.uri = request.url.getPathWithQuery();
@@ -272,7 +301,7 @@ module.exports = {
         catch (e) { return done(e); }
 
         request.addHeader({
-            key: 'Authorization',
+            key: AUTHORIZATION,
             value: header,
             system: true
         });

--- a/lib/authorizer/digest.js
+++ b/lib/authorizer/digest.js
@@ -1,36 +1,47 @@
 var crypto = require('crypto-js'),
 
+    EMPTY = '',
+    ONE = '00000001',
     DISABLE_RETRY_REQUEST = 'disableRetryRequest',
-    _extractNonce,
-    _extractRealm;
+    ASCII_SOURCE = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789',
+    ASCII_SOURCE_LENGTH = ASCII_SOURCE.length,
+
+    nonceRegex = /nonce="([^"]*)"/,
+    realmRegex = /realm="([^"]*)"/,
+    qopRegex = /qop="([^"]*)"/,
+    opaqueRegex = /opaque="([^"]*)"/,
+    _extractField;
 
 /**
- * Extracts Digest Auth nonce from a WWW-Authenticate header value.
+ * Generates a random string of given length
  *
- * @param {String} string
- * @private
+ * @param {Number} length
  */
-_extractNonce = function (string) {
-    // todo - make this more robust
-    var nonceStart = string.indexOf('"', string.indexOf('nonce')) + 1,
-        nonceEnd = string.indexOf('"', nonceStart),
-        nonce = string.slice(nonceStart, nonceEnd);
-    return nonce;
-};
+function randomString (length) {
+    length = length || 6;
+
+    var result = [],
+        i;
+
+    for (i = 0; i < length; i++) {
+        result[i] = ASCII_SOURCE[(Math.random() * ASCII_SOURCE_LENGTH) | 0];
+    }
+    return result.join(EMPTY);
+}
+
 
 /**
- * Extracts Digest Auth realm from a WWW-Authenticate header value.
+ * Extracts a Digest Auth field from a WWW-Authenticate header value using a given regexp.
  *
  * @param {String} string
+ * @param {RegExp} regexp
  * @private
  */
-_extractRealm = function (string) {
-    // todo - make this more robust
-    var realmStart = string.indexOf('"', string.indexOf('realm')) + 1,
-        realmEnd = string.indexOf('"', realmStart),
-        realm = string.slice(realmStart, realmEnd);
-    return realm;
+_extractField = function (string, regexp) {
+    var match = string.match(regexp);
+    return match ? match[1] : EMPTY;
 };
+
 
 /**
  * @implements {AuthHandlerInterface}
@@ -100,6 +111,8 @@ module.exports = {
         var code,
             realm,
             nonce,
+            qop,
+            opaque,
             authHeader;
 
         code = response && response.code;
@@ -109,10 +122,21 @@ module.exports = {
         // we can extract the realm & the nonce, and replay the request.
         // todo: add response.is4XX, response.is5XX, etc in the SDK.
         if ((code === 401 || code === 403) && authHeader) {
-            nonce = _extractNonce(authHeader.value);
-            realm = _extractRealm(authHeader.value);
+            nonce = _extractField(authHeader.value, nonceRegex);
+            realm = _extractField(authHeader.value, realmRegex);
+            qop = _extractField(authHeader.value, qopRegex);
+            opaque = _extractField(authHeader.value, opaqueRegex);
 
             auth.set({nonce: nonce, realm: realm});
+            opaque && (auth.set('opaque', opaque));
+            // we give pref to the value provided by user and then the server
+            // @todo this means user can't clear the qop value (we will always take the value from the server)
+            !auth.get('qop') && qop && (auth.set('qop', qop));
+
+            if (auth.get('qop')) {
+                auth.set({'clientNonce': randomString(8), 'nonceCount': ONE});
+            }
+
             return done(null, false);
         }
 
@@ -202,7 +226,7 @@ module.exports = {
         }
 
         headerParams.push('response="' + reqDigest + '"');
-        headerParams.push('opaque="' + opaque + '"');
+        opaque && headerParams.push('opaque="' + opaque + '"');
 
         return 'Digest ' + headerParams.join(', ');
     },

--- a/lib/authorizer/digest.js
+++ b/lib/authorizer/digest.js
@@ -195,8 +195,7 @@ module.exports = {
         }
 
         if (qop === 'auth-int') {
-            // Cannot be implemented here.
-            throw new Error('Digest Auth with "qop": "auth-int" is not supported.');
+            A2 = method + ':' + uri + ':' + crypto.MD5(params.body);
         }
         else {
             A2 = method + ':' + uri;
@@ -265,6 +264,7 @@ module.exports = {
 
         params.method = request.method;
         params.uri = request.url.getPathWithQuery();
+        params.body = request.body && request.body.toString();
 
         try {
             header = this.computeHeader(params);

--- a/lib/authorizer/digest.js
+++ b/lib/authorizer/digest.js
@@ -15,14 +15,14 @@ var crypto = require('crypto-js'),
     MD5_SESS = 'MD5-sess',
     ASCII_SOURCE = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789',
     ASCII_SOURCE_LENGTH = ASCII_SOURCE.length,
-    USERNAME_EQUALS = 'username="',
-    REALM_EQUALS = 'realm="',
-    NONCE_EQUALS = 'nonce="',
-    URI_EQUALS = 'uri="',
-    ALGORITHM_EQUALS = 'algorithm="',
-    CNONCE_EQUALS = 'cnonce="',
-    RESPONSE_EQUALS = 'response="',
-    OPAQUE_EQUALS = 'opaque="',
+    USERNAME_EQUALS_QUOTE = 'username="',
+    REALM_EQUALS_QUOTE = 'realm="',
+    NONCE_EQUALS_QUOTE = 'nonce="',
+    URI_EQUALS_QUOTE = 'uri="',
+    ALGORITHM_EQUALS_QUOTE = 'algorithm="',
+    CNONCE_EQUALS_QUOTE = 'cnonce="',
+    RESPONSE_EQUALS_QUOTE = 'response="',
+    OPAQUE_EQUALS_QUOTE = 'opaque="',
     QOP_EQUALS = 'qop=',
     NC_EQUALS = 'nc=',
     AUTH_PARAMETERS = [
@@ -251,13 +251,13 @@ module.exports = {
             reqDigest = crypto.MD5([hashA1, nonce, hashA2].join(COLON)).toString();
         }
 
-        headerParams = [USERNAME_EQUALS + username + QUOTE,
-            REALM_EQUALS + realm + QUOTE,
-            NONCE_EQUALS + nonce + QUOTE,
-            URI_EQUALS + uri + QUOTE
+        headerParams = [USERNAME_EQUALS_QUOTE + username + QUOTE,
+            REALM_EQUALS_QUOTE + realm + QUOTE,
+            NONCE_EQUALS_QUOTE + nonce + QUOTE,
+            URI_EQUALS_QUOTE + uri + QUOTE
         ];
 
-        algorithm && headerParams.push(ALGORITHM_EQUALS + algorithm + QUOTE);
+        algorithm && headerParams.push(ALGORITHM_EQUALS_QUOTE + algorithm + QUOTE);
 
         if (qop === AUTH || qop === AUTH_INT) {
             headerParams.push(QOP_EQUALS + qop);
@@ -265,11 +265,11 @@ module.exports = {
 
         if (qop === AUTH || qop === AUTH_INT || algorithm === MD5_SESS) {
             nonceCount && headerParams.push(NC_EQUALS + nonceCount);
-            headerParams.push(CNONCE_EQUALS + clientNonce + QUOTE);
+            headerParams.push(CNONCE_EQUALS_QUOTE + clientNonce + QUOTE);
         }
 
-        headerParams.push(RESPONSE_EQUALS + reqDigest + QUOTE);
-        opaque && headerParams.push(OPAQUE_EQUALS + opaque + QUOTE);
+        headerParams.push(RESPONSE_EQUALS_QUOTE + reqDigest + QUOTE);
+        opaque && headerParams.push(OPAQUE_EQUALS_QUOTE + opaque + QUOTE);
 
         return DIGEST_PREFIX + headerParams.join(', ');
     },

--- a/test/integration/auth-methods/digest.test.js
+++ b/test/integration/auth-methods/digest.test.js
@@ -3,7 +3,10 @@ var expect = require('expect.js');
 describe('digest auth', function () {
     var testrun;
 
-    describe('with correct details (MD5)', function () {
+    // @todo add a test case with qop="". For this we need a Digest server which does not return qop value
+    // echo, httpbin and windows server, all return the value of qop
+
+    describe('with correct details (qop="auth", algorithm="MD5)', function () {
         before(function (done) {
             var runOptions = {
                 collection: {
@@ -87,9 +90,16 @@ describe('digest auth', function () {
             expect(request.url.toString()).to.eql('https://postman-echo.com/digest-auth');
             expect(response.code).to.eql(200);
         });
+
+        it('must have taken the qop value from the server\'s response', function () {
+            var request = testrun.request.getCall(1).args[3],
+                authHeader = request.headers.get('authorization');
+
+            expect(authHeader.match(/qop=auth/)).to.be.ok();
+        });
     });
 
-    describe('with correct details (MD5-sess)', function () {
+    describe('with correct details (qop="auth", algorithm="MD5-sess")', function () {
         before(function (done) {
             var runOptions = {
                 collection: {
@@ -100,6 +110,7 @@ describe('digest auth', function () {
                             auth: {
                                 type: 'digest',
                                 digest: {
+                                    qop: 'auth',
                                     algorithm: 'MD5-sess',
                                     username: '{{uname}}',
                                     password: '{{pass}}'

--- a/test/integration/auth-methods/digest.test.js
+++ b/test/integration/auth-methods/digest.test.js
@@ -3,10 +3,15 @@ var expect = require('expect.js');
 describe('digest auth', function () {
     var testrun;
 
-    // @todo add a test case with qop="". For this we need a Digest server which does not return qop value
-    // echo, httpbin and windows server, all return the value of qop
+    // @todo
+    // 1. add a test case with (qop=""). For this we need a Digest server which does not return qop value
+    //        echo, httpbin and windows server, all return the value of qop
+    // 2. add a test case with (qop="auth-int" and algorithm="MD5-sess")
+    //        httpbin has auth-int but no support for MD5-sess
+    // 3. add a test case with (qop="auth-int" and with body defined (method != "GET"))
+    //        httbin does not support methods other than "GET"
 
-    describe('with correct details (qop="auth", algorithm="MD5)', function () {
+    describe('with correct details (qop="auth", algorithm="MD5")', function () {
         before(function (done) {
             var runOptions = {
                 collection: {
@@ -306,30 +311,39 @@ describe('digest auth', function () {
         });
     });
 
-    describe('with unsupported qop', function () {
+    describe('with correct details (qop="auth-int", algorithm="MD5")', function () {
         before(function (done) {
             var runOptions = {
                 collection: {
                     item: {
                         name: 'DigestAuth',
                         request: {
-                            url: 'https://postman-echo.com/digest-auth',
+                            url: 'https://httpbin.org/digest-auth/auth-int/postman/password/MD5',
                             auth: {
                                 type: 'digest',
                                 digest: {
                                     algorithm: 'MD5',
-                                    username: 'postman',
-                                    password: 'password',
-                                    qop: 'auth-int'
+                                    username: '{{uname}}',
+                                    password: '{{pass}}'
                                 }
                             }
                         }
                     }
                 },
+                environment: {
+                    values: [{
+                        key: 'uname',
+                        value: 'postman'
+                    }, {
+                        key: 'pass',
+                        value: 'password'
+                    }]
+                },
                 authorizer: {
                     interactive: true
                 }
             };
+
             // perform the collection run
             this.run(runOptions, function (err, results) {
                 testrun = results;
@@ -345,10 +359,38 @@ describe('digest auth', function () {
             expect(testrun.start.callCount).to.be(1);
         });
 
-        it('must have bubbled the error to callback', function () {
-            var err = testrun.console.firstCall.args[3];
+        it('must have sent two requests internally', function () {
+            expect(testrun.io.callCount).to.be(2);
+            expect(testrun.request.callCount).to.be(2);
 
-            expect(err).to.have.property('message', 'Digest Auth with "qop": "auth-int" is not supported.');
+            var firstError = testrun.io.firstCall.args[0],
+                secondError = testrun.io.secondCall.args[0],
+                firstResponse = testrun.io.firstCall.args[3],
+                secondResponse = testrun.io.secondCall.args[3];
+
+            expect(firstError).to.be(null);
+            expect(secondError).to.be(null);
+            expect(firstResponse.code).to.eql(401);
+            expect(secondResponse.code).to.eql(200);
+        });
+
+        it('must have failed the digest authorization in first attempt', function () {
+            var response = testrun.request.getCall(0).args[2];
+
+            expect(response.code).to.eql(401);
+        });
+
+        it('must have passed the digest authorization in second attempt', function () {
+            var response = testrun.request.getCall(1).args[2];
+
+            expect(response.code).to.eql(200);
+        });
+
+        it('must have taken the qop value from the server\'s response', function () {
+            var request = testrun.request.getCall(1).args[3],
+                authHeader = request.headers.get('authorization');
+
+            expect(authHeader.match(/qop=auth-int/)).to.be.ok();
         });
     });
 });


### PR DESCRIPTION
1. Takes `qop` and `opaque` from the `www-authenticate` header from the server's response
2. Auto-generate `clientNonce`
3. `nonceCount` is fixed to 0000001
4. Added support for auth-int