### PR TITLE
Added redirect server to separate module in tests

### DIFF
--- a/test/fixtures/server.js
+++ b/test/fixtures/server.js
@@ -78,9 +78,9 @@ function createRawEchoServer () {
  *
  * @example
  * var s = createSSLServer();
- * s.on('/foo', function (req, resp) {
- *     resp.writeHead(200, {'Content-Type': 'text/plain'});
- *     resp.end('Hello World');
+ * s.on('/foo', function (req, res) {
+ *     res.writeHead(200, {'Content-Type': 'text/plain'});
+ *     res.end('Hello World');
  * });
  * s.listen(3000, 'localhost');
  */
@@ -104,8 +104,8 @@ function createSSLServer (opts) {
         }
     }
 
-    server = https.createServer(options, function (req, resp) {
-        server.emit(req.url, req, resp);
+    server = https.createServer(options, function (req, res) {
+        server.emit(req.url, req, res);
     });
 
     enableServerDestroy(server);
@@ -119,22 +119,22 @@ function createSSLServer (opts) {
  *
  * @example
  * var s = createRedirectServer();
- * s.on('hit', function (req, resp) {
+ * s.on('hit', function (req, res) {
  *     console.log(req.location);
  * });
- * s.on('/foo', function (req, resp)) {
+ * s.on('/foo', function (req, res)) {
  *     // this is called when there is no redirect.
  * }
  * s.listen(3000, callback);
  */
 function createRedirectServer () {
-    var server = http.createServer(function (req, resp) {
+    var server = http.createServer(function (req, res) {
         var urlTokens,
             numberOfRedirects,
             responseCode,
             redirectURL;
 
-        server.emit('hit', req, resp);
+        server.emit('hit', req, res);
 
         // /<urlPath>/<numberOfRedirects>/<responseCode>
         if ((/\/\d+\/\d{3}$/).test(req.url)) {
@@ -150,13 +150,13 @@ function createRedirectServer () {
                 redirectURL = urlTokens.slice(0, -2).join('/') + '/';
             }
 
-            resp.writeHead(responseCode, {location: redirectURL});
+            res.writeHead(responseCode, {location: redirectURL});
 
-            return resp.end();
+            return res.end();
         }
 
         // emit event if this is not a redirect request
-        server.emit(req.url, req, resp);
+        server.emit(req.url, req, res);
     });
 
     enableServerDestroy(server);

--- a/test/fixtures/server.js
+++ b/test/fixtures/server.js
@@ -139,8 +139,8 @@ function createRedirectServer () {
         // /<urlPath>/<numberOfRedirects>/<responseCode>
         if ((/\/\d+\/\d{3}$/).test(req.url)) {
             urlTokens = req.url.split('/');
-            numberOfRedirects = parseInt(urlTokens[1], 10);
-            responseCode = parseInt(urlTokens[2], 10);
+            numberOfRedirects = parseInt(urlTokens[urlTokens.length - 2], 10);
+            responseCode = parseInt(urlTokens[urlTokens.length - 1], 10);
 
             // redirect until all hops are covered
             if (numberOfRedirects > 1) {

--- a/test/fixtures/server.js
+++ b/test/fixtures/server.js
@@ -1,8 +1,8 @@
-const net = require('net'),
-    fs = require('fs'),
+const fs = require('fs'),
+    net = require('net'),
     path = require('path'),
-    https = require('https'),
     http = require('http'),
+    https = require('https'),
     enableServerDestroy = require('server-destroy');
 
 /**
@@ -116,6 +116,7 @@ function createSSLServer (opts) {
 /**
  * Simple redirect server for tests that emit hit events on each request captured.
  * Use the URL format: /<urlPath>/<numberOfRedirects>/<responseCode>
+ * The final redirect in redirect chain will happen at /<urlPath>
  *
  * @example
  * var s = createRedirectServer();
@@ -144,7 +145,7 @@ function createRedirectServer () {
 
             // redirect until all hops are covered
             if (numberOfRedirects > 1) {
-                redirectURL = urlTokens.slice(0, -2).join('/') + '/' + (numberOfRedirects - 1) + '/' + responseCode;
+                redirectURL = urlTokens.slice(0, -2).join('/') + `/${(numberOfRedirects - 1)}/${responseCode}`;
             }
             else {
                 redirectURL = urlTokens.slice(0, -2).join('/') + '/';
@@ -165,7 +166,7 @@ function createRedirectServer () {
 }
 
 module.exports = {
-    createRawEchoServer,
     createSSLServer,
+    createRawEchoServer,
     createRedirectServer
 };

--- a/test/fixtures/server.js
+++ b/test/fixtures/server.js
@@ -144,10 +144,10 @@ function createRedirectServer () {
 
             // redirect until all hops are covered
             if (numberOfRedirects > 1) {
-                redirectURL = urlTokens.slice(0, -2) + '/' + (numberOfRedirects - 1) + '/' + responseCode;
+                redirectURL = urlTokens.slice(0, -2).join('/') + '/' + (numberOfRedirects - 1) + '/' + responseCode;
             }
             else {
-                redirectURL = urlTokens.slice(0, -2) + '/';
+                redirectURL = urlTokens.slice(0, -2).join('/') + '/';
             }
 
             resp.writeHead(responseCode, {location: redirectURL});

--- a/test/integration/protocol-profile-behavior/sanity.test.js
+++ b/test/integration/protocol-profile-behavior/sanity.test.js
@@ -24,9 +24,9 @@ describe('protocolProfileBehavior', function () {
             });
         });
 
-        redirectServer.on('/', function (req, resp) {
-            resp.writeHead(200, {'content-type': 'text/plain'});
-            resp.end('okay');
+        redirectServer.on('/', function (req, res) {
+            res.writeHead(200, {'content-type': 'text/plain'});
+            res.end('okay');
         });
 
         redirectServer.listen(PORT, done);
@@ -427,14 +427,14 @@ describe('protocolProfileBehavior', function () {
             }),
             certificateId = 'test-certificate';
 
-        sslServer.on('/', function (req, resp) {
+        sslServer.on('/', function (req, res) {
             if (req.client.authorized) {
-                resp.writeHead(200, {'Content-Type': 'text/plain'});
-                resp.end('authorized\n');
+                res.writeHead(200, {'Content-Type': 'text/plain'});
+                res.end('authorized\n');
             }
             else {
-                resp.writeHead(401, {'Content-Type': 'text/plain'});
-                resp.end('unauthorized\n');
+                res.writeHead(401, {'Content-Type': 'text/plain'});
+                res.end('unauthorized\n');
             }
         });
 

--- a/test/integration/protocol-profile-behavior/sanity.test.js
+++ b/test/integration/protocol-profile-behavior/sanity.test.js
@@ -24,6 +24,7 @@ describe('protocolProfileBehavior', function () {
             });
         });
 
+        // This will be called on final redirect
         redirectServer.on('/', function (req, res) {
             res.writeHead(200, {'content-type': 'text/plain'});
             res.end('okay');

--- a/test/integration/requester-spec/redirect.test.js
+++ b/test/integration/requester-spec/redirect.test.js
@@ -21,9 +21,9 @@ describe('Requester Spec: redirect', function () {
             });
         });
 
-        redirectServer.on('/', function (req, resp) {
-            resp.writeHead(200, {'content-type': 'text/plain'});
-            resp.end('okay');
+        redirectServer.on('/', function (req, res) {
+            res.writeHead(200, {'content-type': 'text/plain'});
+            res.end('okay');
         });
 
         redirectServer.listen(PORT, done);

--- a/test/integration/requester-spec/redirect.test.js
+++ b/test/integration/requester-spec/redirect.test.js
@@ -21,6 +21,7 @@ describe('Requester Spec: redirect', function () {
             });
         });
 
+        // This will be called on final redirect
         redirectServer.on('/', function (req, res) {
             res.writeHead(200, {'content-type': 'text/plain'});
             res.end('okay');

--- a/test/integration/requester-spec/redirect.test.js
+++ b/test/integration/requester-spec/redirect.test.js
@@ -1,48 +1,40 @@
-var http = require('http'),
-    sinon = require('sinon'),
+var sinon = require('sinon'),
     expect = require('chai').expect,
-    enableServerDestroy = require('server-destroy');
+    server = require('../../fixtures/server');
 
 describe('Requester Spec: redirect', function () {
-    var server,
+    var redirectServer,
         testrun,
         hits = [],
         PORT = 5050,
         HOST = 'http://localhost:' + PORT;
 
     before(function (done) {
-        server = http.createServer(function (req, res) {
-            var hops;
+        redirectServer = server.createRedirectServer();
 
+        redirectServer.on('hit', function (req) {
             // keep track of all the requests made during redirects.
             hits.push({
                 url: req.url,
                 method: req.method,
                 headers: req.headers
             });
+        });
 
-            // path: /{n}
-            if ((/^\/\d+$/).test(req.url)) {
-                hops = parseInt(req.url.substring(1), 10) - 1;
+        redirectServer.on('/', function (req, resp) {
+            resp.writeHead(200, {'content-type': 'text/plain'});
+            resp.end('okay');
+        });
 
-                // redirect until all hops are covered
-                res.writeHead(302, {location: hops > 0 ? `/${hops}` : '/'});
-                res.end();
-            }
-            else {
-                res.writeHead(200, {'content-type': 'text/plain'});
-                res.end('okay');
-            }
-        }).listen(PORT, done);
-        enableServerDestroy(server);
+        redirectServer.listen(PORT, done);
     });
 
     after(function (done) {
-        server.destroy(done);
+        redirectServer.destroy(done);
     });
 
     describe('with followOriginalHttpMethod: false', function () {
-        var URL = HOST + '/1';
+        var URL = HOST + '/1/302';
 
         before(function (done) {
             hits = [];
@@ -92,7 +84,7 @@ describe('Requester Spec: redirect', function () {
     });
 
     describe('with followOriginalHttpMethod: true', function () {
-        var URL = HOST + '/1';
+        var URL = HOST + '/1/302';
 
         before(function (done) {
             hits = [];
@@ -142,7 +134,7 @@ describe('Requester Spec: redirect', function () {
     });
 
     describe('with removeRefererHeaderOnRedirect: false', function () {
-        var URL = HOST + '/1';
+        var URL = HOST + '/1/302';
 
         before(function (done) {
             hits = [];
@@ -194,7 +186,7 @@ describe('Requester Spec: redirect', function () {
     });
 
     describe('with removeRefererHeaderOnRedirect: true', function () {
-        var URL = HOST + '/1';
+        var URL = HOST + '/1/302';
 
         describe('should not have referer header', function () {
             before(function (done) {
@@ -301,7 +293,7 @@ describe('Requester Spec: redirect', function () {
     });
 
     describe('without maxRedirects', function () {
-        var URL = HOST + '/11';
+        var URL = HOST + '/11/302';
 
         before(function (done) {
             hits = [];
@@ -335,16 +327,16 @@ describe('Requester Spec: redirect', function () {
             var response = testrun.response.getCall(0);
 
             expect(response.args[0]).to.have.property('message',
-                `Exceeded maxRedirects. Probably stuck in a redirect loop ${HOST}/1`);
+                `Exceeded maxRedirects. Probably stuck in a redirect loop ${HOST}/1/302`);
 
             expect(hits).to.have.lengthOf(11);
-            expect(hits[10]).to.have.property('url', '/1');
+            expect(hits[10]).to.have.property('url', '/1/302');
             expect(hits[10]).to.have.property('method', 'GET');
         });
     });
 
     describe('with maxRedirects', function () {
-        var URL = HOST + '/11';
+        var URL = HOST + '/11/302';
 
         before(function (done) {
             hits = [];

--- a/test/integration/sanity/certificate.test.js
+++ b/test/integration/sanity/certificate.test.js
@@ -27,14 +27,14 @@ describe('certificates', function () {
                 requestCert: true
             });
 
-            sslServer.on('/', function (req, resp) {
+            sslServer.on('/', function (req, res) {
                 if (req.client.authorized) {
-                    resp.writeHead(200, {'Content-Type': 'text/plain'});
-                    resp.end('authorized\n');
+                    res.writeHead(200, {'Content-Type': 'text/plain'});
+                    res.end('authorized\n');
                 }
                 else {
-                    resp.writeHead(401, {'Content-Type': 'text/plain'});
-                    resp.end('unauthorized\n');
+                    res.writeHead(401, {'Content-Type': 'text/plain'});
+                    res.end('unauthorized\n');
                 }
             });
 
@@ -99,14 +99,14 @@ describe('certificates', function () {
 
             sslServer = server.createSSLServer();
 
-            sslServer.on('/', function (req, resp) {
+            sslServer.on('/', function (req, res) {
                 if (req.client.authorized) {
-                    resp.writeHead(200, {'Content-Type': 'text/plain'});
-                    resp.end('authorized\n');
+                    res.writeHead(200, {'Content-Type': 'text/plain'});
+                    res.end('authorized\n');
                 }
                 else {
-                    resp.writeHead(401, {'Content-Type': 'text/plain'});
-                    resp.end('unauthorized\n');
+                    res.writeHead(401, {'Content-Type': 'text/plain'});
+                    res.end('unauthorized\n');
                 }
             });
 

--- a/test/integration/sanity/redirect.test.js
+++ b/test/integration/sanity/redirect.test.js
@@ -12,7 +12,7 @@ describe('redirects', function() {
     before(function (done) {
         redirectServer = server.createRedirectServer();
 
-        redirectServer.on('/', function (req, resp) {
+        redirectServer.on('/', function (req, res) {
             var data = '';
 
             req.on('data', function (d) {
@@ -20,8 +20,8 @@ describe('redirects', function() {
             });
 
             req.once('end', function () {
-                resp.writeHead(200, {connection: 'close'});
-                resp.end(data);
+                res.writeHead(200, {connection: 'close'});
+                res.end(data);
             });
         });
 

--- a/test/integration/sanity/redirect.test.js
+++ b/test/integration/sanity/redirect.test.js
@@ -12,6 +12,7 @@ describe('redirects', function() {
     before(function (done) {
         redirectServer = server.createRedirectServer();
 
+        // This will be called on final redirect
         redirectServer.on('/', function (req, res) {
             var data = '';
 

--- a/test/integration/sanity/redirect.test.js
+++ b/test/integration/sanity/redirect.test.js
@@ -1,39 +1,35 @@
 var fs = require('fs'),
-    http = require('http'),
     sinon = require('sinon'),
     expect = require('chai').expect,
-    enableServerDestroy = require('server-destroy');
+    server = require('../../fixtures/server');
 
 describe('redirects', function() {
     var testrun,
-        server,
+        redirectServer,
         PORT = 5050,
         URL = 'http://localhost:' + PORT;
 
     before(function (done) {
-        server = http.createServer(function (req, res) {
+        redirectServer = server.createRedirectServer();
+
+        redirectServer.on('/', function (req, resp) {
             var data = '';
 
-            // /redirect/<responseCode>
-            if ((/^\/redirect\/(\d{3})$/).test(req.url)) {
-                res.writeHead(parseInt(req.url.substr(-3), 10), {location: '/'});
-
-                return res.end();
-            }
-
-
-            req.on('data', function (d) { data += d; });
+            req.on('data', function (d) {
+                data += d;
+            });
 
             req.once('end', function () {
-                res.writeHead(200, {connection: 'close'});
-                res.end(data);
+                resp.writeHead(200, {connection: 'close'});
+                resp.end(data);
             });
-        }).listen(PORT, done);
-        enableServerDestroy(server);
+        });
+
+        redirectServer.listen(PORT, done);
     });
 
     after(function (done) {
-        server.destroy(done);
+        redirectServer.destroy(done);
     });
 
     describe('sanity', function () {
@@ -77,7 +73,7 @@ describe('redirects', function() {
                 collection: {
                     item: [{
                         request: {
-                            url: URL + '/redirect/301',
+                            url: URL + '/1/301',
                             method: 'POST',
                             body: {
                                 mode: 'formdata',
@@ -124,7 +120,7 @@ describe('redirects', function() {
                 collection: {
                     item: [{
                         request: {
-                            url: URL + '/redirect/307',
+                            url: URL + '/1/307',
                             method: 'POST',
                             body: {
                                 mode: 'formdata',
@@ -179,7 +175,7 @@ describe('redirects', function() {
                 collection: {
                     item: [{
                         request: {
-                            url: URL + '/redirect/308',
+                            url: URL + '/1/308',
                             method: 'POST',
                             body: {
                                 mode: 'formdata',


### PR DESCRIPTION
Removed duplicate code for local redirect server from test files and added it in server.js module.

Also changed URL pattern for redirect server to make it more generic. Previously two patterns were used in different instances of redirect server:
1. /redirect/\<responseCode\>
2. /<n:hops>

Now it only uses one combined pattern:
1. /\<path\>[/<n:hops>/\<responseCode\>]
