### PR TITLE
Added `connection` system header

### DIFF
--- a/lib/requester/requester.js
+++ b/lib/requester/requester.js
@@ -159,11 +159,11 @@ _.assign(Requester.prototype, /** @lends Requester.prototype */ {
                 return complete(err);
             }
 
-            var connectionHeader,
-                responseString,
+            var responseString,
                 responseTime,
                 responseJSON,
                 requestStart,
+                keepAlive,
                 response,
                 cookies,
                 timings,
@@ -240,14 +240,14 @@ _.assign(Requester.prototype, /** @lends Requester.prototype */ {
                 }
             });
 
-            connectionHeader = _.get(requestOptions, 'agentOptions.keepAlive');
+            keepAlive = _.get(requestOptions, 'agentOptions.keepAlive');
 
             // @note Connection header is added by Node based on the agent's
             // keepAlive option. Don't add if custom is defined already.
             if (!request.headers.has(CONNECTION_HEADER.key)) {
                 request.headers.add({
                     key: CONNECTION_HEADER.key,
-                    value: connectionHeader ? CONNECTION_HEADER.keepAlive : CONNECTION_HEADER.close,
+                    value: keepAlive ? CONNECTION_HEADER.keepAlive : CONNECTION_HEADER.close,
                     system: true
                 });
             }

--- a/lib/requester/requester.js
+++ b/lib/requester/requester.js
@@ -20,6 +20,19 @@ var _ = require('lodash'),
     },
 
     /**
+     * Connection Header, added based on agentOptions.keepAlive
+     *
+     * @private
+     * @const
+     * @type {Object}
+     */
+    CONNECTION_HEADER = {
+        key: 'Connection',
+        keepAlive: 'keep-alive',
+        close: 'close'
+    },
+
+    /**
      * Creates a Chrome-compatible cookie from a tough-cookie compatible cookie.
      *
      * @param cookie
@@ -146,7 +159,8 @@ _.assign(Requester.prototype, /** @lends Requester.prototype */ {
                 return complete(err);
             }
 
-            var responseString,
+            var connectionHeader,
+                responseString,
                 responseTime,
                 responseJSON,
                 requestStart,
@@ -214,9 +228,6 @@ _.assign(Requester.prototype, /** @lends Requester.prototype */ {
                 // neither request nor runtime overwrites user-defined headers
                 // so instead of upsert, just add missing headers to the list
                 // with system: true flag.
-                // @note headers added by Node e.g. `Connection: keep-alive` are
-                // missing from this list.
-                // @todo maybe parse raw HTTP header payload to catch em all.
                 if (!header) {
                     request.headers.add({key: key, value: value, system: true});
 
@@ -228,6 +239,18 @@ _.assign(Requester.prototype, /** @lends Requester.prototype */ {
                     header.update({key: key, value: value, system: true});
                 }
             });
+
+            connectionHeader = _.get(requestOptions, 'agentOptions.keepAlive');
+
+            // @note Connection header is added by Node based on the agent's
+            // keepAlive option. Don't add if custom is defined already.
+            if (!request.headers.has(CONNECTION_HEADER.key)) {
+                request.headers.add({
+                    key: CONNECTION_HEADER.key,
+                    value: connectionHeader ? CONNECTION_HEADER.keepAlive : CONNECTION_HEADER.close,
+                    system: true
+                });
+            }
 
             complete(null, response, cookies);
         });

--- a/test/integration/request-flow/headers.test.js
+++ b/test/integration/request-flow/headers.test.js
@@ -209,12 +209,13 @@ describe('request headers', function () {
             new Header({key: 'Accept', value: '*/*', system: true}),
             new Header({key: 'Cache-Control', value: 'no-cache', system: true}),
             new Header({key: 'Host', value: 'localhost:5050', system: true}),
-            new Header({key: 'accept-encoding', value: 'gzip, deflate', system: true})
+            new Header({key: 'accept-encoding', value: 'gzip, deflate', system: true}),
+            new Header({key: 'Connection', value: 'keep-alive', system: true})
         ]);
 
-        // @todo handle headers added by Node's HTTP client
-        expect(request.headers.members).to.not.deep.include(new Header({
-            key: 'Connection', value: 'close', system: true
-        }));
+        // @note currently, only `Connection` header is added by NodeJS which
+        // is handled by the requester. This test will fail if any other
+        // header will be added by NodeJS.
+        expect(request.headers.count()).to.equal(requestHeaders.length);
     });
 });


### PR DESCRIPTION
- Add `connection` system header which is added by Node based on agent option.
- This is also useful for true request size calculation.
- Previously handled by https://github.com/postmanlabs/postman-collection/pull/814 hack.