### PR TITLE
Additional request-response timings properties

### DIFF
--- a/lib/requester/requester.js
+++ b/lib/requester/requester.js
@@ -163,6 +163,7 @@ _.assign(Requester.prototype, /** @lends Requester.prototype */ {
             responseTime = Date.now() - startTime;
 
             if (res && res.timingStart) {
+                // runtime + postman-request initialization time
                 requestStart = res.timingStart - startTime;
 
                 timings = {
@@ -172,6 +173,7 @@ _.assign(Requester.prototype, /** @lends Requester.prototype */ {
                     }
                 };
 
+                // add initialization overhead to request offsets
                 _.forOwn(res.timings, function (value, key) {
                     timings.offset[key] = value + requestStart;
                 });
@@ -222,7 +224,7 @@ _.assign(Requester.prototype, /** @lends Requester.prototype */ {
 
 _.assign(Requester, /** @lends Requester */ {
     /**
-     * Asyncronously create a new requester.
+     * Asynchronously create a new requester.
      *
      * @param trace
      * @param trace.type - type of requester to return (for now, just http)

--- a/lib/requester/requester.js
+++ b/lib/requester/requester.js
@@ -102,7 +102,7 @@ _.assign(Requester.prototype, /** @lends Requester.prototype */ {
             cookieJar,
             requestOptions,
             networkOptions = self.options.network || {},
-            startTime,
+            startTime = Date.now(),
             hostname,
 
             complete = function (error, response, cookies) {
@@ -120,7 +120,6 @@ _.assign(Requester.prototype, /** @lends Requester.prototype */ {
 
         cookieJar = self.options.cookieJar;
         requestOptions = core.getRequestOptions(request, self.options, protocolProfileBehavior);
-        startTime = Date.now();
         hostname = request.url.getHost();
 
         // check if host is on the `restrictedAddresses`
@@ -139,6 +138,7 @@ _.assign(Requester.prototype, /** @lends Requester.prototype */ {
                 timings,
                 responseTime,
                 responseJSON,
+                requestStart,
                 cookies,
                 response;
 
@@ -150,9 +150,6 @@ _.assign(Requester.prototype, /** @lends Requester.prototype */ {
                 responseString = core.arrayBufferToString(resBody);
             }
 
-            // Calculate the time taken for us to get the response.
-            responseTime = Date.now() - startTime;
-
             // This helps us to unify the information from XHR or Node calls.
             responseJSON = core.jsonifyResponse(res, requestOptions, responseString);
 
@@ -162,12 +159,27 @@ _.assign(Requester.prototype, /** @lends Requester.prototype */ {
                     acc.push(toChromeCookie(cookie));
                 }, []) : [];
 
+            // Calculate the time taken for us to get the response.
+            responseTime = Date.now() - startTime;
+
             if (res && res.timingStart) {
+                requestStart = res.timingStart - startTime;
+
                 timings = {
-                    start: res.timingStart,
-                    overhead: responseTime - (res.timings && res.timings.end || 0),
-                    offset: res.timings
+                    start: startTime,
+                    offset: {
+                        request: requestStart
+                    }
                 };
+
+                _.forOwn(res.timings, function (value, key) {
+                    timings.offset[key] = value + requestStart;
+                });
+
+                timings.offset.done = responseTime;
+
+                // update response time to actual response end time
+                responseTime = Math.ceil(res.timings.end);
             }
 
             // Response in the SDK format

--- a/lib/requester/requester.js
+++ b/lib/requester/requester.js
@@ -165,6 +165,7 @@ _.assign(Requester.prototype, /** @lends Requester.prototype */ {
             if (res && res.timingStart) {
                 timings = {
                     start: res.timingStart,
+                    overhead: responseTime - (res.timings && res.timings.end || 0),
                     offset: res.timings
                 };
             }

--- a/test/integration/requester-spec/timing.test.js
+++ b/test/integration/requester-spec/timing.test.js
@@ -26,10 +26,8 @@ describe('Requester Spec: timings', function () {
             var response = testrun.response.getCall(0).args[2];
 
             expect(response).to.have.property('timings');
-            expect(response.timings).to.be.an('object').that.has.all.keys([
-                'start',
-                'offset'
-            ]);
+            expect(response).to.have.property('responseTime');
+            expect(response.timings).to.be.an('object').that.has.all.keys(['start', 'overhead', 'offset']);
             expect(response.timings.offset).to.be.an('object').that.includes.all.keys([
                 'socket',
                 'lookup',
@@ -38,6 +36,7 @@ describe('Requester Spec: timings', function () {
                 'response',
                 'end'
             ]);
+            expect(response.timings.overhead).to.equal(response.responseTime - response.timings.offset.end);
         });
     });
 
@@ -58,10 +57,8 @@ describe('Requester Spec: timings', function () {
             var response = testrun.response.getCall(0).args[2];
 
             expect(response).to.have.property('timings');
-            expect(response.timings).to.be.an('object').that.has.all.keys([
-                'start',
-                'offset'
-            ]);
+            expect(response).to.have.property('responseTime');
+            expect(response.timings).to.be.an('object').that.has.all.keys(['start', 'overhead', 'offset']);
             expect(response.timings.offset).to.be.an('object').that.includes.all.keys([
                 'socket',
                 'lookup',

--- a/test/integration/requester-spec/timing.test.js
+++ b/test/integration/requester-spec/timing.test.js
@@ -27,16 +27,19 @@ describe('Requester Spec: timings', function () {
 
             expect(response).to.have.property('timings');
             expect(response).to.have.property('responseTime');
-            expect(response.timings).to.be.an('object').that.has.all.keys(['start', 'overhead', 'offset']);
+            expect(response.timings).to.be.an('object').that.has.all.keys(['start', 'offset']);
             expect(response.timings.offset).to.be.an('object').that.includes.all.keys([
+                'request',
                 'socket',
                 'lookup',
                 'connect',
                 'secureConnect',
                 'response',
-                'end'
+                'end',
+                'done'
             ]);
-            expect(response.timings.overhead).to.equal(response.responseTime - response.timings.offset.end);
+            expect(response.responseTime).to
+                .equal(Math.ceil(response.timings.offset.end - response.timings.offset.request));
         });
     });
 
@@ -58,14 +61,16 @@ describe('Requester Spec: timings', function () {
 
             expect(response).to.have.property('timings');
             expect(response).to.have.property('responseTime');
-            expect(response.timings).to.be.an('object').that.has.all.keys(['start', 'overhead', 'offset']);
+            expect(response.timings).to.be.an('object').that.has.all.keys(['start', 'offset']);
             expect(response.timings.offset).to.be.an('object').that.includes.all.keys([
+                'request',
                 'socket',
                 'lookup',
                 'connect',
                 'secureConnect',
                 'response',
-                'end'
+                'end',
+                'done'
             ]);
         });
     });


### PR DESCRIPTION
- Update `response.responseTime` to `timings.end` i.e, response `end` event.
- Update `timings.start` with runtime's request start time
- Track request start time in offset
- Update all the postman-request offset with runtime overhead
- Track runtime request `done` in offset