### PR TITLE
Marked private examples, tweaked JSDoc build

### DIFF
--- a/lib/runner/instruction.js
+++ b/lib/runner/instruction.js
@@ -30,7 +30,7 @@ pool = function (processors) {
      * @param {Object} [payload] - a **JSON compatible** object that will be forwarded as the 2nd last parameter to the
      * processor.
      * @param {Array} [args] - all the arguments that needs to be passed to the processor is in this array
-     *
+     * @private
      * @example
      * var inst = Instruction.create(function (arg1, payload, next) {
      *         console.log(payload);

--- a/lib/runner/timings.js
+++ b/lib/runner/timings.js
@@ -13,7 +13,7 @@ var /**
 /**
  * An instance of a timer can record times with a label associated with it.
  * @constructor
- *
+ * @private
  * @param {Object.<Number>} records create the timer instance with one or more labels and their timestamp.
  */
 Timings = function Timings (records) {

--- a/npm/build-docs.js
+++ b/npm/build-docs.js
@@ -26,7 +26,7 @@ module.exports = function (exit) {
     }
 
     exec(`${IS_WINDOWS ? '' : 'node'} ${path.join('node_modules', '.bin', 'jsdoc')}${IS_WINDOWS ? '.cmd' : ''}` +
-        ` -c .jsdoc-config.json -u docs lib --query 'pkgVersion=${pkg.version}'`, function (code) {
+        ` -c .jsdoc-config.json -u docs lib --query 'pkgVersion=${pkg.version}' -p`, function (code) {
         // output status
         console.log(code ?
             colors.red.bold('unable to genereate documentation') :


### PR DESCRIPTION
- Marked `Timing` and `Instruction` as `@private`.
- Added support to display examples marked `@private` in the generated documentation.