### PR TITLE
General cleanup in `createItemContext` exports and docs 

### DIFF
--- a/lib/runner/create-item-context.js
+++ b/lib/runner/create-item-context.js
@@ -1,50 +1,48 @@
 var _ = require('lodash'),
     sdk = require('postman-collection'),
 
-    SAFE_CONTEXT_PROPERTIES = ['replayState', 'coords'],
+    SAFE_CONTEXT_PROPERTIES = ['replayState', 'coords'];
+
+/**
+ * Creates a context object to be used with `http-request.command` extension.
+ *
+ * @function createItemContext
+ *
+ * @param {Object} payload
+ * @param {Item} payload.item
+ * @param {Object} [payload.coords]
+ * @param {Object} [defaults]
+ * @param {Object} [defaults.replayState]
+ * @param {Object} [defaults.coords]
+ *
+ * @returns {ItemContext}
+ */
+module.exports = function (payload, defaults) {
+    // extract properties from defaults that can/should be reused in new context
+    var context = defaults ? _.pick(defaults, SAFE_CONTEXT_PROPERTIES) : {};
+
+    // set cursor to context
+    !context.coords && (context.coords = payload.coords);
+
+    // save original item for reference
+    context.originalItem = payload.item;
+
+    // we clone item from the payload, so that we can make any changes we need there, without mutating the
+    // collection
+    context.item = new sdk.Item(payload.item.toJSON());
+
+    // get a reference to the Auth instance from the item, so changes are synced back
+    context.auth = context.originalItem.getAuth();
 
     /**
-     * Creates a context object to be used with `http-request.command` extension.
-     *
-     * @param {Object} payload
-     * @param {Item} payload.item
-     * @param {Object} [payload.coords]
-     * @param {Object} [defaults]
-     * @param {Object} [defaults.replayState]
-     * @param {Object} [defaults.coords]
-     *
-     * @returns {Object}
+     * @typedef {Object} ItemContext
+     * @property {Object} coords - current cursor
+     * @property {Item} originalItem - reference to the item in the collection
+     * @property {Item} item -  Holds a copy of the item given in the payload, so that it can be manipulated
+     * as necessary
+     * @property {RequestAuthBase|undefined} auth - If present, is the instance of Auth in the collection, which
+     * is changed as necessary using intermediate requests, etc.
+     * @property {ReplayState} replayState - has context on number of replays(if any) for this request
      */
-    createItemContext = function (payload, defaults) {
-        // extract properties from defaults that can/should be reused in new context
-        var context = defaults ? _.pick(defaults, SAFE_CONTEXT_PROPERTIES) : {};
-
-        // set cursor to context
-        !context.coords && (context.coords = payload.coords);
-
-        // save original item for reference
-        context.originalItem = payload.item;
-
-        // we clone item from the payload, so that we can make any changes we need there, without mutating the
-        // collection
-        context.item = new sdk.Item(payload.item.toJSON());
-
-        // get a reference to the Auth instance from the item, so changes are synced back
-        context.auth = context.originalItem.getAuth();
-
-        /**
-         * @type {Object}
-         * @property {Object} coords - current cursor
-         * @property {Item} originalItem - reference to the item in the collection
-         * @property {Item} item -  Holds a copy of the item given in the payload, so that it can be manipulated
-         * as necessary
-         * @property {RequestAuthBase|undefined} auth - If present, is the instance of Auth in the collection, which
-         * is changed as necessary using intermediate requests, etc.
-         * @property {ReplayState} replayState - has context on number of replays(if any) for this request
-         */
-        return context;
-    };
-
-module.exports = {
-    createItemContext: createItemContext
+    return context;
 };

--- a/lib/runner/extensions/event.command.js
+++ b/lib/runner/extensions/event.command.js
@@ -7,7 +7,7 @@ var _ = require('lodash'),
     sandbox = require('postman-sandbox'),
     serialisedError = require('serialised-error'),
 
-    createItemContext = require('../create-item-context').createItemContext,
+    createItemContext = require('../create-item-context'),
 
     ASSERTION_FAILURE = 'AssertionFailure',
     SAFE_CONTEXT_VARIABLES = ['_variables', 'environment', 'globals', 'collectionVariables', 'cookies', 'data',

--- a/lib/runner/extensions/request.command.js
+++ b/lib/runner/extensions/request.command.js
@@ -1,12 +1,12 @@
 var _ = require('lodash'),
     sdk = require('postman-collection'),
 
-    createItemContext = require('../create-item-context').createItemContext,
+    createItemContext = require('../create-item-context'),
 
     /**
      * Resolve variables in item and auth in context.
      *
-     * @param {Object} context
+     * @param {ItemContext} context
      * @param {Item} [context.item]
      * @param {RequestAuth} [context.auth]
      * @param {Object} payload

--- a/lib/runner/replay-controller.js
+++ b/lib/runner/replay-controller.js
@@ -44,12 +44,12 @@ _.assign(ReplayController.prototype, /** @lends ReplayController.prototype */{
         context.replayState = this.getReplayState();
 
         // construct payload for request
-        var payload = _.merge({}, desiredPayload, {
+        var payload = _.defaults({
             item: item,
             // abortOnError makes sure request command bubbles errors
             // so we can pass it on to the callback
             abortOnError: true
-        });
+        }, desiredPayload);
 
         // create item context from the new item
         payload.context = createItemContext(payload, context);

--- a/lib/runner/replay-controller.js
+++ b/lib/runner/replay-controller.js
@@ -1,5 +1,5 @@
 var _ = require('lodash'),
-    createItemContext = require('./create-item-context').createItemContext,
+    createItemContext = require('./create-item-context'),
 
     // total number of replays allowed
     MAX_REPLAY_COUNT = 3,


### PR DESCRIPTION
* General cleanup around `createItemContext` exports and docs
* Reorganize `merge` options with `defaults` 