### PR TITLE
Add support for multiple entry points to extract runnable items

### DIFF
--- a/lib/runner/extract-runnable-items.js
+++ b/lib/runner/extract-runnable-items.js
@@ -66,40 +66,37 @@ var sdk = require('postman-collection'),
      *
      * @param {ItemGroup} itemGroup - Composite list of Item or ItemGroup.
      * @param {Object} entrypointSubset - Entry-points reference passed across multiple recursive calls.
-     * @param {Boolean} recursive - Flag used to decide whether to include nested items or not.
+     * @param {Boolean} _continueAccumulation - Flag used to decide whether to accumulate items or not.
      * @param {Array<String>} _accumulatedItems - Found Items or ItemGroups.
      * @returns {Object}
      */
-    findItemsOrGroups = function (itemGroup, entrypointSubset, recursive, _accumulatedItems) {
+    findItemsOrGroups = function (itemGroup, entrypointSubset, _continueAccumulation, _accumulatedItems) {
         if (!itemGroup || !itemGroup.items) { return; }
 
         !_accumulatedItems && (_accumulatedItems = []);
 
-        var idOrName;
+        var match;
 
         itemGroup.items.each(function (item) {
             // bail out if all entry-points are found.
             if (!Object.keys(entrypointSubset).length) { return false; }
 
-            // lookup for item.id in entrypointSubset.
-            idOrName = entrypointSubset[item.id] && item.id;
-
-            // if item.id not found, lookup by item.name in entrypointSubset.
-            !idOrName && (idOrName = entrypointSubset[item.name] && item.name);
-
-            if (idOrName) {
-                // only push items which are not previously got tracked from its parent entry-point.
-                recursive && _accumulatedItems.push(item);
-
-                // delete looked-up entry-point.
-                delete entrypointSubset[idOrName];
-
-                // recursive call to find nested entry-points. To make sure all provided entry-points got tracked.
-                // set recursive flag to `false` for children, since current item is included already.
-                return findItemsOrGroups(item, entrypointSubset, false, _accumulatedItems);
+            // lookup for item.id in entrypointSubset and if not found, lookup by item.name.
+            if (!(match = entrypointSubset[item.id] && item.id)) {
+                match = entrypointSubset[item.name] && item.name;
             }
 
-            findItemsOrGroups(item, entrypointSubset, recursive, _accumulatedItems);
+            if (match) {
+                // only accumulate items which are not previously got tracked from its parent entrypoint.
+                _continueAccumulation && _accumulatedItems.push(item);
+
+                // delete looked-up entrypoint.
+                delete entrypointSubset[match];
+            }
+
+            // recursive call to find nested entry-points. To make sure all provided entry-points got tracked.
+            // _continueAccumulation flag will be `false` for children if their parent entrypoint is found.
+            return findItemsOrGroups(item, entrypointSubset, !match, _accumulatedItems);
         });
 
         return _accumulatedItems;

--- a/lib/runner/extract-runnable-items.js
+++ b/lib/runner/extract-runnable-items.js
@@ -72,6 +72,7 @@ var sdk = require('postman-collection'),
      */
     findItemsOrGroups = function (itemGroup, entrypointSubset, recursive, _accumulatedItems) {
         if (!itemGroup || !itemGroup.items) { return; }
+
         !_accumulatedItems && (_accumulatedItems = []);
 
         var idOrName;
@@ -80,9 +81,11 @@ var sdk = require('postman-collection'),
             // bail out if all entry-points are found.
             if (!Object.keys(entrypointSubset).length) { return false; }
 
-            // lookup for item's id or name.
-            idOrName = entrypointSubset[item.id] ? item.id :
-                entrypointSubset[item.name] ? item.name : null;
+            // lookup for item.id in entrypointSubset.
+            idOrName = entrypointSubset[item.id] && item.id;
+
+            // if item.id not found, lookup by item.name in entrypointSubset.
+            !idOrName && (idOrName = entrypointSubset[item.name] && item.name);
 
             if (idOrName) {
                 // only push items which are not previously got tracked from its parent entry-point.
@@ -95,6 +98,7 @@ var sdk = require('postman-collection'),
                 // set recursive flag to `false` for children, since current item is included already.
                 return findItemsOrGroups(item, entrypointSubset, false, _accumulatedItems);
             }
+
             findItemsOrGroups(item, entrypointSubset, recursive, _accumulatedItems);
         });
 

--- a/lib/runner/extract-runnable-items.js
+++ b/lib/runner/extract-runnable-items.js
@@ -61,6 +61,45 @@ var sdk = require('postman-collection'),
         return matched;
     },
 
+    /**
+     * Finds items based on multiple ids or names provided.
+     *
+     * @param {ItemGroup} itemGroup - Composite list of Item or ItemGroup.
+     * @param {Object} state - Reference passed across multiple recursive calls.
+     * @param {Array<String>} state.items - Found Items or ItemGroups.
+     * @param {Object} state.lookup - Entry-points to lookup for.
+     * @param {Boolean} includeItem - Flag used to decide whether to include nested items or not.
+     * @returns {Object}
+     */
+    findItemsOrGroups = function (itemGroup, state, includeItem) {
+        if (!itemGroup || !itemGroup.items) { return; }
+
+        var idOrName;
+
+        itemGroup.items.each(function (item) {
+            // bail out if all entry-points are found.
+            if (!Object.keys(state.lookup).length) { return false; }
+
+            // lookup for item's id or name.
+            idOrName = state.lookup[item.id] ? item.id :
+                state.lookup[item.name] ? item.name : null;
+
+            if (idOrName) {
+                // only push items which are not previously got tracked from its parent entry-point.
+                includeItem && state.items.push(item);
+
+                // delete looked-up entry-point.
+                delete state.lookup[idOrName];
+
+                // recursive call to find nested entry-points. To make sure all provided entry-points got tracked.
+                // set includeItem to `false` for children, since current item is included already.
+                return findItemsOrGroups(item, state, false);
+            }
+            findItemsOrGroups(item, state, includeItem);
+        });
+
+        return state;
+    },
 
     /**
      * Finds an item or group from a path. The path should be an array of ids from the parent chain.
@@ -112,9 +151,48 @@ var sdk = require('postman-collection'),
         callback(null, flattenNode(matched), matched);
     },
 
+    lookupByMultipleIdOrName = function (collection, options, callback) {
+        var entrypoints = options.execute,
+            runnableItems = [],
+            state,
+            i,
+            ii;
+
+        if (!Array.isArray(entrypoints) || !entrypoints.length) {
+            return callback(null, []);
+        }
+
+        // initialize the state to be passed as reference in `findItemsOrGroups`.
+        state = {
+            items: [],
+            lookup: {}
+        };
+
+        // add temp reference for faster lookup of entry-point name/id.
+        // entry-points with same name/id will be ignored.
+        for (i = 0, ii = entrypoints.length; i < ii; i++) {
+            state.lookup[entrypoints[i]] = true;
+        }
+
+        state = findItemsOrGroups(collection, state, true);
+
+        // bail out if any of the given endpoint is not found.
+        if (Object.keys(state.lookup).length) {
+            return callback(null, []);
+        }
+
+        // extract runnable items from the searched items.
+        for (i = 0, ii = state.items.length; i < ii; i++) {
+            runnableItems = runnableItems.concat(flattenNode(state.items[i]));
+        }
+
+        callback(null, runnableItems, collection);
+    },
+
     lookupStrategyMap = {
         path: lookupByPath,
-        idOrName: lookupByIdOrName
+        idOrName: lookupByIdOrName,
+        multipleIdOrName: lookupByMultipleIdOrName
     },
 
     /**

--- a/lib/runner/extract-runnable-items.js
+++ b/lib/runner/extract-runnable-items.js
@@ -176,7 +176,7 @@ var sdk = require('postman-collection'),
 
         state = findItemsOrGroups(collection, state, true);
 
-        // bail out if any of the given endpoint is not found.
+        // bail out if any of the given entry-point is not found.
         if (Object.keys(state.lookup).length) {
             return callback(null, []);
         }

--- a/lib/runner/extract-runnable-items.js
+++ b/lib/runner/extract-runnable-items.js
@@ -65,40 +65,40 @@ var sdk = require('postman-collection'),
      * Finds items based on multiple ids or names provided.
      *
      * @param {ItemGroup} itemGroup - Composite list of Item or ItemGroup.
-     * @param {Object} state - Reference passed across multiple recursive calls.
-     * @param {Array<String>} state.items - Found Items or ItemGroups.
-     * @param {Object} state.lookup - Entry-points to lookup for.
-     * @param {Boolean} includeItem - Flag used to decide whether to include nested items or not.
+     * @param {Object} entrypointSubset - Entry-points reference passed across multiple recursive calls.
+     * @param {Boolean} recursive - Flag used to decide whether to include nested items or not.
+     * @param {Array<String>} _accumulatedItems - Found Items or ItemGroups.
      * @returns {Object}
      */
-    findItemsOrGroups = function (itemGroup, state, includeItem) {
+    findItemsOrGroups = function (itemGroup, entrypointSubset, recursive, _accumulatedItems) {
         if (!itemGroup || !itemGroup.items) { return; }
+        !_accumulatedItems && (_accumulatedItems = []);
 
         var idOrName;
 
         itemGroup.items.each(function (item) {
             // bail out if all entry-points are found.
-            if (!Object.keys(state.lookup).length) { return false; }
+            if (!Object.keys(entrypointSubset).length) { return false; }
 
             // lookup for item's id or name.
-            idOrName = state.lookup[item.id] ? item.id :
-                state.lookup[item.name] ? item.name : null;
+            idOrName = entrypointSubset[item.id] ? item.id :
+                entrypointSubset[item.name] ? item.name : null;
 
             if (idOrName) {
                 // only push items which are not previously got tracked from its parent entry-point.
-                includeItem && state.items.push(item);
+                recursive && _accumulatedItems.push(item);
 
                 // delete looked-up entry-point.
-                delete state.lookup[idOrName];
+                delete entrypointSubset[idOrName];
 
                 // recursive call to find nested entry-points. To make sure all provided entry-points got tracked.
-                // set includeItem to `false` for children, since current item is included already.
-                return findItemsOrGroups(item, state, false);
+                // set recursive flag to `false` for children, since current item is included already.
+                return findItemsOrGroups(item, entrypointSubset, false, _accumulatedItems);
             }
-            findItemsOrGroups(item, state, includeItem);
+            findItemsOrGroups(item, entrypointSubset, recursive, _accumulatedItems);
         });
 
-        return state;
+        return _accumulatedItems;
     },
 
     /**
@@ -153,37 +153,35 @@ var sdk = require('postman-collection'),
 
     lookupByMultipleIdOrName = function (collection, options, callback) {
         var entrypoints = options.execute,
+            entrypointLookup = {},
             runnableItems = [],
-            state,
+            items,
             i,
             ii;
 
-        if (!Array.isArray(entrypoints) || !entrypoints.length) {
+        if (!(Array.isArray(entrypoints) && entrypoints.length)) {
             return callback(null, []);
         }
-
-        // initialize the state to be passed as reference in `findItemsOrGroups`.
-        state = {
-            items: [],
-            lookup: {}
-        };
 
         // add temp reference for faster lookup of entry-point name/id.
         // entry-points with same name/id will be ignored.
         for (i = 0, ii = entrypoints.length; i < ii; i++) {
-            state.lookup[entrypoints[i]] = true;
+            entrypointLookup[entrypoints[i]] = true;
         }
 
-        state = findItemsOrGroups(collection, state, true);
+        items = findItemsOrGroups(collection, entrypointLookup, true);
 
-        // bail out if any of the given entry-point is not found.
-        if (Object.keys(state.lookup).length) {
+        // at this point of time, we should have traversed all items mentioned in entrypoint and created a linear
+        // subset of items. However, if post that, we still have items remaining in lookup object, that implies that
+        // extra items were present in user input and corresponding items for those do not exist in collection. As such
+        // we need to bail out if any of the given entry-point is not found.
+        if (Object.keys(entrypointLookup).length) {
             return callback(null, []);
         }
 
         // extract runnable items from the searched items.
-        for (i = 0, ii = state.items.length; i < ii; i++) {
-            runnableItems = runnableItems.concat(flattenNode(state.items[i]));
+        for (i = 0, ii = items.length; i < ii; i++) {
+            runnableItems = runnableItems.concat(flattenNode(items[i]));
         }
 
         callback(null, runnableItems, collection);

--- a/lib/runner/index.js
+++ b/lib/runner/index.js
@@ -84,6 +84,15 @@ _.assign(Runner.prototype, {
         callback = backpack.normalise(callback);
         !_.isObject(options) && (options = {});
 
+        // @todo make the extract runnables interface better defined and documented
+        // - give the ownership of error to each strategy lookup functions
+        // - think about moving these codes into an extension command prior to waterfall
+        // - the third argument in callback that returns control, is ambiguous and can be removed if error is controlled
+        //   by each lookup function.
+        // - the interface can be further broken down to have the "flattenNode" action be made common and not be
+        //   required to be coded in each lookup strategy
+        //
+        // serialise the items into a linear array based on the lookup strategy provided as input
         extractRunnableItems(collection, options.entrypoint, function (err, runnableItems, entrypoint) {
             if (err || !runnableItems) { return callback(new Error('Error fetching run items')); }
 

--- a/test/unit/extract-runnable-items.test.js
+++ b/test/unit/extract-runnable-items.test.js
@@ -227,4 +227,202 @@ describe('extractRunnableItems', function () {
             );
         });
     });
+
+    describe('lookupStrategy: multipleIdOrName', function () {
+        it('should handle invalid entry points', function (done) {
+            extractRunnableItems(
+                collection, {
+                    execute: 'random',
+                    lookupStrategy: 'multipleIdOrName'
+                },
+                function (err, runnableItems, entrypoint) {
+                    expect(err).to.be(null);
+                    expect(runnableItems).to.eql([]);
+                    expect(entrypoint).to.be(undefined);
+                    done();
+                }
+            );
+        });
+
+        it('should bail out if any of the given entrypoint is not found. ', function (done) {
+            extractRunnableItems(
+                collection, {
+                    execute: ['ID3', 'RANDOM'],
+                    lookupStrategy: 'multipleIdOrName'
+                },
+                function (err, runnableItems, entrypoint) {
+                    expect(err).to.be(null);
+                    expect(runnableItems).to.eql([]);
+                    expect(entrypoint).to.be(undefined);
+                    done();
+                }
+            );
+        });
+
+        it('should filter single item group by id', function (done) {
+            extractRunnableItems(
+                collection, {
+                    execute: ['ID2'],
+                    lookupStrategy: 'multipleIdOrName'
+                },
+                function (err, runnableItems, entrypoint) {
+                    expect(err).to.be(null);
+                    expect(_.map(runnableItems, 'name')).to.eql(['F2.R1']);
+                    expect(entrypoint).to.have.property('name', 'Collection C1');
+                    done();
+                }
+            );
+        });
+
+        it('should filter multiple item groups by id', function (done) {
+            extractRunnableItems(
+                collection, {
+                    execute: ['ID1', 'ID2'],
+                    lookupStrategy: 'multipleIdOrName'
+                },
+                function (err, runnableItems, entrypoint) {
+                    expect(err).to.be(null);
+                    expect(_.map(runnableItems, 'name')).to.eql(['F1.R1', 'F1.F1.R1', 'F2.R1']);
+                    expect(entrypoint).to.have.property('name', 'Collection C1');
+                    done();
+                }
+            );
+        });
+
+        it('should filter single item by id', function (done) {
+            extractRunnableItems(
+                collection, {
+                    execute: ['ID3'],
+                    lookupStrategy: 'multipleIdOrName'
+                },
+                function (err, runnableItems, entrypoint) {
+                    expect(err).to.be(null);
+                    expect(_.map(runnableItems, 'name')).to.eql(['F1.R1']);
+                    expect(entrypoint).to.have.property('name', 'Collection C1');
+                    done();
+                }
+            );
+        });
+
+        it('should filter multiple items by id', function (done) {
+            extractRunnableItems(
+                collection, {
+                    execute: ['ID3', 'ID4', 'ID6'],
+                    lookupStrategy: 'multipleIdOrName'
+                },
+                function (err, runnableItems, entrypoint) {
+                    expect(err).to.be(null);
+                    expect(_.map(runnableItems, 'name')).to.eql(['F1.R1', 'F1.F1.R1', 'R1']);
+                    expect(entrypoint).to.have.property('name', 'Collection C1');
+                    done();
+                }
+            );
+        });
+
+        it('should filter single item group by name', function (done) {
+            extractRunnableItems(
+                collection, {
+                    execute: ['F1'],
+                    lookupStrategy: 'multipleIdOrName'
+                },
+                function (err, runnableItems, entrypoint) {
+                    expect(err).to.be(null);
+                    expect(_.map(runnableItems, 'name')).to.eql(['F1.R1', 'F1.F1.R1']);
+                    expect(entrypoint).to.have.property('name', 'Collection C1');
+                    done();
+                }
+            );
+        });
+
+        it('should filter multiple item groups by name', function (done) {
+            extractRunnableItems(
+                collection, {
+                    execute: ['F1', 'F2'],
+                    lookupStrategy: 'multipleIdOrName'
+                },
+                function (err, runnableItems, entrypoint) {
+                    expect(err).to.be(null);
+                    expect(_.map(runnableItems, 'name')).to.eql(['F1.R1', 'F1.F1.R1', 'F2.R1']);
+                    expect(entrypoint).to.have.property('name', 'Collection C1');
+                    done();
+                }
+            );
+        });
+
+        it('should filter single item by name', function (done) {
+            extractRunnableItems(
+                collection, {
+                    execute: ['F1.R1'],
+                    lookupStrategy: 'multipleIdOrName'
+                },
+                function (err, runnableItems, entrypoint) {
+                    expect(err).to.be(null);
+                    expect(runnableItems).to.have.length(1);
+                    expect(_.map(runnableItems, 'name')).to.eql(['F1.R1']);
+                    expect(entrypoint).to.have.property('name', 'Collection C1');
+                    done();
+                }
+            );
+        });
+
+        it('should filter multiple items by name', function (done) {
+            extractRunnableItems(
+                collection, {
+                    execute: ['F1.R1', 'F2.R1'],
+                    lookupStrategy: 'multipleIdOrName'
+                },
+                function (err, runnableItems, entrypoint) {
+                    expect(err).to.be(null);
+                    expect(_.map(runnableItems, 'name')).to.eql(['F1.R1', 'F2.R1']);
+                    expect(entrypoint).to.have.property('name', 'Collection C1');
+                    done();
+                }
+            );
+        });
+
+        it('should filter by combination of id and name', function (done) {
+            extractRunnableItems(
+                collection, {
+                    execute: ['ID1', 'F2'],
+                    lookupStrategy: 'multipleIdOrName'
+                },
+                function (err, runnableItems, entrypoint) {
+                    expect(err).to.be(null);
+                    expect(_.map(runnableItems, 'name')).to.eql(['F1.R1', 'F1.F1.R1', 'F2.R1']);
+                    expect(entrypoint).to.have.property('name', 'Collection C1');
+                    done();
+                }
+            );
+        });
+
+        it('should follow collection order', function (done) {
+            extractRunnableItems(
+                collection, {
+                    execute: ['ID6', 'ID1', 'ID2'],
+                    lookupStrategy: 'multipleIdOrName'
+                },
+                function (err, runnableItems, entrypoint) {
+                    expect(err).to.be(null);
+                    expect(_.map(runnableItems, 'name')).to.eql(['F1.R1', 'F1.F1.R1', 'F2.R1', 'R1']);
+                    expect(entrypoint).to.have.property('name', 'Collection C1');
+                    done();
+                }
+            );
+        });
+
+        it('should avoid nested entrypoints', function (done) {
+            extractRunnableItems(
+                collection, {
+                    execute: ['F1', 'F1.F1', 'F1.F1.R1'],
+                    lookupStrategy: 'multipleIdOrName'
+                },
+                function (err, runnableItems, entrypoint) {
+                    expect(err).to.be(null);
+                    expect(_.map(runnableItems, 'name')).to.eql(['F1.R1', 'F1.F1.R1']);
+                    expect(entrypoint).to.have.property('name', 'Collection C1');
+                    done();
+                }
+            );
+        });
+    });
 });

--- a/test/unit/extract-runnable-items.test.js
+++ b/test/unit/extract-runnable-items.test.js
@@ -48,7 +48,7 @@ describe('extractRunnableItems', function () {
         });
     });
 
-    describe('with invalid entrypoint', function () {
+    describe('invalid entrypoint', function () {
         it('should handle invalid entry points as string', function (done) {
             extractRunnableItems(collection, 'random', function (err, runnableItems, entrypoint) {
                 expect(err).to.be(null);
@@ -56,32 +56,6 @@ describe('extractRunnableItems', function () {
                 expect(entrypoint).to.be(undefined);
                 done();
             });
-        });
-
-        it('should handle invalid entry points for path lookupStrategy', function (done) {
-            extractRunnableItems(
-                collection,
-                {execute: 'random', lookupStrategy: 'path', path: ['random_path']},
-                function (err, runnableItems, entrypoint) {
-                    expect(err).to.be(null);
-                    expect(runnableItems).to.eql([]);
-                    expect(entrypoint).to.be(undefined);
-                    done();
-                }
-            );
-        });
-
-        it('should handle invalid entry points for idOrName lookupStrategy', function (done) {
-            extractRunnableItems(
-                collection,
-                {execute: 'random', lookupStrategy: 'idOrName'},
-                function (err, runnableItems, entrypoint) {
-                    expect(err).to.be(null);
-                    expect(runnableItems).to.eql([]);
-                    expect(entrypoint).to.be(undefined);
-                    done();
-                }
-            );
         });
 
         it('should handle invalid lookupStrategy', function (done) {
@@ -100,8 +74,24 @@ describe('extractRunnableItems', function () {
         });
     });
 
-    describe('with entrypoint with lookupStrategy as path', function () {
-        it('can match item in top level', function (done) {
+    describe('lookupStrategy: path', function () {
+        it('should handle invalid entry points', function (done) {
+            extractRunnableItems(
+                collection, {
+                    execute: 'random',
+                    lookupStrategy: 'path',
+                    path: ['random_path']
+                },
+                function (err, runnableItems, entrypoint) {
+                    expect(err).to.be(null);
+                    expect(runnableItems).to.eql([]);
+                    expect(entrypoint).to.be(undefined);
+                    done();
+                }
+            );
+        });
+
+        it('should match item in top level', function (done) {
             extractRunnableItems(
                 collection,
                 {execute: 'ID6', lookupStrategy: 'path'},
@@ -114,7 +104,7 @@ describe('extractRunnableItems', function () {
             );
         });
 
-        it('can match item in nested level', function (done) {
+        it('should match item in nested level', function (done) {
             extractRunnableItems(
                 collection,
                 {execute: 'ID3', lookupStrategy: 'path', path: ['ID1']},
@@ -127,7 +117,7 @@ describe('extractRunnableItems', function () {
             );
         });
 
-        it('can match item group at top level', function (done) {
+        it('should match item group at top level', function (done) {
             extractRunnableItems(
                 collection,
                 {execute: 'ID1', lookupStrategy: 'path'},
@@ -140,7 +130,7 @@ describe('extractRunnableItems', function () {
             );
         });
 
-        it('can match item group at nested level', function (done) {
+        it('should match item group at nested level', function (done) {
             extractRunnableItems(
                 collection,
                 {execute: 'ID4', lookupStrategy: 'path', path: ['ID1']},
@@ -154,7 +144,22 @@ describe('extractRunnableItems', function () {
         });
     });
 
-    describe('with lookupStrategy idOrName', function () {
+    describe('lookupStrategy: idOrName', function () {
+        it('should handle invalid entry points', function (done) {
+            extractRunnableItems(
+                collection, {
+                    execute: 'random',
+                    lookupStrategy: 'idOrName'
+                },
+                function (err, runnableItems, entrypoint) {
+                    expect(err).to.be(null);
+                    expect(runnableItems).to.eql([]);
+                    expect(entrypoint).to.be(undefined);
+                    done();
+                }
+            );
+        });
+
         it('should be default', function (done) {
             extractRunnableItems(
                 collection,


### PR DESCRIPTION
**Behavior:**
- Follows the same order as of Postman Collection.
- Picks the first match for an entry point in the collection.
- Ignores nested entry points.
- Bail out if any of the given entry point(s) is not found.

**Benchmark:**
*lookupStrategy: multipleIdOrName*
```
First Match      x 72,505 ops/sec ±19.81% (74 runs sampled)
Last Match       x 62,777 ops/sec ±4.04% (81 runs sampled)
No Match         x 51,929 ops/sec ±4.06% (55 runs sampled)
Deeply Nested    x 67,807 ops/sec ±5.09% (78 runs sampled)
Multiple Matches x 40,379 ops/sec ±3.17% (74 runs sampled)
Nested Matches   x 38,728 ops/sec ±2.55% (80 runs sampled)
```

*lookupStrategy: idOrName*
```
First Match   x 87,271 ops/sec ±12.31% (76 runs sampled)
Last Match    x 74,652 ops/sec ±2.12% (81 runs sampled)
No Match      x 58,218 ops/sec ±3.40% (64 runs sampled)
Deeply Nested x 59,936 ops/sec ±3.60% (49 runs sampled)
```