### PR TITLE
Added time option for requester to get detailed timings in response

### DIFF
--- a/lib/requester/core.js
+++ b/lib/requester/core.js
@@ -208,6 +208,7 @@ module.exports = {
      * @param defaultOpts.followOriginalHttpMethod
      * @param defaultOpts.maxRedirects
      * @param defaultOpts.removeRefererHeaderOnRedirect
+     * @param defaultOpts.time
      * @param protocolProfileBehavior
      * @returns {{}}
      */

--- a/lib/requester/core.js
+++ b/lib/requester/core.js
@@ -208,7 +208,7 @@ module.exports = {
      * @param defaultOpts.followOriginalHttpMethod
      * @param defaultOpts.maxRedirects
      * @param defaultOpts.removeRefererHeaderOnRedirect
-     * @param defaultOpts.responseTimings
+     * @param defaultOpts.timings
      * @param protocolProfileBehavior
      * @returns {{}}
      */
@@ -234,7 +234,7 @@ module.exports = {
         options.jar = defaultOpts.cookieJar || true;
         options.timeout = defaultOpts.timeout;
         options.gzip = true;
-        options.time = defaultOpts.responseTimings;
+        options.time = defaultOpts.timings;
 
         // Ensures that "request" creates URL encoded formdata or querystring as
         // foo=bar&foo=baz instead of foo[0]=bar&foo[1]=baz

--- a/lib/requester/core.js
+++ b/lib/requester/core.js
@@ -208,7 +208,7 @@ module.exports = {
      * @param defaultOpts.followOriginalHttpMethod
      * @param defaultOpts.maxRedirects
      * @param defaultOpts.removeRefererHeaderOnRedirect
-     * @param defaultOpts.time
+     * @param defaultOpts.responseTimings
      * @param protocolProfileBehavior
      * @returns {{}}
      */
@@ -234,7 +234,7 @@ module.exports = {
         options.jar = defaultOpts.cookieJar || true;
         options.timeout = defaultOpts.timeout;
         options.gzip = true;
-        options.time = defaultOpts.time;
+        options.time = defaultOpts.responseTimings;
 
         // Ensures that "request" creates URL encoded formdata or querystring as
         // foo=bar&foo=baz instead of foo[0]=bar&foo[1]=baz

--- a/lib/requester/core.js
+++ b/lib/requester/core.js
@@ -233,6 +233,7 @@ module.exports = {
         options.jar = defaultOpts.cookieJar || true;
         options.timeout = defaultOpts.timeout;
         options.gzip = true;
+        options.time = defaultOpts.time;
 
         // Ensures that "request" creates URL encoded formdata or querystring as
         // foo=bar&foo=baz instead of foo[0]=bar&foo[1]=baz

--- a/lib/requester/requester-pool.js
+++ b/lib/requester/requester-pool.js
@@ -9,7 +9,7 @@ RequesterPool = function (options) {
             _.get(options, 'timeout.request'),
             _.get(options, 'timeout.global')
         ]), // validated later inside requester
-        responseTimings: _.get(options, 'requester.responseTimings', true),
+        timings: _.get(options, 'requester.timings', true),
         keepAlive: _.get(options, 'requester.keepAlive', true),
         cookieJar: _.get(options, 'requester.cookieJar'), // default set later in this constructor
         strictSSL: _.get(options, 'requester.strictSSL'),

--- a/lib/requester/requester-pool.js
+++ b/lib/requester/requester-pool.js
@@ -9,6 +9,7 @@ RequesterPool = function (options) {
             _.get(options, 'timeout.request'),
             _.get(options, 'timeout.global')
         ]), // validated later inside requester
+        time: _.get(options, 'requester.time', true),
         keepAlive: _.get(options, 'requester.keepAlive', true),
         cookieJar: _.get(options, 'requester.cookieJar'), // default set later in this constructor
         strictSSL: _.get(options, 'requester.strictSSL'),

--- a/lib/requester/requester-pool.js
+++ b/lib/requester/requester-pool.js
@@ -9,7 +9,7 @@ RequesterPool = function (options) {
             _.get(options, 'timeout.request'),
             _.get(options, 'timeout.global')
         ]), // validated later inside requester
-        time: _.get(options, 'requester.time', true),
+        responseTimings: _.get(options, 'requester.responseTimings', true),
         keepAlive: _.get(options, 'requester.keepAlive', true),
         cookieJar: _.get(options, 'requester.cookieJar'), // default set later in this constructor
         strictSSL: _.get(options, 'requester.strictSSL'),

--- a/lib/requester/requester.js
+++ b/lib/requester/requester.js
@@ -136,6 +136,7 @@ _.assign(Requester.prototype, /** @lends Requester.prototype */ {
             }
 
             var responseString,
+                responseTimings,
                 responseTime,
                 responseJSON,
                 cookies,
@@ -161,6 +162,10 @@ _.assign(Requester.prototype, /** @lends Requester.prototype */ {
                     acc.push(toChromeCookie(cookie));
                 }, []) : [];
 
+            if (res.timingStart) {
+                responseTimings = _.merge({}, {start: res.timingStart}, res.timings);
+            }
+
             // Response in the SDK format
             response = new sdk.Response({ // @todo get rid of jsonifyResponse
                 code: responseJSON.statusCode,
@@ -169,7 +174,7 @@ _.assign(Requester.prototype, /** @lends Requester.prototype */ {
                 stream: resBody,
                 responseTime: responseTime,
                 timingStart: res.timingStart,
-                timings: res.timings
+                timings: responseTimings
             });
 
             // Insert the missing sent headers in the request object, so that they get bubbled up into the UI

--- a/lib/requester/requester.js
+++ b/lib/requester/requester.js
@@ -163,7 +163,10 @@ _.assign(Requester.prototype, /** @lends Requester.prototype */ {
                 }, []) : [];
 
             if (res && res.timingStart) {
-                timings = _.merge({start: res.timingStart}, res.timings);
+                timings = {
+                    start: res.timingStart,
+                    offset: res.timings
+                };
             }
 
             // Response in the SDK format

--- a/lib/requester/requester.js
+++ b/lib/requester/requester.js
@@ -169,8 +169,7 @@ _.assign(Requester.prototype, /** @lends Requester.prototype */ {
                 stream: resBody,
                 responseTime: responseTime,
                 timingStart: res.timingStart,
-                timings: res.timings,
-                timingPhases: res.timingPhases
+                timings: res.timings
             });
 
             // Insert the missing sent headers in the request object, so that they get bubbled up into the UI

--- a/lib/requester/requester.js
+++ b/lib/requester/requester.js
@@ -162,7 +162,7 @@ _.assign(Requester.prototype, /** @lends Requester.prototype */ {
                     acc.push(toChromeCookie(cookie));
                 }, []) : [];
 
-            if (res.timingStart) {
+            if (res && res.timingStart) {
                 timings = _.merge({start: res.timingStart}, res.timings);
             }
 
@@ -173,7 +173,6 @@ _.assign(Requester.prototype, /** @lends Requester.prototype */ {
                 header: _.transform(responseJSON.headers, transformMultiValueHeaders, []),
                 stream: resBody,
                 responseTime: responseTime,
-                timingStart: res.timingStart,
                 timings: timings
             });
 

--- a/lib/requester/requester.js
+++ b/lib/requester/requester.js
@@ -136,7 +136,7 @@ _.assign(Requester.prototype, /** @lends Requester.prototype */ {
             }
 
             var responseString,
-                responseTimings,
+                timings,
                 responseTime,
                 responseJSON,
                 cookies,
@@ -163,7 +163,7 @@ _.assign(Requester.prototype, /** @lends Requester.prototype */ {
                 }, []) : [];
 
             if (res.timingStart) {
-                responseTimings = _.merge({}, {start: res.timingStart}, res.timings);
+                timings = _.merge({start: res.timingStart}, res.timings);
             }
 
             // Response in the SDK format
@@ -174,7 +174,7 @@ _.assign(Requester.prototype, /** @lends Requester.prototype */ {
                 stream: resBody,
                 responseTime: responseTime,
                 timingStart: res.timingStart,
-                timings: responseTimings
+                timings: timings
             });
 
             // Insert the missing sent headers in the request object, so that they get bubbled up into the UI

--- a/lib/requester/requester.js
+++ b/lib/requester/requester.js
@@ -167,7 +167,10 @@ _.assign(Requester.prototype, /** @lends Requester.prototype */ {
                 status: res && res.statusMessage,
                 header: _.transform(responseJSON.headers, transformMultiValueHeaders, []),
                 stream: resBody,
-                responseTime: responseTime
+                responseTime: responseTime,
+                timingStart: res.timingStart,
+                timings: res.timings,
+                timingPhases: res.timingPhases
             });
 
             // Insert the missing sent headers in the request object, so that they get bubbled up into the UI

--- a/package-lock.json
+++ b/package-lock.json
@@ -1977,9 +1977,9 @@
       }
     },
     "postman-collection": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/postman-collection/-/postman-collection-3.4.2.tgz",
-      "integrity": "sha512-6A2YroLuw0jLHSqC9uKVJul9UsEHRPOeLnU0HKLholwENInNf1LI0Kpy2g3lIW87yjki2LqKk/hiZg8NxrGOqQ==",
+      "version": "3.4.3-beta.1",
+      "resolved": "https://registry.npmjs.org/postman-collection/-/postman-collection-3.4.3-beta.1.tgz",
+      "integrity": "sha512-5A+91WiKghHpUDOzoDc4eVuyAhRnsKO8pyxU8mf/ns9R9mM6TtHwYeHD7hVQzvFDwNKKbXBJjtZFjlm358p7iw==",
       "requires": {
         "escape-html": "1.0.3",
         "file-type": "3.9.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -245,7 +245,7 @@
     },
     "bluebird": {
       "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
+      "resolved": "http://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
       "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE="
     },
     "brace-expansion": {
@@ -571,7 +571,7 @@
       "dependencies": {
         "marked": {
           "version": "0.3.19",
-          "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.19.tgz",
+          "resolved": "http://registry.npmjs.org/marked/-/marked-0.3.19.tgz",
           "integrity": "sha512-ea2eGWOqNxPcXv8dyERdSr/6FmzvWwzjMxpfGB/sbMccXoct+xY+YukPD+QTUZwyvK7BZwcr4m21WBOW41pAkg==",
           "dev": true
         }
@@ -689,7 +689,7 @@
         },
         "source-map": {
           "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
           "integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
           "dev": true,
           "optional": true,
@@ -1322,7 +1322,7 @@
       "dependencies": {
         "async": {
           "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "resolved": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
           "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
           "dev": true
         },
@@ -1420,13 +1420,13 @@
         },
         "marked": {
           "version": "0.3.19",
-          "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.19.tgz",
+          "resolved": "http://registry.npmjs.org/marked/-/marked-0.3.19.tgz",
           "integrity": "sha512-ea2eGWOqNxPcXv8dyERdSr/6FmzvWwzjMxpfGB/sbMccXoct+xY+YukPD+QTUZwyvK7BZwcr4m21WBOW41pAkg==",
           "dev": true
         },
         "underscore": {
           "version": "1.8.3",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+          "resolved": "http://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
           "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
           "dev": true
         }
@@ -1665,13 +1665,13 @@
     },
     "minimist": {
       "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
       "dev": true
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "requires": {
@@ -1705,7 +1705,7 @@
       "dependencies": {
         "commander": {
           "version": "2.15.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+          "resolved": "http://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
           "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
           "dev": true
         },
@@ -1896,7 +1896,7 @@
     },
     "os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
@@ -1921,7 +1921,7 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
@@ -2132,7 +2132,7 @@
       "dependencies": {
         "array-back": {
           "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
+          "resolved": "http://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
           "integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
           "dev": true,
           "requires": {
@@ -2174,7 +2174,7 @@
       "dependencies": {
         "array-back": {
           "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
+          "resolved": "http://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
           "integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
           "dev": true,
           "requires": {
@@ -2216,7 +2216,7 @@
       "dependencies": {
         "underscore": {
           "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
+          "resolved": "http://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
           "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag=",
           "dev": true
         }
@@ -2224,7 +2224,7 @@
     },
     "resolve": {
       "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+      "resolved": "http://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
       "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
       "dev": true
     },
@@ -2283,7 +2283,7 @@
     },
     "safe-regex": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "dev": true,
       "requires": {
@@ -2410,7 +2410,7 @@
       "dependencies": {
         "array-back": {
           "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
+          "resolved": "http://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
           "integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
           "dev": true,
           "requires": {
@@ -2426,7 +2426,7 @@
     },
     "sprintf-js": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "resolved": "http://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
@@ -2471,7 +2471,7 @@
       "dependencies": {
         "array-back": {
           "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
+          "resolved": "http://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
           "integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
           "dev": true,
           "requires": {
@@ -2584,7 +2584,7 @@
     },
     "text-encoding": {
       "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
+      "resolved": "http://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
       "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
       "dev": true
     },
@@ -2596,7 +2596,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
@@ -2680,7 +2680,7 @@
     },
     "underscore": {
       "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
+      "resolved": "http://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
       "integrity": "sha1-a7rwh3UA02vjTsqlhODbn+8DUgk="
     },
     "underscore-contrib": {
@@ -2694,7 +2694,7 @@
       "dependencies": {
         "underscore": {
           "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
+          "resolved": "http://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
           "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag=",
           "dev": true
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "postman-runtime",
-  "version": "7.6.1",
+  "version": "7.7.0-beta.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postman-runtime",
-  "version": "7.6.1",
+  "version": "7.7.0-beta.1",
   "description": "Underlying library of executing Postman Collections (used by Newman)",
   "main": "index.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "inherits": "2.0.3",
     "lodash": "4.17.11",
     "node-oauth1": "1.2.2",
-    "postman-collection": "3.4.2",
+    "postman-collection": "3.4.3-beta.1",
     "postman-request": "2.88.1-postman.5",
     "postman-sandbox": "3.2.3",
     "resolve-from": "4.0.0",

--- a/test/integration/requester-spec/timing.test.js
+++ b/test/integration/requester-spec/timing.test.js
@@ -1,0 +1,77 @@
+var expect = require('chai').expect;
+
+describe('Requester Spec: timing', function () {
+    var testrun,
+        URL = 'http://postman-echo.com/get',
+        collection = {
+            item: [{
+                request: {
+                    url: URL,
+                    method: 'GET'
+                }
+            }]
+        };
+
+    describe('with time: undefined', function () {
+        before(function (done) {
+            this.run({
+                collection: collection
+            }, function (err, results) {
+                testrun = results;
+                done(err);
+            });
+        });
+
+        it('should include timing information by default', function () {
+            var response = testrun.response.getCall(0).args[2];
+
+            expect(response).to.have.property('timingStart');
+            expect(response).to.have.property('timings');
+            expect(response).to.have.property('timingPhases');
+        });
+    });
+
+    describe('with time: true', function () {
+        before(function (done) {
+            this.run({
+                requester: {
+                    time: true
+                },
+                collection: collection
+            }, function (err, results) {
+                testrun = results;
+                done(err);
+            });
+        });
+
+        it('should include timing information', function () {
+            var response = testrun.response.getCall(0).args[2];
+
+            expect(response).to.have.property('timingStart');
+            expect(response).to.have.property('timings');
+            expect(response).to.have.property('timingPhases');
+        });
+    });
+
+    describe('with time: false', function () {
+        before(function (done) {
+            this.run({
+                requester: {
+                    time: false
+                },
+                collection: collection
+            }, function (err, results) {
+                testrun = results;
+                done(err);
+            });
+        });
+
+        it('should not include timing information', function () {
+            var response = testrun.response.getCall(0).args[2];
+
+            expect(response).to.not.have.property('timingStart');
+            expect(response).to.not.have.property('timings');
+            expect(response).to.not.have.property('timingPhases');
+        });
+    });
+});

--- a/test/integration/requester-spec/timing.test.js
+++ b/test/integration/requester-spec/timing.test.js
@@ -1,6 +1,6 @@
 var expect = require('chai').expect;
 
-describe('Requester Spec: responseTimings', function () {
+describe('Requester Spec: timings', function () {
     var testrun,
         URL = 'http://postman-echo.com/get',
         collection = {
@@ -12,7 +12,7 @@ describe('Requester Spec: responseTimings', function () {
             }]
         };
 
-    describe('with responseTimings: undefined', function () {
+    describe('with timings: undefined', function () {
         before(function (done) {
             this.run({
                 collection: collection
@@ -37,11 +37,11 @@ describe('Requester Spec: responseTimings', function () {
         });
     });
 
-    describe('with responseTimings: true', function () {
+    describe('with timings: true', function () {
         before(function (done) {
             this.run({
                 requester: {
-                    responseTimings: true
+                    timings: true
                 },
                 collection: collection
             }, function (err, results) {
@@ -65,11 +65,11 @@ describe('Requester Spec: responseTimings', function () {
         });
     });
 
-    describe('with responseTimings: false', function () {
+    describe('with timings: false', function () {
         before(function (done) {
             this.run({
                 requester: {
-                    responseTimings: false
+                    timings: false
                 },
                 collection: collection
             }, function (err, results) {

--- a/test/integration/requester-spec/timing.test.js
+++ b/test/integration/requester-spec/timing.test.js
@@ -25,8 +25,9 @@ describe('Requester Spec: responseTimings', function () {
         it('should include timing information by default', function () {
             var response = testrun.response.getCall(0).args[2];
 
-            expect(response).to.include.all.keys('timingStart', 'timings');
+            expect(response).to.have.property('timings');
             expect(response.timings).to.be.an('object').that.have.all.keys([
+                'start',
                 'socket',
                 'lookup',
                 'connect',
@@ -52,8 +53,9 @@ describe('Requester Spec: responseTimings', function () {
         it('should include timing information', function () {
             var response = testrun.response.getCall(0).args[2];
 
-            expect(response).to.include.all.keys('timingStart', 'timings');
+            expect(response).to.have.property('timings');
             expect(response.timings).to.be.an('object').that.have.all.keys([
+                'start',
                 'socket',
                 'lookup',
                 'connect',
@@ -79,7 +81,7 @@ describe('Requester Spec: responseTimings', function () {
         it('should not include timing information', function () {
             var response = testrun.response.getCall(0).args[2];
 
-            expect(response).to.not.include.all.keys('timingStart', 'timings');
+            expect(response).to.not.have.property('timings');
         });
     });
 });

--- a/test/integration/requester-spec/timing.test.js
+++ b/test/integration/requester-spec/timing.test.js
@@ -2,7 +2,7 @@ var expect = require('chai').expect;
 
 describe('Requester Spec: timings', function () {
     var testrun,
-        URL = 'http://postman-echo.com/get',
+        URL = 'https://postman-echo.com/get',
         collection = {
             item: [{
                 request: {
@@ -30,6 +30,14 @@ describe('Requester Spec: timings', function () {
                 'start',
                 'offset'
             ]);
+            expect(response.timings.offset).to.be.an('object').that.includes.all.keys([
+                'socket',
+                'lookup',
+                'connect',
+                'secureConnect',
+                'response',
+                'end'
+            ]);
         });
     });
 
@@ -53,6 +61,14 @@ describe('Requester Spec: timings', function () {
             expect(response.timings).to.be.an('object').that.has.all.keys([
                 'start',
                 'offset'
+            ]);
+            expect(response.timings.offset).to.be.an('object').that.includes.all.keys([
+                'socket',
+                'lookup',
+                'connect',
+                'secureConnect',
+                'response',
+                'end'
             ]);
         });
     });

--- a/test/integration/requester-spec/timing.test.js
+++ b/test/integration/requester-spec/timing.test.js
@@ -26,7 +26,7 @@ describe('Requester Spec: timings', function () {
             var response = testrun.response.getCall(0).args[2];
 
             expect(response).to.have.property('timings');
-            expect(response.timings).to.be.an('object').that.have.all.keys([
+            expect(response.timings).to.be.an('object').that.has.all.keys([
                 'start',
                 'socket',
                 'lookup',
@@ -54,7 +54,7 @@ describe('Requester Spec: timings', function () {
             var response = testrun.response.getCall(0).args[2];
 
             expect(response).to.have.property('timings');
-            expect(response.timings).to.be.an('object').that.have.all.keys([
+            expect(response.timings).to.be.an('object').that.has.all.keys([
                 'start',
                 'socket',
                 'lookup',

--- a/test/integration/requester-spec/timing.test.js
+++ b/test/integration/requester-spec/timing.test.js
@@ -25,13 +25,14 @@ describe('Requester Spec: responseTimings', function () {
         it('should include timing information by default', function () {
             var response = testrun.response.getCall(0).args[2];
 
-            expect(response).to.have.property('timingStart');
-            expect(response).to.have.property('timings');
-            expect(response.timings).to.have.property('socket');
-            expect(response.timings).to.have.property('lookup');
-            expect(response.timings).to.have.property('connect');
-            expect(response.timings).to.have.property('response');
-            expect(response.timings).to.have.property('end');
+            expect(response).to.include.all.keys('timingStart', 'timings');
+            expect(response.timings).to.be.an('object').that.have.all.keys([
+                'socket',
+                'lookup',
+                'connect',
+                'response',
+                'end'
+            ]);
         });
     });
 
@@ -51,13 +52,14 @@ describe('Requester Spec: responseTimings', function () {
         it('should include timing information', function () {
             var response = testrun.response.getCall(0).args[2];
 
-            expect(response).to.have.property('timingStart');
-            expect(response).to.have.property('timings');
-            expect(response.timings).to.have.property('socket');
-            expect(response.timings).to.have.property('lookup');
-            expect(response.timings).to.have.property('connect');
-            expect(response.timings).to.have.property('response');
-            expect(response.timings).to.have.property('end');
+            expect(response).to.include.all.keys('timingStart', 'timings');
+            expect(response.timings).to.be.an('object').that.have.all.keys([
+                'socket',
+                'lookup',
+                'connect',
+                'response',
+                'end'
+            ]);
         });
     });
 
@@ -77,8 +79,7 @@ describe('Requester Spec: responseTimings', function () {
         it('should not include timing information', function () {
             var response = testrun.response.getCall(0).args[2];
 
-            expect(response).to.not.have.property('timingStart');
-            expect(response).to.not.have.property('timings');
+            expect(response).to.not.include.all.keys('timingStart', 'timings');
         });
     });
 });

--- a/test/integration/requester-spec/timing.test.js
+++ b/test/integration/requester-spec/timing.test.js
@@ -1,6 +1,6 @@
 var expect = require('chai').expect;
 
-describe('Requester Spec: timing', function () {
+describe('Requester Spec: responseTimings', function () {
     var testrun,
         URL = 'http://postman-echo.com/get',
         collection = {
@@ -12,7 +12,7 @@ describe('Requester Spec: timing', function () {
             }]
         };
 
-    describe('with time: undefined', function () {
+    describe('with responseTimings: undefined', function () {
         before(function (done) {
             this.run({
                 collection: collection
@@ -27,15 +27,19 @@ describe('Requester Spec: timing', function () {
 
             expect(response).to.have.property('timingStart');
             expect(response).to.have.property('timings');
-            expect(response).to.have.property('timingPhases');
+            expect(response.timings).to.have.property('socket');
+            expect(response.timings).to.have.property('lookup');
+            expect(response.timings).to.have.property('connect');
+            expect(response.timings).to.have.property('response');
+            expect(response.timings).to.have.property('end');
         });
     });
 
-    describe('with time: true', function () {
+    describe('with responseTimings: true', function () {
         before(function (done) {
             this.run({
                 requester: {
-                    time: true
+                    responseTimings: true
                 },
                 collection: collection
             }, function (err, results) {
@@ -49,15 +53,19 @@ describe('Requester Spec: timing', function () {
 
             expect(response).to.have.property('timingStart');
             expect(response).to.have.property('timings');
-            expect(response).to.have.property('timingPhases');
+            expect(response.timings).to.have.property('socket');
+            expect(response.timings).to.have.property('lookup');
+            expect(response.timings).to.have.property('connect');
+            expect(response.timings).to.have.property('response');
+            expect(response.timings).to.have.property('end');
         });
     });
 
-    describe('with time: false', function () {
+    describe('with responseTimings: false', function () {
         before(function (done) {
             this.run({
                 requester: {
-                    time: false
+                    responseTimings: false
                 },
                 collection: collection
             }, function (err, results) {
@@ -71,7 +79,6 @@ describe('Requester Spec: timing', function () {
 
             expect(response).to.not.have.property('timingStart');
             expect(response).to.not.have.property('timings');
-            expect(response).to.not.have.property('timingPhases');
         });
     });
 });

--- a/test/integration/requester-spec/timing.test.js
+++ b/test/integration/requester-spec/timing.test.js
@@ -28,11 +28,7 @@ describe('Requester Spec: timings', function () {
             expect(response).to.have.property('timings');
             expect(response.timings).to.be.an('object').that.has.all.keys([
                 'start',
-                'socket',
-                'lookup',
-                'connect',
-                'response',
-                'end'
+                'offset'
             ]);
         });
     });
@@ -56,11 +52,7 @@ describe('Requester Spec: timings', function () {
             expect(response).to.have.property('timings');
             expect(response.timings).to.be.an('object').that.has.all.keys([
                 'start',
-                'socket',
-                'lookup',
-                'connect',
-                'response',
-                'end'
+                'offset'
             ]);
         });
     });

--- a/test/unit/requester-core.test.js
+++ b/test/unit/requester-core.test.js
@@ -41,7 +41,8 @@ describe('requester util', function () {
                 maxRedirects: undefined,
                 removeRefererHeader: undefined,
                 encoding: null,
-                agentOptions: {keepAlive: undefined}
+                agentOptions: {keepAlive: undefined},
+                time: undefined
             });
         });
 
@@ -75,7 +76,8 @@ describe('requester util', function () {
                 maxRedirects: undefined,
                 removeRefererHeader: undefined,
                 encoding: null,
-                agentOptions: {keepAlive: undefined}
+                agentOptions: {keepAlive: undefined},
+                time: undefined
             });
         });
 
@@ -205,7 +207,8 @@ describe('requester util', function () {
                 maxRedirects: 15,
                 removeRefererHeader: true,
                 encoding: null,
-                agentOptions: {keepAlive: undefined}
+                agentOptions: {keepAlive: undefined},
+                time: undefined
             });
         });
     });


### PR DESCRIPTION
Added time option to get detailed timing information about different phases of a request. Now you can use {time:<Boolean>} (true by default) in requester options for the same. The timing information will be added in response object returned in Requester.request function's callback.

**Note:** Need to merge https://github.com/postmanlabs/postman-collection/pull/796 first and bump SDK version(beta) for green builds. ✅

- [x] Bump `postman-collection` version(beta)