### PR TITLE
Digest auth retry logic updated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### Unreleased
 * Runtime now adds `system: true` to all the query parameters that it sets
 * More useful error messages for assertion failures in legacy `tests`
-* Digest auth now does not retry when all the required auth parameters were already present in the first request sent
+* Digest auth does not attempt retries for invalid credentials/configuration. It will continue to retry for missing configuration.
 
 ### v7.0.1 (November 8, 2017)
 * :bug: Fixed a bug where the assertions for legacy `tests` failures did not have an `error` object.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Unreleased
 * Runtime now adds `system: true` to all the query parameters that it sets
 * More useful error messages for assertion failures in legacy `tests`
+* Digest auth now does not retry when all the required auth parameters were already present in the first request sent
 
 ### v7.0.1 (November 8, 2017)
 * :bug: Fixed a bug where the assertions for legacy `tests` failures did not have an `error` object.

--- a/lib/authorizer/digest.js
+++ b/lib/authorizer/digest.js
@@ -159,7 +159,8 @@ module.exports = {
             nonce,
             qop,
             opaque,
-            authHeader;
+            authHeader,
+            authParams = {};
 
         code = response.code;
         authHeader = _getDigestAuthHeader(response.headers);
@@ -173,12 +174,15 @@ module.exports = {
             qop = _extractField(authHeader.value, qopRegex);
             opaque = _extractField(authHeader.value, opaqueRegex);
 
-            auth.set({nonce: nonce, realm: realm});
-            opaque && (auth.set({opaque: opaque}));
-            qop && (auth.set({qop: qop}));
+            authParams.nonce = nonce;
+            authParams.realm = realm;
+            opaque && (authParams.opaque = opaque);
+            qop && (authParams.qop = qop);
 
-            if (auth.get(QOP)) {
-                auth.set({clientNonce: randomString(8), nonceCount: ONE});
+            if (authParams.qop || auth.get(QOP)) {
+                authParams.clientNonce = randomString(8);
+                authParams.nonceCount = ONE;
+                auth.set(authParams);
             }
 
             return done(null, false);

--- a/lib/authorizer/digest.js
+++ b/lib/authorizer/digest.js
@@ -182,8 +182,14 @@ module.exports = {
             if (authParams.qop || auth.get(QOP)) {
                 authParams.clientNonce = randomString(8);
                 authParams.nonceCount = ONE;
-                auth.set(authParams);
             }
+
+            // if all the auth parameters sent by server were already in auth definition then we do not retry
+            if (_.every(_.keys(authParams), function (param) { return auth.get(param); })) {
+                return done(null, true);
+            }
+
+            auth.set(authParams);
 
             return done(null, false);
         }

--- a/lib/authorizer/digest.js
+++ b/lib/authorizer/digest.js
@@ -185,7 +185,7 @@ module.exports = {
             }
 
             // if all the auth parameters sent by server were already present in auth definition then we do not retry
-            if (_.every(_.keys(authParams), function (param) { return auth.get(param); })) {
+            if (_.every(authParams, function (value, key) { return auth.get(key); })) {
                 return done(null, true);
             }
 

--- a/lib/authorizer/digest.js
+++ b/lib/authorizer/digest.js
@@ -184,7 +184,7 @@ module.exports = {
                 authParams.nonceCount = ONE;
             }
 
-            // if all the auth parameters sent by server were already in auth definition then we do not retry
+            // if all the auth parameters sent by server were already present in auth definition then we do not retry
             if (_.every(_.keys(authParams), function (param) { return auth.get(param); })) {
                 return done(null, true);
             }


### PR DESCRIPTION
Digest auth now does not retry when all the required auth parameters were already present in the first request sent

Required parameters are defined by those sent by the server in the authorization header.
So this can vary from server to server.