### PR TITLE
Test: restore all sinon spies using sandbox

### DIFF
--- a/test/integration/auth-methods/control-flow/errors.test.js
+++ b/test/integration/auth-methods/control-flow/errors.test.js
@@ -1,4 +1,4 @@
-var sinon = require('sinon'),
+var sinon = require('sinon').createSandbox(),
     expect = require('chai').expect,
     AuthLoader = require('../../../../lib/authorizer/index').AuthLoader;
 
@@ -20,6 +20,10 @@ describe('auth control flow', function () {
             }
         }
     };
+
+    after(function () {
+        sinon.restore();
+    });
 
     describe('with error in pre', function () {
         var testrun,

--- a/test/integration/auth-methods/control-flow/typical.test.js
+++ b/test/integration/auth-methods/control-flow/typical.test.js
@@ -1,4 +1,4 @@
-var sinon = require('sinon'),
+var sinon = require('sinon').createSandbox(),
     expect = require('chai').expect,
     AuthLoader = require('../../../../lib/authorizer/index').AuthLoader;
 
@@ -20,6 +20,10 @@ describe('auth control flow', function () {
             }
         }
     };
+
+    after(function () {
+        sinon.restore();
+    });
 
     describe('with working init, pre, and post', function () {
         var testrun,

--- a/test/integration/bootstrap.js
+++ b/test/integration/bootstrap.js
@@ -7,9 +7,9 @@ var _ = require('lodash'),
     runtime;
 
 runtime = function (spec, done) {
-    // reset the internal state of all spies created in the previous run
-    // Refer: https://sinonjs.org/releases/latest/sandbox/
-    sinon.reset();
+    // restores all spies created through sandbox in the previous run
+    // @todo avoid restore on the first run
+    sinon.restore();
 
     _.isString(spec) && (spec = require('./' + spec));
 
@@ -39,4 +39,6 @@ before(function () {
 
 after(function () {
     delete global.expect;
+    // restores all spies created through sandbox in the previous run
+    sinon.restore();
 });

--- a/test/integration/request-flow/intermediate-requests.test.js
+++ b/test/integration/request-flow/intermediate-requests.test.js
@@ -1,4 +1,4 @@
-var sinon = require('sinon'),
+var sinon = require('sinon').createSandbox(),
     AuthLoader = require('../../../lib/authorizer').AuthLoader,
     expect = require('chai').expect;
 
@@ -20,6 +20,10 @@ describe('intermediate requests from auth', function () {
             }
         }
     };
+
+    after(function () {
+        sinon.restore();
+    });
 
     describe('with intermediate request in pre', function () {
         var testrun,

--- a/test/integration/sanity/control-flow.test.js
+++ b/test/integration/sanity/control-flow.test.js
@@ -1,5 +1,5 @@
 var _ = require('lodash'),
-    sinon = require('sinon'),
+    sinon = require('sinon').createSandbox(),
     expect = require('chai').expect,
     Collection = require('postman-collection').Collection,
     Runner = require('../../../index.js').Runner;
@@ -30,6 +30,10 @@ describe('Control Flow', function () {
         _.forEach(_.keys(Runner.Run.triggers), function (eventName) {
             callbacks[eventName] = sinon.spy();
         });
+    });
+
+    after(function () {
+        sinon.restore();
     });
 
     it('should allow a run to be aborted', function (done) {

--- a/test/integration/sanity/systemproxy.test.js
+++ b/test/integration/sanity/systemproxy.test.js
@@ -1,9 +1,13 @@
 var proxy = require('http-proxy'),
-    sinon = require('sinon'),
+    sinon = require('sinon').createSandbox(),
     expect = require('chai').expect,
     sdk = require('postman-collection');
 
 describe('systemProxy', function () {
+    after(function () {
+        sinon.restore();
+    });
+
     describe('valid output config', function () {
         var server,
             testrun,

--- a/test/unit/backpack-ensure.test.js
+++ b/test/unit/backpack-ensure.test.js
@@ -1,8 +1,12 @@
 var expect = require('chai').expect,
-    sinon = require('sinon');
+    sinon = require('sinon').createSandbox();
 
 describe('backpack.ensure', function () {
     var ensure = require('../../lib/backpack').ensure;
+
+    after(function () {
+        sinon.restore();
+    });
 
     it('should return a function if the original argument is a function and not otherwise', function () {
         var fn = function () { return 1; };

--- a/test/unit/backpack-multiback.test.js
+++ b/test/unit/backpack-multiback.test.js
@@ -1,8 +1,12 @@
 var expect = require('chai').expect,
-    sinon = require('sinon');
+    sinon = require('sinon').createSandbox();
 
 describe('backpack.multiback', function () {
     var multiback = require('../../lib/backpack').multiback;
+
+    after(function () {
+        sinon.restore();
+    });
 
     it('should exist as a function', function () {
         expect(multiback).to.be.ok;

--- a/test/unit/backpack-normalise.test.js
+++ b/test/unit/backpack-normalise.test.js
@@ -1,8 +1,12 @@
 var expect = require('chai').expect,
-    sinon = require('sinon');
+    sinon = require('sinon').createSandbox();
 
 describe('backpack.normalise', function () {
     var normalise = require('../../lib/backpack').normalise;
+
+    after(function () {
+        sinon.restore();
+    });
 
     it('should exist as a function', function () {
         expect(normalise).to.be.ok;

--- a/test/unit/backpack-timeback.test.js
+++ b/test/unit/backpack-timeback.test.js
@@ -1,8 +1,12 @@
 var expect = require('chai').expect,
-    sinon = require('sinon');
+    sinon = require('sinon').createSandbox();
 
 describe('backpack.timeback', function () {
     var timeback = require('../../lib/backpack').timeback;
+
+    after(function () {
+        sinon.restore();
+    });
 
     it('should exist as a function', function () {
         expect(timeback).to.be.ok;

--- a/test/unit/runner-util.test.js
+++ b/test/unit/runner-util.test.js
@@ -1,8 +1,12 @@
-var sinon = require('sinon'),
+var sinon = require('sinon').createSandbox(),
     expect = require('chai').expect,
     runnerUtil = require('../../lib/runner/util');
 
 describe('runner util', function () {
+    after(function () {
+        sinon.restore();
+    });
+
     describe('.safeCall', function () {
         it('should not throw an error if a non function is passed', function () {
             var err = runnerUtil.safeCall('not a function');


### PR DESCRIPTION
Extends #738

- Update bootstrap reset -> restore, reset clears the state whereas restore removes the sinon instance from the function.
- Restores all the spies created in the test to avoid memory leak in Node v6 and below.
- sinon by default is a sandbox instance but it's better to create individual sandbox per test suite to make sure it won't affect others.
- sandbox allows to restore all the spies/stubs created in one go but its better if these functions are restored in their individual `after` block(unlike currently: top level `after`).
