### PR TITLE
Better handling of disabled property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -169,7 +169,7 @@
 * #350 Fixed abort-after-pause :bug:
 * #386 Added support for bearer-token auth :tada:
 * #373 Added response callback :tada:
-* #360 Shifted the auth sign function from the C.
+* #360 Shifted the auth sign function from the Collection SDK.
 * #368 All new auth-interface :tada:
 * #367 Made basic-auth username optional :tada:
 * #366 Documented exception callback :scroll:
@@ -182,7 +182,7 @@
 
 #### v6.2.6 (August 18, 2017)
 * Updated dependencies :arrow_up:
-* Bumped C to `v2.1.1` and Sandbox to `v2.3.1`. #353, #354
+* Bumped Collection SDK to `v2.1.1` and Sandbox to `v2.3.1`. #353, #354
 * :lock: Prevented files from being uploaded via `pm.sendRequest` #351
 * Queued `pm.sendRequest` through the request command, emitted the `request` event. #345
 * :scroll: Expanded documentation for the `assertion` event. #342
@@ -196,12 +196,12 @@
 * Fixed a bug that prevented the `Content-Length` header from being set for file uploads in `binary` mode.
 
 #### 6.2.3 (July 5, 2017)
-* Support for updated `ProxyConfig` from C v2.0.0
+* Support for updated `ProxyConfig` from Collection SDK v2.0.0
 * Custom proxies now have higher preference than system proxies
 
 #### 6.2.2 (June 28, 2017)
 * Bumped Postman Sandbox to v2.3.0, which includes support for synchronous csv-parse #298
-* Bumped Postman C to v1.2.9, with critical bugfixes. #297
+* Bumped Postman Collection SDK to v1.2.9, with critical bugfixes. #297
 * Updated other dependencies
 
 #### 6.2.1 (June 23, 2017)
@@ -511,7 +511,7 @@
 * Disabled file uploads if no fileResolver is provided
 * Ensure that URL encoding is done in an XHR compatible way by the request library
 * Allow aborting of individual HTTP requests
-* Parse XHR headers using the Postman C
+* Parse XHR headers using the Postman Collection SDK
 * Updated the SDK version to v0.4.6
 
 #### 2.2.2 (July 25, 2016)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Postman Runtime Changelog
 
+#### v7.7.0 (unreleased)
+* #707 Avoid executing disabled `prerequest` and `test` scripts.
+* #707 Uses Collection SDK `Request~getHeaders` method to get request headers object.
+* Updated `postman-collection` to v3.4.2 which avoids substitution of disabled variables.
+
 #### v7.6.1 (January 3, 2019)
 * Updated `postman-collection` to v3.4.1 which fixes a bug where poly chained variables are not resolved correctly
 * Updated dependencies
@@ -164,7 +169,7 @@
 * #350 Fixed abort-after-pause :bug:
 * #386 Added support for bearer-token auth :tada:
 * #373 Added response callback :tada:
-* #360 Shifted the auth sign function from the Collection SDK.
+* #360 Shifted the auth sign function from the C.
 * #368 All new auth-interface :tada:
 * #367 Made basic-auth username optional :tada:
 * #366 Documented exception callback :scroll:
@@ -177,7 +182,7 @@
 
 #### v6.2.6 (August 18, 2017)
 * Updated dependencies :arrow_up:
-* Bumped Collection SDK to `v2.1.1` and Sandbox to `v2.3.1`. #353, #354
+* Bumped C to `v2.1.1` and Sandbox to `v2.3.1`. #353, #354
 * :lock: Prevented files from being uploaded via `pm.sendRequest` #351
 * Queued `pm.sendRequest` through the request command, emitted the `request` event. #345
 * :scroll: Expanded documentation for the `assertion` event. #342
@@ -191,12 +196,12 @@
 * Fixed a bug that prevented the `Content-Length` header from being set for file uploads in `binary` mode.
 
 #### 6.2.3 (July 5, 2017)
-* Support for updated `ProxyConfig` from Collection SDK v2.0.0
+* Support for updated `ProxyConfig` from C v2.0.0
 * Custom proxies now have higher preference than system proxies
 
 #### 6.2.2 (June 28, 2017)
 * Bumped Postman Sandbox to v2.3.0, which includes support for synchronous csv-parse #298
-* Bumped Postman Collection SDK to v1.2.9, with critical bugfixes. #297
+* Bumped Postman C to v1.2.9, with critical bugfixes. #297
 * Updated other dependencies
 
 #### 6.2.1 (June 23, 2017)
@@ -506,7 +511,7 @@
 * Disabled file uploads if no fileResolver is provided
 * Ensure that URL encoding is done in an XHR compatible way by the request library
 * Allow aborting of individual HTTP requests
-* Parse XHR headers using the Postman Collection SDK
+* Parse XHR headers using the Postman C
 * Updated the SDK version to v0.4.6
 
 #### 2.2.2 (July 25, 2016)

--- a/lib/requester/core.js
+++ b/lib/requester/core.js
@@ -225,9 +225,7 @@ module.exports = {
 
         !defaultOpts && (defaultOpts = {});
 
-        // @todo replace this with request.header.toObject(true, true, true, true); once the sanitize option has been
-        // added to PropertyList~toObject
-        options.headers = self.getRequestHeaders(request);
+        options.headers = request.getHeaders({enabled: true, sanitizeKeys: true});
         url = request.url.toString();
         options.url = (/^https?:\/\//i).test(url) ? url : 'http://' + url;
         options.method = request.method;
@@ -296,33 +294,6 @@ module.exports = {
 
         if (!headerName) {
             headers[headerKey] = defaultValue;
-        }
-    },
-
-    /**
-     * Returns a header object
-     *
-     * @param request
-     * @returns {{}}
-     */
-    getRequestHeaders: function (request) {
-        var headers = {};
-        if (request.headers) {
-            request.forEachHeader(function (header) {
-                if (header && (header.disabled || !header.key)) { return; }
-
-                var key = header.key,
-                    value = header.value;
-
-                if (headers[key]) {
-                    _.isArray(headers[key]) ? headers[key].push(value) :
-                        (headers[key] = [headers[key], value]);
-                }
-                else {
-                    headers[key] = value;
-                }
-            });
-            return headers;
         }
     },
 

--- a/lib/runner/extensions/event.command.js
+++ b/lib/runner/extensions/event.command.js
@@ -199,7 +199,7 @@ module.exports = {
 
             // get the list of events to be executed
             // includes events in parent as well
-            events = item.events.listeners(eventName);
+            events = item.events.listeners(eventName, {excludeDisabled: true});
 
             // call the "before" event trigger by its event name.
             // at this point, the one who queued this event, must ensure that the trigger for it is defined in its

--- a/package-lock.json
+++ b/package-lock.json
@@ -710,7 +710,7 @@
       "dependencies": {
         "domelementtype": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
           "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs="
         }
       }
@@ -1065,7 +1065,7 @@
     },
     "file-type": {
       "version": "3.9.0",
-      "resolved": "http://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
       "integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek="
     },
     "find-replace": {
@@ -2086,9 +2086,9 @@
       }
     },
     "postman-collection": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/postman-collection/-/postman-collection-3.4.1.tgz",
-      "integrity": "sha512-8aix5u0yBfC1qedVsgNfvXOlyZNpKFDZ5XHWGxBB6YYoFKJFdfxtdv3McTMpiOtUNy3S08NtFPwBa0VbTUMfqA==",
+      "version": "3.4.2-beta.2",
+      "resolved": "https://registry.npmjs.org/postman-collection/-/postman-collection-3.4.2-beta.2.tgz",
+      "integrity": "sha512-TimaH2xv5eMDctzgze//kfNZ7PnnkazY4B4cTlfzC/SfiuxRMVG5Mr6tTkDGJbqy6d6uh/qyj0H0JTuW+YsuWQ==",
       "requires": {
         "escape-html": "1.0.3",
         "file-type": "3.9.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "inherits": "2.0.3",
     "lodash": "4.17.11",
     "node-oauth1": "1.2.2",
-    "postman-collection": "3.4.1",
+    "postman-collection": "3.4.2-beta.2",
     "postman-request": "2.88.1-postman.5",
     "postman-sandbox": "3.2.2",
     "resolve-from": "4.0.0",

--- a/test/integration/inherited-entities/events.test.js
+++ b/test/integration/inherited-entities/events.test.js
@@ -299,4 +299,83 @@ describe('Events', function () {
             expect(testRun.console.getCall(3).args[2]).to.equal('folder level test script');
         });
     });
+
+    describe('disabled events', function () {
+        before(function (done) {
+            var runOptions = {
+                collection: {
+                    event: [
+                        {
+                            disabled: true,
+                            listen: 'prerequest',
+                            script: {exec: 'console.log("collection level prerequest script")'}
+                        },
+                        {
+                            listen: 'test',
+                            script: {exec: 'console.log("collection level test script")'}
+                        }
+                    ],
+                    item: [{
+                        event: [
+                            {
+                                listen: 'prerequest',
+                                script: {exec: 'console.log("folder level prerequest script")'}
+                            },
+                            {
+                                disabled: true,
+                                listen: 'test',
+                                script: {exec: 'console.log("folder level test script")'}
+                            }
+                        ],
+                        item: {
+                            event: [
+                                {
+                                    disabled: true,
+                                    listen: 'prerequest',
+                                    script: {exec: 'console.log("request level prerequest script")'}
+                                },
+                                {
+                                    listen: 'test',
+                                    script: {exec: 'console.log("request level test script")'}
+                                }
+                            ],
+                            request: 'https://postman-echo.com/get'
+                        }
+                    }]
+                }
+            };
+
+            // perform the collection run
+            this.run(runOptions, function (err, results) {
+                testRun = results;
+                done(err);
+            });
+        });
+
+        it('should have completed the run', function () {
+            expect(testRun).to.be.ok;
+            expect(testRun).to.nested.include({
+                'done.callCount': 1
+            });
+            testRun.done.getCall(0).args[0] && console.error(testRun.done.getCall(0).args[0].stack);
+            expect(testRun.done.getCall(0).args[0]).to.be.null;
+            expect(testRun).to.nested.include({
+                'start.callCount': 1
+            });
+        });
+
+        it('should have executed only the enabled events', function () {
+            expect(testRun).to.nested.include({
+                'prerequest.callCount': 1,
+                'test.callCount': 1,
+                'console.callCount': 3
+            });
+
+            expect(testRun).to.have.property('console').that.nested.include({
+                'firstCall.args[2]': 'folder level prerequest script',
+                'secondCall.args[2]': 'collection level test script',
+                'thirdCall.args[2]': 'request level test script'
+            });
+        });
+    });
 });

--- a/test/integration/request-flow/headers.test.js
+++ b/test/integration/request-flow/headers.test.js
@@ -1,0 +1,172 @@
+var http = require('http'),
+    sinon = require('sinon'),
+    expect = require('chai').expect,
+    enableServerDestroy = require('server-destroy');
+
+describe('request headers', function () {
+    var server,
+        testrun,
+        PORT = 5050,
+        HOST = 'http://localhost:' + PORT;
+
+    /**
+     * Converts raw request headers to array of key-value object.
+     *
+     * [ 'User-Agent', 'PostmanRuntime' ] -> [{key: 'User-Agent', value: 'PostmanRuntime'}]
+     *
+     * @param {String[]} rawHeaders - raw request headers
+     * @returns {Object[]}
+     */
+    function parseRawHeaders(rawHeaders) {
+        if (!Array.isArray(rawHeaders)) { return []; }
+
+        var headerList = [],
+            i,
+            ii;
+
+        for (i = 0, ii = rawHeaders.length; i < ii; i += 2) {
+            headerList.push({
+                key: rawHeaders[i],
+                value: rawHeaders[i + 1]
+            });
+        }
+
+        return headerList;
+    }
+
+    before(function (done) {
+        server = http.createServer(function (req, res) {
+            res.writeHead(200, {'content-type': 'application/json'});
+            res.end(JSON.stringify(parseRawHeaders(req.rawHeaders)));
+        }).listen(PORT, function (err) {
+            if (err) { return done(err); }
+
+            this.run({
+                collection: {
+                    item: [{
+                        name: 'Duplicate headers',
+                        request: {
+                            url: HOST,
+                            header: [{
+                                key: 'Header-Name',
+                                value: 'value1'
+                            }, {
+                                key: 'Header-Name',
+                                value: 'value2'
+                            }]
+                        }
+                    }, {
+                        name: 'Disabled & Falsy headers',
+                        request: {
+                            url: HOST,
+                            header: [{
+                                key: 'Header-Name-1',
+                                value: 'value1'
+                            }, {
+                                key: 'Header-Name-2',
+                                value: 'value2',
+                                disabled: true
+                            }, {
+                                key: '',
+                                value: 'value3'
+                            }]
+                        }
+                    }, {
+                        name: 'Case Insensitive',
+                        request: {
+                            url: HOST,
+                            header: [{
+                                key: 'Header-Name-0',
+                                value: 'value0'
+                            }, {
+                                key: 'Header-Name-1',
+                                value: 'value1'
+                            }, {
+                                key: 'header-name-1',
+                                value: 'value2'
+                            }, {
+                                key: 'HEADER-NAME-2',
+                                value: 'value3'
+                            }]
+                        }
+                    }]
+                }
+            }, function (err, results) {
+                testrun = results;
+                done(err);
+            });
+        }.bind(this));
+        enableServerDestroy(server);
+    });
+
+    after(function (done) {
+        server.destroy(done);
+    });
+
+    it('should complete the run', function () {
+        expect(testrun).to.be.ok;
+        sinon.assert.calledOnce(testrun.start);
+        sinon.assert.calledOnce(testrun.done);
+        sinon.assert.calledWith(testrun.done.getCall(0), null);
+
+        sinon.assert.calledThrice(testrun.request);
+        sinon.assert.calledThrice(testrun.response);
+    });
+
+    it('should handle duplicate headers correctly', function () {
+        sinon.assert.calledWith(testrun.request.getCall(0), null);
+        sinon.assert.calledWith(testrun.response.getCall(0), null);
+
+        var response = testrun.response.getCall(0).args[2],
+            requestHeaders = JSON.parse(response.stream);
+
+        expect(requestHeaders).to.deep.include.members([
+            {key: 'Header-Name', value: 'value1'},
+            {key: 'Header-Name', value: 'value2'}
+        ]);
+    });
+
+    it('should handle disabled and falsy header keys correctly', function () {
+        sinon.assert.calledWith(testrun.request.getCall(1), null);
+        sinon.assert.calledWith(testrun.response.getCall(1), null);
+
+        var response = testrun.response.getCall(1).args[2],
+            requestHeaders = JSON.parse(response.stream);
+
+        expect(requestHeaders).to.deep.include({
+            key: 'Header-Name-1',
+            value: 'value1'
+        });
+
+        expect(requestHeaders).to.not.deep.include({
+            key: 'Header-Name-2',
+            value: 'value2'
+        });
+
+        expect(requestHeaders).to.not.deep.include({
+            key: '',
+            value: 'value3'
+        });
+    });
+
+    it('should handle headers with different cases correctly', function () {
+        sinon.assert.calledWith(testrun.request.getCall(2), null);
+        sinon.assert.calledWith(testrun.response.getCall(2), null);
+
+        var response = testrun.response.getCall(2).args[2],
+            requestHeaders = JSON.parse(response.stream);
+
+        expect(requestHeaders).to.deep.include.members([
+            {key: 'Header-Name-0', value: 'value0'},
+            {key: 'header-name-1', value: 'value2'},
+            {key: 'HEADER-NAME-2', value: 'value3'}
+        ]);
+
+        // @todo: handle multiple headers with different capitalization
+        // https://github.com/postmanlabs/postman-app-support/issues/5372
+        expect(requestHeaders).to.not.deep.include({
+            key: 'Header-Name-1',
+            value: 'value1'
+        });
+    });
+});

--- a/test/integration/sanity/variable-resolution.test.js
+++ b/test/integration/sanity/variable-resolution.test.js
@@ -80,6 +80,10 @@ describe('variable resolution', function () {
                 }, {
                     key: 'helloWorld',
                     value: '{{22{{20{{19}}}}}}'
+                }, {
+                    key: '22',
+                    disabled: true,
+                    value: 'disabled-variable'
                 }]
             },
             environment: {

--- a/test/unit/requester-core.test.js
+++ b/test/unit/requester-core.test.js
@@ -226,34 +226,6 @@ describe('requester util', function () {
         });
     });
 
-    describe('.getRequestHeaders', function () {
-        it('should handle invalid input correctly', function () {
-            var result = requesterCore.getRequestHeaders({});
-            expect(result).to.be.undefined;
-        });
-
-        it('should correctly fetch request headers from a sdk Request instance', function () {
-            var request = new sdk.Request({
-                    url: 'postman-echo.com',
-                    method: 'GET',
-                    header: [
-                        {key: 'alpha', value: 'foo'},
-                        {key: 'beta', value: 'bar', disabled: true},
-                        {key: 'gamma', value: 'baz'},
-                        {key: 'alpha', value: 'next'},
-                        {key: 'alpha', value: 'other'},
-                        {key: '', value: 'random'}
-                    ]
-                }),
-                headers = requesterCore.getRequestHeaders(request);
-
-            expect(headers).to.eql({
-                alpha: ['foo', 'next', 'other'],
-                gamma: 'baz'
-            });
-        });
-    });
-
     describe('.getRequestBody', function () {
         it('should correctly handle empty bodies', function () {
             var request = new sdk.Request({


### PR DESCRIPTION
- Use `Request~getHeaders` method to get headers object
- Added tests for request headers variants
- Excluded disabled events from `event.command`