### PR TITLE
Avoid excluding postman-collection from nsp check

### DIFF
--- a/.nsprc
+++ b/.nsprc
@@ -1,4 +1,4 @@
 {
   "exceptions": [],
-  "exclusions": ["postman-collection"]
+  "exclusions": []
 }

--- a/test/system/nsp.test.js
+++ b/test/system/nsp.test.js
@@ -29,7 +29,7 @@ describe('nsp', function () {
         });
 
         it('must exclude only a known set of packages', function () {
-            expect(nsprc.exclusions).to.eql(['postman-collection']);
+            expect(nsprc.exclusions).to.eql([]);
         });
 
         // if you are changing the version here, most probably you are better of removing the exclusion in first place.


### PR DESCRIPTION
`postman-collection` is using `8fold-marked` in beta version and we are using that beta version in runtime. There is no need to exclude `postman-collection` from nsp check.