### PR TITLE
Improvements to `timeout` value normalization

### DIFF
--- a/lib/runner/index.js
+++ b/lib/runner/index.js
@@ -9,28 +9,6 @@ var _ = require('lodash'),
         global: 3 * 60 * 1000, // 3 minutes
         request: Infinity,
         script: Infinity
-    },
-
-    /**
-     * Sanitizes run options. Only handles timeout for now.
-     *
-     * @param {Object} options
-     *
-     * @returns {Object}
-     */
-    sanitizeRunOptions = function (options) {
-        !options.timeout && (options.timeout = {});
-
-        // start timeout sanitization
-        _.mergeWith(options.timeout, defaultTimeouts, function (userTimeout, defaultTimeout) {
-            // non numbers, Infinity and missing values are set to default
-            if (!_.isFinite(userTimeout)) { return defaultTimeout; }
-
-            // 0 and negative numbers are set to Infinity, which only leaves positive numbers
-            return userTimeout > 0 ? userTimeout : Infinity;
-        });
-
-        return options;
     };
 
 /**
@@ -50,6 +28,33 @@ Runner = function PostmanCollectionRunner (options) {
 };
 
 _.assign(Runner.prototype, {
+    /**
+     * Prepares `run` config by combining `runner` config with given run options.
+     *
+     * @param {Object} [options]
+     * @param {Object} [options.timeout]
+     * @param {Object} [options.timeout.global]
+     * @param {Object} [options.timeout.request]
+     * @param {Object} [options.timeout.script]
+     */
+    prepareRunConfig: function (options) {
+        // combine runner config and make a copy
+        var runOptions = _.merge(_.omit(options, ['environment', 'globals', 'data']), this.options.run) || {};
+
+        // start timeout sanitization
+        !runOptions.timeout && (runOptions.timeout = {});
+
+        _.mergeWith(runOptions.timeout, defaultTimeouts, function (userTimeout, defaultTimeout) {
+            // non numbers, Infinity and missing values are set to default
+            if (!_.isFinite(userTimeout)) { return defaultTimeout; }
+
+            // 0 and negative numbers are set to Infinity, which only leaves positive numbers
+            return userTimeout > 0 ? userTimeout : Infinity;
+        });
+
+        return runOptions;
+    },
+
     /**
      * Runs a collection or a folder.
      *
@@ -74,9 +79,7 @@ _.assign(Runner.prototype, {
      */
     run: function (collection, options, callback) {
         var self = this,
-            runOptions = _.merge(_.omit(options, ['environment', 'globals', 'data']), this.options.run) || {};
-
-        sanitizeRunOptions(runOptions);
+            runOptions = this.prepareRunConfig(options);
 
         callback = backpack.normalise(callback);
         !_.isObject(options) && (options = {});

--- a/lib/runner/index.js
+++ b/lib/runner/index.js
@@ -3,35 +3,34 @@ var _ = require('lodash'),
     Run = require('./run'),
     extractRunnableItems = require('./extract-runnable-items').extractRunnableItems,
 
-    DEFAULT_GLOBAL_TIMEOUT = 3 * 60 * 1000, // 3 minutes
     Runner,
 
-    /**
-     * Converts any non finite values and 0 or negative values to Infinity.
-     *
-     * @param {Number} ms
-     *
-     * @returns {Number}
-     */
-    sanitizeTimeout = function (ms) {
-        return (_.isFinite(ms) && ms > 0) ? ms : Infinity;
+    defaultTimeouts = {
+        global: 3 * 60 * 1000, // 3 minutes
+        request: Infinity,
+        script: Infinity
     },
 
     /**
-     * Sanitizes `timeout` `options` if any on the options object.
+     * Sanitizes run options. Only handles timeout for now.
      *
-     * @param {Object} [timeoutOptions]
+     * @param {Object} options
      *
-     * @returns {Object|undefined}
+     * @returns {Object}
      */
-    sanitizeTimeouts = function (timeoutOptions) {
-        if (!timeoutOptions) { return; }
+    sanitizeRunOptions = function (options) {
+        !options.timeout && (options.timeout = {});
 
-        _.forEach(timeoutOptions, function (value, key) {
-            timeoutOptions[key] = sanitizeTimeout(value);
+        // start timeout sanitization
+        _.mergeWith(options.timeout, defaultTimeouts, function (userTimeout, defaultTimeout) {
+            // non numbers, Infinity and missing values are set to default
+            if (!_.isFinite(userTimeout)) { return defaultTimeout; }
+
+            // 0 and negative numbers are set to Infinity, which only leaves positive numbers
+            return userTimeout > 0 ? userTimeout : Infinity;
         });
 
-        return timeoutOptions;
+        return options;
     };
 
 /**
@@ -75,16 +74,12 @@ _.assign(Runner.prototype, {
      */
     run: function (collection, options, callback) {
         var self = this,
-            runOptions = _.merge({timeout: {
-                global: DEFAULT_GLOBAL_TIMEOUT,
-                script: 0,
-                request: 0
-            }}, _.omit(options, ['environment', 'globals', 'data']), this.options.run);
+            runOptions = _.merge(_.omit(options, ['environment', 'globals', 'data']), this.options.run) || {};
+
+        sanitizeRunOptions(runOptions);
 
         callback = backpack.normalise(callback);
         !_.isObject(options) && (options = {});
-
-        sanitizeTimeouts(runOptions.timeout);
 
         extractRunnableItems(collection, options.entrypoint, function (err, runnableItems, entrypoint) {
             if (err || !runnableItems) { return callback(new Error('Error fetching run items')); }

--- a/test/unit/runner.test.js
+++ b/test/unit/runner.test.js
@@ -247,6 +247,22 @@ describe('runner', function () {
                     });
                 });
 
+                it('should normalize Infinty values to default', function (done) {
+                    var runner = new Runner({
+                        run: {
+                            timeout: {global: Infinity}
+                        }
+                    });
+
+                    runner.run(collection, {}, function (err, run) {
+                        expect(err).to.not.be.ok();
+
+                        expect(run).to.be.ok();
+                        expect(run.options.timeout.global).to.be(defaultGlobalTimeout);
+                        done();
+                    });
+                });
+
                 it('should preserve finite timeouts', function (done) {
                     var runner = new Runner({
                         run: {


### PR DESCRIPTION
* Default timeouts are set if user provided timeout is missing/null/undefined
* To clear a timeout, 0 should be sent as timeout value
* Negative timeout values are treated as no timeout