### PR TITLE
Do not set parent on cloned item in `createContext`

### DIFF
--- a/lib/runner/extensions/http-request.command.js
+++ b/lib/runner/extensions/http-request.command.js
@@ -33,17 +33,11 @@ var _ = require('lodash'),
      */
     createContext = function (payload) {
         var context = _.pick(payload, CONTEXT_PROPERTIES),
-            item,
-            parent;
+            item;
 
         // we clone item from the payload, so that we can make any changes we need there, without mutating the
         // collection.
         item = new sdk.Item(payload.item.toJSON());
-
-        // in order to ensure that variable resolution works correctly, we set the __parent property,
-        // so that the SDK can locate the VariableList in the collection.
-        parent = payload.item.parent();
-        parent && (item.setParent(parent));
 
         // save the cloned item in context
         context.item = item;

--- a/lib/runner/replay-controller.js
+++ b/lib/runner/replay-controller.js
@@ -42,9 +42,6 @@ _.assign(ReplayController.prototype, /** @lends ReplayController.prototype */{
         // update replay state to context
         context.replayState = this.getReplayState();
 
-        // set item parent
-        !item.parent() && item.setParent(context.originalItem);
-
         // construct payload for request
         var payload = _.merge({}, desiredPayload, context, {
             item: item,


### PR DESCRIPTION
We no longer need to do this, as SDK allows to resolve objects without parents.