### PR TITLE
Remove workaround for variable resolution `toObjectResolved`

### DIFF
--- a/lib/runner/request-helpers-presend.js
+++ b/lib/runner/request-helpers-presend.js
@@ -14,14 +14,10 @@ module.exports = [
         if (!context.item) { return done(new Error('Nothing to resolve variables for.')); }
 
         // @todo - resolve variables in a more graceful way
-        // @todo - no need to sync vatiables when SDK starts supporting resolution from scope directly
-        // @todo remove this hack of using empty variableList once it's fixed in sdk
-        context.item = new sdk.Item(context.item.toObjectResolved({variables: new sdk.VariableList(null, [])}, [
-            context.data,
-            context.environment.syncVariablesTo({}),
-            context.collectionVariables.syncVariablesTo({}),
-            context.globals.syncVariablesTo({})
-        ]));
+        // @todo - no need to sync variables when SDK starts supporting resolution from scope directly
+        context.item = new sdk.Item(context.item.toObjectResolved(null, [context.data,
+            context.environment.syncVariablesTo({}), context.collectionVariables.syncVariablesTo({}),
+            context.globals.syncVariablesTo({})], {ignoreOwnVariables: true}));
 
         var item = context.item,
             auth = context.auth;
@@ -30,15 +26,9 @@ module.exports = [
         item.request.url = new (sdk.Url)(item.request.url.toString());
 
         // resolve variables in auth
-        auth && (context.auth = new sdk.RequestAuth(auth.toObjectResolved(
-            {variables: new sdk.VariableList(null, [])}, // @todo remove this hack once it's fixed in sdk
-            [
-                context.data,
-                context.environment.syncVariablesTo({}),
-                context.collectionVariables.syncVariablesTo({}),
-                context.globals.syncVariablesTo({})
-            ]
-        )));
+        auth && (context.auth = new sdk.RequestAuth(auth.toObjectResolved(null, [context.data,
+            context.environment.syncVariablesTo({}), context.collectionVariables.syncVariablesTo({}),
+            context.globals.syncVariablesTo({})], {ignoreOwnVariables: true})));
 
         done();
     },


### PR DESCRIPTION
The fix has been moved upstream