### PR TITLE
Remove duplicate headers and query params in OAuth 2.0 before signing

### DIFF
--- a/lib/authorizer/oauth2.js
+++ b/lib/authorizer/oauth2.js
@@ -95,6 +95,12 @@ module.exports = {
 
         // @TODO Add support for HMAC
         if (tokenType === BEARER) {
+            // clean conflicting headers and query params
+            // @todo: we should be able to get conflicting params from auth manifest
+            // and clear them before the sign step for any auth
+            request.removeHeader(AUTHORIZATION, {ignoreCase: true});
+            request.removeQueryParams([ACCESS_TOKEN]);
+
             if (params.addTokenTo === QUERY_PARAMS) {
                 request.addQueryParams({
                     key: ACCESS_TOKEN,


### PR DESCRIPTION
Postman App indicates that duplicate headers will be removed. This behaviour of adding without removing creates two `Authorization` headers.