### PR TITLE
Added tests for missing & non-string HTTP method

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "inherits": "2.0.3",
     "lodash": "4.17.10",
     "node-oauth1": "1.2.2",
-    "postman-collection": "3.2.0",
+    "postman-collection": "git://github.com/postmanlabs/postman-collection.git#develop",
     "postman-request": "2.86.1-postman.1",
     "postman-sandbox": "3.1.2",
     "resolve-from": "4.0.0",

--- a/test/integration/sanity/http-methods.test.js
+++ b/test/integration/sanity/http-methods.test.js
@@ -59,13 +59,13 @@ describe('http methods', function () {
             sinon.assert.calledWith(testrun.response.getCall(0), null);
 
             var request = testrun.request.getCall(0).args[3],
-                response = testrun.request.getCall(0).args[2];
+                response = testrun.request.getCall(0).args[2].stream.toString();
 
             // method sent to server in request
             expect(request).to.have.property('method', 'GET');
 
             // method received at server
-            expect(response.stream.toString()).to.contain('GET / HTTP/1.1');
+            expect(response).to.contain('GET / HTTP/1.1');
         });
     });
 
@@ -101,13 +101,13 @@ describe('http methods', function () {
             sinon.assert.calledWith(testrun.response.getCall(0), null);
 
             var request = testrun.request.getCall(0).args[3],
-                response = testrun.request.getCall(0).args[2];
+                response = testrun.request.getCall(0).args[2].stream.toString();
 
             // method sent to server in request
             expect(request).to.have.property('method', 'POSTMAN');
 
             // method received at server
-            expect(response.stream.toString()).to.contain('POSTMAN / HTTP/1.1');
+            expect(response).to.contain('POSTMAN / HTTP/1.1');
         });
 
         describe('with request body', function () {
@@ -307,6 +307,88 @@ describe('http methods', function () {
                     expect(response).to.contain('{\n\t"key1":"value1",\n\t"key2": 2\n}\n');
                 });
             });
+        });
+    });
+
+    describe('missing', function () {
+        before(function (done) {
+            this.run({
+                collection: {
+                    item: [{
+                        request: {url: URL}
+                    }]
+                }
+            }, function (err, results) {
+                testrun = results;
+                done(err);
+            });
+        });
+
+        it('should complete the run', function () {
+            expect(testrun).be.ok();
+            sinon.assert.calledOnce(testrun.start);
+            sinon.assert.calledOnce(testrun.done);
+            sinon.assert.calledWith(testrun.done.getCall(0), null);
+        });
+
+        it('should defaults to GET method', function () {
+            sinon.assert.calledOnce(testrun.request);
+            sinon.assert.calledWith(testrun.request.getCall(0), null);
+
+            sinon.assert.calledOnce(testrun.response);
+            sinon.assert.calledWith(testrun.response.getCall(0), null);
+
+            var request = testrun.request.getCall(0).args[3],
+                response = testrun.request.getCall(0).args[2].stream.toString();
+
+            // method sent to server in request
+            expect(request).to.have.property('method', 'GET');
+
+            // method received at server
+            expect(response).to.contain('GET / HTTP/1.1');
+        });
+    });
+
+    // @todo enable this when non-string request method is accepted in SDK.
+    describe.skip('non-string', function () {
+        before(function (done) {
+            this.run({
+                collection: {
+                    item: [{
+                        request: {
+                            url: URL,
+                            method: 12345
+                        }
+                    }]
+                }
+            }, function (err, results) {
+                testrun = results;
+                done(err);
+            });
+        });
+
+        it('should complete the run', function () {
+            expect(testrun).be.ok();
+            sinon.assert.calledOnce(testrun.start);
+            sinon.assert.calledOnce(testrun.done);
+            sinon.assert.calledWith(testrun.done.getCall(0), null);
+        });
+
+        it('should handle non-string method correctly', function () {
+            sinon.assert.calledOnce(testrun.request);
+            sinon.assert.calledWith(testrun.request.getCall(0), null);
+
+            sinon.assert.calledOnce(testrun.response);
+            sinon.assert.calledWith(testrun.response.getCall(0), null);
+
+            var request = testrun.request.getCall(0).args[3],
+                response = testrun.request.getCall(0).args[2].stream.toString();
+
+            // method sent to server in request
+            expect(request).to.have.property('method', '12345');
+
+            // method received at server
+            expect(response).to.contain('12345 / HTTP/1.1');
         });
     });
 });

--- a/test/integration/sanity/http-methods.test.js
+++ b/test/integration/sanity/http-methods.test.js
@@ -349,8 +349,7 @@ describe('http methods', function () {
         });
     });
 
-    // @todo enable this when non-string request method is accepted in SDK.
-    describe.skip('non-string', function () {
+    describe('non-string', function () {
         before(function (done) {
             this.run({
                 collection: {


### PR DESCRIPTION
Extends #632 

TODO:
- [x] Handle non-string request methods in SDK