### PR TITLE
Remove fallback for unsupported property in AWS4 auth

### DIFF
--- a/lib/authorizer/aws4.js
+++ b/lib/authorizer/aws4.js
@@ -111,7 +111,6 @@ module.exports = {
                 'secretKey',
                 'sessionToken',
                 'service',
-                'serviceName',
                 'region'
             ]);
 
@@ -137,7 +136,7 @@ module.exports = {
             },
             host: request.url.getRemote(),
             path: request.url.getPathWithQuery(),
-            service: params.service || params.serviceName || 'execute-api', // AWS API Gateway is the default service.
+            service: params.service || 'execute-api', // AWS API Gateway is the default service.
             region: params.region || 'us-east-1',
             method: request.method,
             body: request.body ? request.body.toString() : undefined,


### PR DESCRIPTION
`service` is the defined property for AWSv4 definitions in the v2 postman-collection schema. The fallback was introduced as a fix for `service` not being used [here](https://github.com/postmanlabs/postman-collection/pull/33/commits/8c8146e0f0daaf74c3122af48ed181793ae752ef).

This might create issues when a collection has both `service`(empty - intended to use default) and `serviceName`(an outdated value) the outdated value will be used which is not intended behaviour.