### PR TITLE
Add `multiEntry` support to extract runnable items

### DIFF
--- a/lib/runner/extract-runnable-items.js
+++ b/lib/runner/extract-runnable-items.js
@@ -112,9 +112,82 @@ var sdk = require('postman-collection'),
         callback(null, flattenNode(matched), matched);
     },
 
+    /**
+     * Utility function called recursively to find `multiEntry`.
+     *
+     * @param {ItemGroup} itemGroup
+     * @param {Boolean} includeItem
+     */
+    multiEntryUtil = function (itemGroup, includeItem) {
+        let self = this;
+
+        itemGroup.items.each(function (item) {
+            if (self.reference[item.id] || self.reference[item.name]) {
+                self.found++;
+                // push item to state if includeItem is true
+                includeItem && self.items.push(item);
+                // recursive call to find nested entry-points.
+                // set includeItem to false for children, since current item is added already.
+                item.items && multiEntryUtil.call(self, item, false);
+            }
+            else if (item.items) {
+                multiEntryUtil.call(self, item, true);
+            }
+            // bail out if all entry-points are found.
+            if (self.found === self.totalEntrypoints) { return false; }
+        });
+    },
+
+    /**
+     * Finds multiple items or groups on a collection with the matching ids or names.
+     *
+     * @param {Collection} collection
+     * @param {Object} options
+     * @param {Array<String>} options.execute
+     * @param {Function} callback
+     */
+    multiEntry = function (collection, options, callback) {
+        var entrypoints = options.execute,
+            runnableItems = [],
+            state;
+
+        if (!Array.isArray(entrypoints) || !entrypoints.length) {
+            return callback(null, []);
+        }
+
+        // initialize state used to call `findMultiEntry`.
+        state = {
+            totalEntrypoints: entrypoints.length,
+            entrypoints: entrypoints,
+            found: 0,
+            items: [],
+            reference: {}
+        };
+
+        // add temp reference for faster access of entry-point name/id.
+        entrypoints.forEach(function (entry) {
+            state.reference[entry] = true;
+        });
+
+        multiEntryUtil.call(state, collection, true);
+
+        // bail out if any of the given endpoint is not found.
+        if (state.found !== state.totalEntrypoints) {
+            return callback(null, []);
+        }
+
+        // extract runnable items from the searched items.
+        state.items.forEach(function (item) {
+            runnableItems = runnableItems.concat(flattenNode(item));
+        });
+
+        callback(null, runnableItems, collection);
+    },
+
     lookupStrategyMap = {
         path: lookupByPath,
-        idOrName: lookupByIdOrName
+        idOrName: lookupByIdOrName,
+        multiEntry: multiEntry
     },
 
     /**

--- a/lib/runner/extract-runnable-items.js
+++ b/lib/runner/extract-runnable-items.js
@@ -149,7 +149,9 @@ var sdk = require('postman-collection'),
     multiEntry = function (collection, options, callback) {
         var entrypoints = options.execute,
             runnableItems = [],
-            state;
+            state,
+            i,
+            ii;
 
         if (!Array.isArray(entrypoints) || !entrypoints.length) {
             return callback(null, []);
@@ -177,9 +179,9 @@ var sdk = require('postman-collection'),
         }
 
         // extract runnable items from the searched items.
-        state.items.forEach(function (item) {
-            runnableItems = runnableItems.concat(flattenNode(item));
-        });
+        for (i = 0, ii = state.items.length; i < ii; i++) {
+            runnableItems = runnableItems.concat(flattenNode(state.items[i]));
+        }
 
         callback(null, runnableItems, collection);
     },

--- a/lib/runner/extract-runnable-items.js
+++ b/lib/runner/extract-runnable-items.js
@@ -84,7 +84,12 @@ var sdk = require('postman-collection'),
             // search for item's name or id in pendingEntries.
             entry = item.name;
             index = state.pendingEntries.indexOf(entry);
-            index === -1 && (entry = item.id) && (state.pendingEntries.indexOf(entry));
+
+            // search by id if item name not found.
+            if (index === -1) {
+                entry = item.id;
+                index = state.pendingEntries.indexOf(entry);
+            }
 
             if (index !== -1) {
                 // remove founded entry from the pendingEntries,

--- a/lib/runner/extract-runnable-items.js
+++ b/lib/runner/extract-runnable-items.js
@@ -61,6 +61,51 @@ var sdk = require('postman-collection'),
         return matched;
     },
 
+    /**
+     * Finds items based on multiple ids or names provided.
+     * common `state` is passed to track pendingEntries and found items.
+     *
+     * @param {ItemGroup} itemGroup
+     * @param {Object} state
+     * @param {Array<string>} state.pendingEntries
+     * @param {Array<Item|ItemGroup>} state.items
+     * @param {Object} state.reference
+     * @returns {Object}
+     */
+    findItemsFromEntries = function (itemGroup, state) {
+        var key,
+            index,
+            entry;
+
+        itemGroup.items.each(function (item) {
+            // bail out if all entries are found.
+            if (!state.pendingEntries.length) { return false; }
+
+            // search for item's name or id in pendingEntries.
+            entry = item.name;
+            index = state.pendingEntries.indexOf(entry);
+            index === -1 && (entry = item.id) && (state.pendingEntries.indexOf(entry));
+
+            if (index !== -1) {
+                // remove founded entry from the pendingEntries,
+                // this will also allow supporting multiple entries with same name/id.
+                state.pendingEntries.splice(index, 1);
+
+                // get entry index in the provided `entries`.
+                key = state.reference[entry].shift();
+
+                // store `item` with the same key as of its index in the list of entries,
+                // this helps to easily access the item in the order of entries.
+                state.items[key.toString()] = item;
+            }
+
+            // recursive call to lookup nested entries.
+            item.items && findItemsFromEntries(item, state);
+        });
+
+        return state;
+    },
+
 
     /**
      * Finds an item or group from a path. The path should be an array of ids from the parent chain.
@@ -113,33 +158,8 @@ var sdk = require('postman-collection'),
     },
 
     /**
-     * Utility function called recursively to find `multiEntry`.
-     *
-     * @param {ItemGroup} itemGroup
-     * @param {Boolean} includeItem
-     */
-    multiEntryUtil = function (itemGroup, includeItem) {
-        let self = this;
-
-        itemGroup.items.each(function (item) {
-            if (self.reference[item.id] || self.reference[item.name]) {
-                self.found++;
-                // push item to state if includeItem is true
-                includeItem && self.items.push(item);
-                // recursive call to find nested entry-points.
-                // set includeItem to false for children, since current item is added already.
-                item.items && multiEntryUtil.call(self, item, false);
-            }
-            else if (item.items) {
-                multiEntryUtil.call(self, item, true);
-            }
-            // bail out if all entry-points are found.
-            if (self.found === self.totalEntrypoints) { return false; }
-        });
-    },
-
-    /**
      * Finds multiple items or groups on a collection with the matching ids or names.
+     * runnable items will be ordered in the same order as of entries.
      *
      * @param {Collection} collection
      * @param {Object} options
@@ -147,40 +167,44 @@ var sdk = require('postman-collection'),
      * @param {Function} callback
      */
     multiEntry = function (collection, options, callback) {
-        var entrypoints = options.execute,
+        var entries = options.execute,
             runnableItems = [],
             state,
+            key,
             i,
             ii;
 
-        if (!Array.isArray(entrypoints) || !entrypoints.length) {
+        if (!Array.isArray(entries) || !entries.length) {
             return callback(null, []);
         }
 
-        // initialize state used to call `findMultiEntry`.
+        // initialize the state to be passed as reference in `findItemsFromEntries`.
         state = {
-            totalEntrypoints: entrypoints.length,
-            entrypoints: entrypoints,
-            found: 0,
-            items: [],
+            // copy entries, otherwise it will affect the reference also.
+            pendingEntries: entries.slice(),
+            items: {},
             reference: {}
         };
 
-        // add temp reference for faster access of entry-point name/id.
-        entrypoints.forEach(function (entry) {
-            state.reference[entry] = true;
-        });
+        // create an object with entries as key and array of its index(s) as value.
+        // used to get entry key for `state.items`, helps to support multiple items with same name.
+        for (i = 0, ii = entries.length; i < ii; i++) {
+            key = entries[i];
+            !state.reference[key] && (state.reference[key] = []);
+            state.reference[key].push(i);
+        }
 
-        multiEntryUtil.call(state, collection, true);
+        // recursive lookup to find all entries and build the state.
+        state = findItemsFromEntries(collection, state);
 
-        // bail out if any of the given endpoint is not found.
-        if (state.found !== state.totalEntrypoints) {
+        // bail out if any of the given entry is not found.
+        if (state.pendingEntries && state.pendingEntries.length) {
             return callback(null, []);
         }
 
-        // extract runnable items from the searched items.
-        for (i = 0, ii = state.items.length; i < ii; i++) {
-            runnableItems = runnableItems.concat(flattenNode(state.items[i]));
+        // extract runnable items, nested entries will also be extracted.
+        for (i = 0, ii = entries.length; i < ii; i++) {
+            runnableItems = runnableItems.concat(flattenNode(state.items[i.toString()]));
         }
 
         callback(null, runnableItems, collection);


### PR DESCRIPTION
**Behavior:**
- Follows the same order as of provided endpoints
- Extract nested entry points also.

**Todo:**
- [ ] Check for edge cases
- [ ] Add Unit Tests
- [ ] Integrate with `newman`