### PR TITLE
Moved variable resolution out of `http-request` extension

### DIFF
--- a/lib/runner/create-item-context.js
+++ b/lib/runner/create-item-context.js
@@ -1,0 +1,50 @@
+var _ = require('lodash'),
+    sdk = require('postman-collection'),
+
+    SAFE_CONTEXT_PROPERTIES = ['replayState', 'coords'],
+
+    /**
+     * Creates a context object to be used with `http-request.command` extension.
+     *
+     * @param {Object} payload
+     * @param {Item} payload.item
+     * @param {Object} [payload.coords]
+     * @param {Object} [defaults]
+     * @param {Object} [defaults.replayState]
+     * @param {Object} [defaults.coords]
+     *
+     * @returns {Object}
+     */
+    createItemContext = function (payload, defaults) {
+        // extract properties from defaults that can/should be reused in new context
+        var context = defaults ? _.pick(defaults, SAFE_CONTEXT_PROPERTIES) : {};
+
+        // set cursor to context
+        !context.coords && (context.coords = payload.coords);
+
+        // save original item for reference
+        context.originalItem = payload.item;
+
+        // we clone item from the payload, so that we can make any changes we need there, without mutating the
+        // collection
+        context.item = new sdk.Item(payload.item.toJSON());
+
+        // get a reference to the Auth instance from the item, so changes are synced back
+        context.auth = context.originalItem.getAuth();
+
+        /**
+         * @type {Object}
+         * @property {Object} coords - current cursor
+         * @property {Item} originalItem - reference to the item in the collection
+         * @property {Item} item -  Holds a copy of the item given in the payload, so that it can be manipulated
+         * as necessary
+         * @property {RequestAuthBase|undefined} auth - If present, is the instance of Auth in the collection, which
+         * is changed as necessary using intermediate requests, etc.
+         * @property {ReplayState} replayState - has context on number of replays(if any) for this request
+         */
+        return context;
+    };
+
+module.exports = {
+    createItemContext: createItemContext
+};

--- a/lib/runner/extensions/event.command.js
+++ b/lib/runner/extensions/event.command.js
@@ -7,6 +7,8 @@ var _ = require('lodash'),
     sandbox = require('postman-sandbox'),
     serialisedError = require('serialised-error'),
 
+    createItemContext = require('../create-item-context').createItemContext,
+
     ASSERTION_FAILURE = 'AssertionFailure',
     SAFE_CONTEXT_VARIABLES = ['_variables', 'environment', 'globals', 'collectionVariables', 'cookies', 'data',
         'request', 'response'],
@@ -239,33 +241,27 @@ module.exports = {
                             return this.host.dispatch(EXECUTION_RESPONSE_EVENT_BASE + id, requestId, err);
                         }
 
-                        var tempItem;
+                        var nextPayload;
 
                         // if request is sanitized send a warning
                         if (!_.isEmpty(sanitisedFiles)) {
                             this.triggers.console(cursor, 'warn', 'uploading files from scripts is not allowed');
                         }
 
-                        tempItem = new sdk.Item({
-                            request: request
-                        });
-
-                        tempItem.setParent(item);
-
-                        this.immediate('httprequest', {
-                            item: tempItem,
-                            globals: payload.context.globals,
-                            collectionVariables: payload.context.collectionVariables,
-                            _variables: payload.context._variables,
-                            environment: payload.context.environment,
-                            data: payload.context.data,
+                        nextPayload = {
+                            item: new sdk.Item({request: request}),
                             coords: cursor,
                             // @todo - get script type from the sandbox
                             source: 'script',
                             // abortOnError makes sure request command bubbles errors
                             // so we can pass it on to the callback
                             abortOnError: true
-                        }).done(function (result) {
+                        };
+
+                        // create context for executing this request
+                        nextPayload.context = createItemContext(nextPayload);
+
+                        this.immediate('httprequest', nextPayload).done(function (result) {
                             this.host.dispatch(
                                 EXECUTION_RESPONSE_EVENT_BASE + id,
                                 requestId,

--- a/lib/runner/extensions/http-request.command.js
+++ b/lib/runner/extensions/http-request.command.js
@@ -1,7 +1,6 @@
 var _ = require('lodash'),
     async = require('async'),
     uuid = require('uuid'),
-    sdk = require('postman-collection'),
 
     // These are functions which a request passes through _before_ being sent. They take care of stuff such as
     // variable resolution, loading of files, etc.
@@ -13,47 +12,7 @@ var _ = require('lodash'),
     ReplayController = require('../replay-controller'),
     RequesterPool = require('../../requester').RequesterPool,
 
-    RESPONSE_DOT = 'response.',
-
-    CONTEXT_PROPERTIES = [
-        'data',
-        'environment',
-        'globals',
-        'collectionVariables',
-        '_variables',
-        'coords',
-        'replayState'
-    ],
-
-    /**
-     * Creates a request execution context from a given payload.
-     *
-     * @param payload
-     * @returns {Object}
-     */
-    createContext = function (payload) {
-        var context = _.pick(payload, CONTEXT_PROPERTIES),
-            item;
-
-        // we clone item from the payload, so that we can make any changes we need there, without mutating the
-        // collection.
-        item = new sdk.Item(payload.item.toJSON());
-
-        // save the cloned item in context
-        context.item = item;
-
-        // save original item for reference
-        context.originalItem = payload.item;
-
-        // get a reference to the Auth instance from the item, so changes are synced back
-        context.auth = context.originalItem.getAuth();
-
-        // generates a unique id for each http request
-        // a collection request can have multiple http requests
-        _.set(context, 'coords.httpRequestId', payload.httpRequestId || uuid());
-
-        return context;
-    };
+    RESPONSE_DOT = 'response.';
 
 module.exports = {
     init: function (done) {
@@ -88,19 +47,11 @@ module.exports = {
                 self = this,
                 context;
 
-            /**
-             * @type {Object}
-             * @property {Item} originalItem - reference to the item in the collection
-             * @property {Item} item -  Holds a copy of the item given in the payload, so that it can be manipulated
-             * as necessary
-             * @property {RequestAuthBase|undefined} auth - If present, is the instance of Auth in the collection, which
-             * is changed as necessary using intermediate requests, etc.
-             * @property {VariableScope} environment
-             * @property {VariableScope} globals
-             * @property {Object} data
-             * @property {ReplayState} replayState - has context on number of replays(if any) for this request
-             */
-            context = createContext(payload);
+            context = payload.context;
+
+            // generates a unique id for each http request
+            // a collection request can have multiple http requests
+            _.set(context, 'coords.httpRequestId', payload.httpRequestId || uuid());
 
             // Run the helper functions
             async.applyEachSeries(prehelpers, context, self, function (err) {

--- a/lib/runner/extensions/request.command.js
+++ b/lib/runner/extensions/request.command.js
@@ -1,4 +1,42 @@
-var _ = require('lodash');
+var _ = require('lodash'),
+    sdk = require('postman-collection'),
+
+    createItemContext = require('../create-item-context').createItemContext,
+
+    /**
+     * Resolve variables in item and auth in context.
+     *
+     * @param {Object} context
+     * @param {Item} [context.item]
+     * @param {RequestAuth} [context.auth]
+     * @param {Object} payload
+     * @param {VariableScope} payload._variables
+     * @param {VariableScope} payload.data
+     * @param {VariableScope} payload.environment
+     * @param {VariableScope} payload.collectionVariables
+     * @param {VariableScope} payload.globals
+     */
+    resolveVariables = function (context, payload) {
+        if (!context.item) { return; }
+
+        // @todo - resolve variables in a more graceful way
+
+        // @todo - no need to sync variables when SDK starts supporting resolution from scope directly
+        context.item = new sdk.Item(context.item.toObjectResolved(null, [payload._variables.syncVariablesTo({}),
+            payload.data, payload.environment.syncVariablesTo({}), payload.collectionVariables.syncVariablesTo({}),
+            payload.globals.syncVariablesTo({})], {ignoreOwnVariables: true}));
+
+        var item = context.item,
+            auth = context.auth;
+
+        // Re-parse the URL, because variables have been resolved now, and things might be moved around
+        item.request.url = new (sdk.Url)(item.request.url.toString());
+
+        // resolve variables in auth
+        auth && (context.auth = new sdk.RequestAuth(auth.toObjectResolved(null, [payload._variables.syncVariablesTo({}),
+            payload.data, payload.environment.syncVariablesTo({}), payload.collectionVariables.syncVariablesTo({}),
+            payload.globals.syncVariablesTo({})], {ignoreOwnVariables: true})));
+    };
 
 module.exports = {
     init: function (done) {
@@ -23,7 +61,14 @@ module.exports = {
                     // the error is passed twice to allow control between aborting the error vs just
                     // bubbling it up
                     return next(err && abortOnError ? err : null, nextPayload, err);
-                }.bind(this);
+                }.bind(this),
+                context = createItemContext(payload);
+
+            // resolve variables in item and auth
+            resolveVariables(context, payload);
+
+            // add context for use, after resolution
+            payload.context = context;
 
             // we do not queue `httprequest` instruction here,
             // queueing will unblock the item command to prepare for the next `event` instruction

--- a/lib/runner/replay-controller.js
+++ b/lib/runner/replay-controller.js
@@ -1,4 +1,5 @@
 var _ = require('lodash'),
+    createItemContext = require('./create-item-context').createItemContext,
 
     // total number of replays allowed
     MAX_REPLAY_COUNT = 3,
@@ -43,12 +44,15 @@ _.assign(ReplayController.prototype, /** @lends ReplayController.prototype */{
         context.replayState = this.getReplayState();
 
         // construct payload for request
-        var payload = _.merge({}, desiredPayload, context, {
+        var payload = _.merge({}, desiredPayload, {
             item: item,
             // abortOnError makes sure request command bubbles errors
             // so we can pass it on to the callback
             abortOnError: true
         });
+
+        // create item context from the new item
+        payload.context = createItemContext(payload, context);
 
         this.run.immediate('httprequest', payload)
             .done(function (response) {

--- a/lib/runner/request-helpers-presend.js
+++ b/lib/runner/request-helpers-presend.js
@@ -9,31 +9,6 @@ var _ = require('lodash'),
     DOT_AUTH = '.auth';
 
 module.exports = [
-    // Variable resolution
-    function (context, run, done) {
-        if (!context.item) { return done(new Error('Nothing to resolve variables for.')); }
-
-        // @todo - resolve variables in a more graceful way
-
-        // @todo - no need to sync variables when SDK starts supporting resolution from scope directly
-        context.item = new sdk.Item(context.item.toObjectResolved(null, [context._variables.syncVariablesTo({}),
-            context.data, context.environment.syncVariablesTo({}), context.collectionVariables.syncVariablesTo({}),
-            context.globals.syncVariablesTo({})], {ignoreOwnVariables: true}));
-
-        var item = context.item,
-            auth = context.auth;
-
-        // Re-parse the URL, because variables have been resolved now, and things might be moved around
-        item.request.url = new (sdk.Url)(item.request.url.toString());
-
-        // resolve variables in auth
-        auth && (context.auth = new sdk.RequestAuth(auth.toObjectResolved(null, [context._variables.syncVariablesTo({}),
-            context.data, context.environment.syncVariablesTo({}), context.collectionVariables.syncVariablesTo({}),
-            context.globals.syncVariablesTo({})], {ignoreOwnVariables: true})));
-
-        done();
-    },
-
     // Authorization
     function (context, run, done) {
         // validate all stuff. dont ask.


### PR DESCRIPTION
* `http-request` extension is now only responsible for request send related responsibilities
* Variable resolution is now the responsibility of `request` extension, there is no need to send all variable types to `http-request` from `event` extension and `replay-controller`.
* Context creation extracted out to be used by anyone scheduling a request with `http-request` extension