### PR TITLE
Update Hawk auth tests to use correct identifier for hawk auth app param

### DIFF
--- a/test/fixtures/auth-requests.json
+++ b/test/fixtures/auth-requests.json
@@ -168,7 +168,7 @@
                 "user": "asda",
                 "saveHelperData": true,
                 "extraData": "skjdfklsjhdflkjhsdf",
-                "appId": "",
+                "app": "someAppId",
                 "delegation": ""
             }
         },

--- a/test/integration/auth-methods/hawk.test.js
+++ b/test/integration/auth-methods/hawk.test.js
@@ -19,7 +19,7 @@ describe('hawk auth', function () {
                                 saveHelperData: true,
                                 nonce: 'eFRP2o',
                                 extraData: 'skjdfklsjhdflkjhsdf',
-                                appId: '',
+                                app: 'someAppId',
                                 delegation: '',
                                 timestamp: ''
                             }
@@ -33,6 +33,19 @@ describe('hawk auth', function () {
             testrun = results;
             done(err);
         });
+    });
+
+    it('should include hawk auth parameters in request header', function() {
+        var request = testrun.request.getCall(0).args[3],
+            header = request.headers.members[0];
+
+        expect(header).to.have.have.property('key').eq('Authorization');
+        expect(header).to.have.have.property('value').include('Hawk id="dh37fgj492je"');
+        expect(header).to.have.have.property('value').include('ts=');
+        expect(header).to.have.have.property('value').include('nonce="eFRP2o"');
+        expect(header).to.have.have.property('value').include('ext="skjdfklsjhdflkjhsdf"');
+        expect(header).to.have.have.property('value').include('mac=');
+        expect(header).to.have.have.property('value').include('app="someAppId"');
     });
 
     it('should have completed the run', function () {

--- a/test/integration/auth-methods/hawk.test.js
+++ b/test/integration/auth-methods/hawk.test.js
@@ -39,13 +39,13 @@ describe('hawk auth', function () {
         var request = testrun.request.getCall(0).args[3],
             header = request.headers.members[0];
 
-        expect(header).to.have.have.property('key').eq('Authorization');
-        expect(header).to.have.have.property('value').include('Hawk id="dh37fgj492je"');
-        expect(header).to.have.have.property('value').include('ts=');
-        expect(header).to.have.have.property('value').include('nonce="eFRP2o"');
-        expect(header).to.have.have.property('value').include('ext="skjdfklsjhdflkjhsdf"');
-        expect(header).to.have.have.property('value').include('mac=');
-        expect(header).to.have.have.property('value').include('app="someAppId"');
+        expect(header).to.have.have.property('key', 'Authorization');
+        expect(header).to.have.have.property('value').that.include('Hawk id="dh37fgj492je"');
+        expect(header).to.have.have.property('value').that.include('ts=');
+        expect(header).to.have.have.property('value').that.include('nonce="eFRP2o"');
+        expect(header).to.have.have.property('value').that.include('ext="skjdfklsjhdflkjhsdf"');
+        expect(header).to.have.have.property('value').that.include('mac=');
+        expect(header).to.have.have.property('value').that.include('app="someAppId"');
     });
 
     it('should have completed the run', function () {

--- a/test/integration/sanity/hawk-auth.test.js
+++ b/test/integration/sanity/hawk-auth.test.js
@@ -18,7 +18,7 @@ describe('Hawk authentication', function () {
                                 saveHelperData: true,
                                 nonce: 'eFRP2o',
                                 extraData: 'skjdfklsjhdflkjhsdf',
-                                appId: '',
+                                app: 'someAppId',
                                 delegation: '',
                                 timestamp: ''
                             }
@@ -32,6 +32,19 @@ describe('Hawk authentication', function () {
             testrun = results;
             done(err);
         });
+    });
+
+    it('should include hawk auth parameters in request header', function() {
+        var request = testrun.request.getCall(0).args[3],
+            header = request.headers.members[0];
+
+        expect(header).to.have.have.property('key').eq('Authorization');
+        expect(header).to.have.have.property('value').include('Hawk id="dh37fgj492je"');
+        expect(header).to.have.have.property('value').include('ts=');
+        expect(header).to.have.have.property('value').include('nonce="eFRP2o"');
+        expect(header).to.have.have.property('value').include('ext="skjdfklsjhdflkjhsdf"');
+        expect(header).to.have.have.property('value').include('mac=');
+        expect(header).to.have.have.property('value').include('app="someAppId"');
     });
 
     it('should have authorized successfully', function () {

--- a/test/integration/sanity/hawk-auth.test.js
+++ b/test/integration/sanity/hawk-auth.test.js
@@ -38,13 +38,13 @@ describe('Hawk authentication', function () {
         var request = testrun.request.getCall(0).args[3],
             header = request.headers.members[0];
 
-        expect(header).to.have.have.property('key').eq('Authorization');
-        expect(header).to.have.have.property('value').include('Hawk id="dh37fgj492je"');
-        expect(header).to.have.have.property('value').include('ts=');
-        expect(header).to.have.have.property('value').include('nonce="eFRP2o"');
-        expect(header).to.have.have.property('value').include('ext="skjdfklsjhdflkjhsdf"');
-        expect(header).to.have.have.property('value').include('mac=');
-        expect(header).to.have.have.property('value').include('app="someAppId"');
+        expect(header).to.have.have.property('key', 'Authorization');
+        expect(header).to.have.have.property('value').that.include('Hawk id="dh37fgj492je"');
+        expect(header).to.have.have.property('value').that.include('ts=');
+        expect(header).to.have.have.property('value').that.include('nonce="eFRP2o"');
+        expect(header).to.have.have.property('value').that.include('ext="skjdfklsjhdflkjhsdf"');
+        expect(header).to.have.have.property('value').that.include('mac=');
+        expect(header).to.have.have.property('value').that.include('app="someAppId"');
     });
 
     it('should have authorized successfully', function () {


### PR DESCRIPTION
Hawk auth tests currently uses 'appId' to refer to app paramter, which isn't recognized by postman-runtime where it's defined as 'app' thus app parameter is not inserted into request headers.