### PR TITLE
Added ability to clone file read stream

### DIFF
--- a/lib/runner/request-helpers-presend.js
+++ b/lib/runner/request-helpers-presend.js
@@ -10,6 +10,87 @@ var _ = require('lodash'),
     DOT_AUTH = '.auth';
 
 module.exports = [
+    // File loading
+    function (context, run, done) {
+        if (!context.item) { return done(new Error('Nothing to resolve files for.')); }
+
+        var triggers = run.triggers,
+            cursor = context.coords,
+            resolver,
+            request,
+            mode,
+            data;
+
+        resolver = run.options.fileResolver;
+
+        request = context.item.request;
+
+        if (!request) { return done(new Error('No request to send.')); }
+
+        // if body is disabled than skip loading files.
+        // @todo this may cause problem if body is enabled/disabled programmatically from pre-request script.
+        if (request.body && request.body.disabled) { return done(); }
+
+        // todo: add helper functions in the sdk to do this cleanly for us
+        mode = _.get(request, 'body.mode');
+        data = _.get(request, ['body', mode]);
+
+        // if there is no mode specified, or no data for the specified mode we cannot resolve anything!
+        // @note that if source is not readable, there is no point reading anything, yet we need to warn that file
+        // upload was not done. hence we will have to proceed even without an unreadable source
+        if (!data) { // we do not need to check `mode` here since false mode returns no `data`
+            return done();
+        }
+
+        // in this block, we simply use async.waterfall to ensure that all form of file reading is async. essentially,
+        // we first determine the data mode and based on it pass the waterfall functions.
+        async.waterfall([async.constant(data), {
+            // form data parsing simply "enriches" all form parameters having file data type by replacing / setting the
+            // value as a read stream
+            formdata: function (formdata, next) {
+                // ensure that we only process the file type
+                async.eachSeries(_.filter(formdata.all(), {type: 'file'}), function (formparam, callback) {
+                    if (!formparam || formparam.disabled) {
+                        return callback(); // disabled params will be filtered in body-builder.
+                    }
+
+                    // eslint-disable-next-line security/detect-non-literal-fs-filename
+                    util.createReadStream(resolver, formparam.src, function (err, stream) {
+                        if (err) {
+                            triggers.console(cursor, 'warn',
+                                `Form param \`${formparam.key}\`, file load error: ${err.message || err}`);
+                            formparam.disabled = true; // set disabled, it will be filtered in body-builder.
+                        }
+                        else {
+                            formparam.value = stream;
+                        }
+                        callback();
+                    });
+                }, next);
+            },
+            // file data
+            file: function (filedata, next) {
+                // eslint-disable-next-line security/detect-non-literal-fs-filename
+                util.createReadStream(resolver, filedata.src, function(err, stream) {
+                    if (err) {
+                        triggers.console(cursor, 'warn', 'Binary file load error: ' + err.message || err);
+                        filedata.value = null; // ensure this does not mess with requester
+                        delete filedata.content; // @todo - why content?
+                    }
+                    else {
+                        filedata.content = stream;
+                    }
+                    next();
+                });
+            }
+        }[mode] || async.constant()], function (err) {
+            // just as a precaution, show the error in console. each resolver anyway should handle their own console
+            // warnings.
+            // @todo - get cursor here.
+            err && triggers.console(cursor, 'warn', 'file data resolution error: ' + (err.message || err));
+            done(null); // absorb the error since a console has been trigerred
+        });
+    },
     // Authorization
     function (context, run, done) {
         // validate all stuff. dont ask.
@@ -141,88 +222,6 @@ module.exports = [
 
         // start the by calling the pre hook of the auth
         authPreHook();
-    },
-
-    // File loading
-    function (context, run, done) {
-        if (!context.item) { return done(new Error('Nothing to resolve files for.')); }
-
-        var triggers = run.triggers,
-            cursor = context.coords,
-            resolver,
-            request,
-            mode,
-            data;
-
-        resolver = run.options.fileResolver;
-
-        request = context.item.request;
-
-        if (!request) { return done(new Error('No request to send.')); }
-
-        // if body is disabled than skip loading files.
-        // @todo this may cause problem if body is enabled/disabled programmatically from pre-request script.
-        if (request.body && request.body.disabled) { return done(); }
-
-        // todo: add helper functions in the sdk to do this cleanly for us
-        mode = _.get(request, 'body.mode');
-        data = _.get(request, ['body', mode]);
-
-        // if there is no mode specified, or no data for the specified mode we cannot resolve anything!
-        // @note that if source is not readable, there is no point reading anything, yet we need to warn that file
-        // upload was not done. hence we will have to proceed even without an unreadable source
-        if (!data) { // we do not need to check `mode` here since false mode returns no `data`
-            return done();
-        }
-
-        // in this block, we simply use async.waterfall to ensure that all form of file reading is async. essentially,
-        // we first determine the data mode and based on it pass the waterfall functions.
-        async.waterfall([async.constant(data), {
-            // form data parsing simply "enriches" all form parameters having file data type by replacing / setting the
-            // value as a read stream
-            formdata: function (formdata, next) {
-                // ensure that we only process the file type
-                async.eachSeries(_.filter(formdata.all(), {type: 'file'}), function (formparam, callback) {
-                    if (!formparam || formparam.disabled) {
-                        return callback(); // disabled params will be filtered in body-builder.
-                    }
-
-                    // eslint-disable-next-line security/detect-non-literal-fs-filename
-                    util.createReadStream(resolver, formparam.src, function (err, stream) {
-                        if (err) {
-                            triggers.console(cursor, 'warn',
-                                `Form param \`${formparam.key}\`, file load error: ${err.message || err}`);
-                            formparam.disabled = true; // set disabled, it will be filtered in body-builder.
-                        }
-                        else {
-                            formparam.value = stream;
-                        }
-                        callback();
-                    });
-                }, next);
-            },
-            // file data
-            file: function (filedata, next) {
-                // eslint-disable-next-line security/detect-non-literal-fs-filename
-                util.createReadStream(resolver, filedata.src, function(err, stream) {
-                    if (err) {
-                        triggers.console(cursor, 'warn', 'Binary file load error: ' + err.message || err);
-                        filedata.value = null; // ensure this does not mess with requester
-                        delete filedata.content; // @todo - why content?
-                    }
-                    else {
-                        filedata.content = stream;
-                    }
-                    next();
-                });
-            }
-        }[mode] || async.constant()], function (err) {
-            // just as a precaution, show the error in console. each resolver anyway should handle their own console
-            // warnings.
-            // @todo - get cursor here.
-            err && triggers.console(cursor, 'warn', 'file data resolution error: ' + (err.message || err));
-            done(null); // absorb the error since a console has been trigerred
-        });
     },
     // Proxy lookup
     function (context, run, done) {

--- a/lib/runner/request-helpers-presend.js
+++ b/lib/runner/request-helpers-presend.js
@@ -67,7 +67,7 @@ module.exports = [
             // file data
             file: function (filedata, next) {
                 // eslint-disable-next-line security/detect-non-literal-fs-filename
-                util.createReadStream(resolver, filedata.src, function(err, stream) {
+                util.createReadStream(resolver, filedata.src, function (err, stream) {
                     if (err) {
                         triggers.console(cursor, 'warn', 'Binary file load error: ' + err.message || err);
                         filedata.value = null; // ensure this does not mess with requester

--- a/lib/runner/request-helpers-presend.js
+++ b/lib/runner/request-helpers-presend.js
@@ -16,14 +16,10 @@ module.exports = [
 
         var triggers = run.triggers,
             cursor = context.coords,
-            resolver,
-            request,
+            resolver = run.options.fileResolver,
+            request = context.item && context.item.request,
             mode,
             data;
-
-        resolver = run.options.fileResolver;
-
-        request = context.item.request;
 
         if (!request) { return done(new Error('No request to send.')); }
 

--- a/lib/runner/util.js
+++ b/lib/runner/util.js
@@ -8,7 +8,65 @@ var /**
      * @const
      * @type {string}
      */
-    STRING = 'string';
+    STRING = 'string',
+
+    createReadStream; // function
+
+/**
+ * Create readable stream for given file as well as detect possible file
+ * read issues.
+ *
+ * @param {Object} resolver - External file resolver module
+ * @param {String} fileSrc - File path
+ * @param {Function} callback - Final callback
+ *
+ * @note This function is defined in file's root because there is a need to trap it within closure in order to append
+ * the stream clone functionalities. This ensures lesser footprint in case we have a memory leak
+ */
+createReadStream = function (resolver, fileSrc, callback) {
+    var readStream;
+
+    // check for the existence of the file before creating read stream.
+    // eslint-disable-next-line security/detect-non-literal-fs-filename
+    resolver.stat(fileSrc, function (err, stats) {
+        if (err) {
+            // overwrite `ENOENT: no such file or directory` error message. Most likely the case.
+            err.code === 'ENOENT' && (err.message = `"${fileSrc}", no such file`);
+
+            return callback(err);
+        }
+
+        // check for a valid file.
+        if (stats && typeof stats.isFile === FUNCTION && !stats.isFile()) {
+            return callback(new Error(`"${fileSrc}", is not a file`));
+        }
+
+        // check read permissions for user.
+        // octal `400` signifies 'user permissions'. [4 0 0] -> [u g o]
+        // `4` signifies 'read permission'. [4] -> [1 0 0] -> [r w x]
+        if (stats && !(stats.mode & 0o400)) {
+            return callback(new Error(`"${fileSrc}", read permission denied`));
+        }
+
+        // @note Handle all the errors before `createReadStream` to avoid listening on stream error event.
+        //       listening on error requires listening on end event as well. which will make this sync.
+        // @note In form-data mode stream error will be handled in postman-request but bails out ongoing request.
+        // eslint-disable-next-line security/detect-non-literal-fs-filename
+        readStream = resolver.createReadStream(fileSrc);
+
+        // We might have to read the file before making the actual request
+        // e.g, while calculating body hash during AWS auth or redirecting form-data params
+        // So, this method wraps the `createReadStream` function with fixed arguments.
+        // This makes sure that we don't have to pass `fileResolver` to
+        // internal modules (like auth plugins) for security reasons.
+        readStream.cloneReadStream = function (callback) {
+            // eslint-disable-next-line security/detect-non-literal-fs-filename
+            return createReadStream(resolver, fileSrc, callback);
+        };
+
+        callback(null, readStream);
+    });
+};
 
 /**
  * Utility functions that are required to be re-used throughout the runner
@@ -72,13 +130,15 @@ module.exports = {
 
     /**
      * Create readable stream for given file as well as detect possible file
-     * read issues.
+     * read issues. The resolver also attaches a clone function to the strea so that the stream can be restarted
+     * any time.
      *
      * @param {Object} resolver - External file resolver module
      * @param {Function} resolver.stat - Resolver method to check for existence and permissions of file
      * @param {Function} resolver.createReadStream - Resolver method for creating read stream
      * @param {String} fileSrc - File path
-     * @param {Function} callback - Final callback
+     * @param {Function} callback -
+     *
      */
     createReadStream: function (resolver, fileSrc, callback) {
         // bail out if resolver not found.
@@ -96,48 +156,8 @@ module.exports = {
             return callback(new Error('invalid or missing file source'));
         }
 
-        var self = this,
-            readStream;
-
-        // check for the existence of the file before creating read stream.
-        // eslint-disable-next-line security/detect-non-literal-fs-filename
-        resolver.stat(fileSrc, function(err, stats) {
-            if (err) {
-                // overwrite `ENOENT: no such file or directory` error message. Most likely the case.
-                err.code === 'ENOENT' && (err.message = `"${fileSrc}", no such file`);
-
-                return callback(err);
-            }
-
-            // check for a valid file.
-            if (stats && typeof stats.isFile === FUNCTION && !stats.isFile()) {
-                return callback(new Error(`"${fileSrc}", is not a file`));
-            }
-
-            // check read permissions for user.
-            // octal `400` signifies 'user permissions'. [4 0 0] -> [u g o]
-            // `4` signifies 'read permission'. [4] -> [1 0 0] -> [r w x]
-            if (stats && !(stats.mode & 0o400)) {
-                return callback(new Error(`"${fileSrc}", read permission denied`));
-            }
-
-            // @note Handle all the errors before `createReadStream` to avoid listening on stream error event.
-            //       listening on error requires listening on end event as well. which will make this sync.
-            // @note In form-data mode stream error will be handled in postman-request but bails out ongoing request.
-            // eslint-disable-next-line security/detect-non-literal-fs-filename
-            readStream = resolver.createReadStream(fileSrc);
-
-            // We might have to read the file before making the actual request
-            // e.g, while calculating body hash during AWS auth or redirecting form-data params
-            // So, this method wraps the `createReadStream` function with fixed arguments.
-            // This makes sure that we don't have to pass `fileResolver` to
-            // internal modules (like auth plugins) for security reasons.
-            readStream.cloneReadStream = function (cb) {
-                // eslint-disable-next-line security/detect-non-literal-fs-filename
-                return self.createReadStream(resolver, fileSrc, cb);
-            };
-
-            callback(null, readStream);
-        });
+        // now that things are sanitised and validated, we transfer it to the stream reading utility function that does
+        // the heavy lifting of calling thre resolver to return the stream
+        return createReadStream(resolver, fileSrc, callback);
     }
 };

--- a/lib/runner/util.js
+++ b/lib/runner/util.js
@@ -20,8 +20,9 @@ var /**
  * @param {String} fileSrc - File path
  * @param {Function} callback - Final callback
  *
- * @note This function is defined in file's root because there is a need to trap it within closure in order to append
- * the stream clone functionalities. This ensures lesser footprint in case we have a memory leak
+ * @note This function is defined in the file's root because there is a need to
+ * trap it within closure in order to append the stream clone functionalities.
+ * This ensures lesser footprint in case we have a memory leak.
  */
 createReadStream = function (resolver, fileSrc, callback) {
     var readStream;
@@ -49,7 +50,7 @@ createReadStream = function (resolver, fileSrc, callback) {
         }
 
         // @note Handle all the errors before `createReadStream` to avoid listening on stream error event.
-        //       listening on error requires listening on end event as well. which will make this sync.
+        // listening on error requires listening on end event as well. which will make this sync.
         // @note In form-data mode stream error will be handled in postman-request but bails out ongoing request.
         // eslint-disable-next-line security/detect-non-literal-fs-filename
         readStream = resolver.createReadStream(fileSrc);
@@ -73,20 +74,20 @@ createReadStream = function (resolver, fileSrc, callback) {
  * @module Runner~util
  * @private
  *
- * @note Do not put module logic or business logic related functions here. The functions here are purely decoupled and
- * low-level functions.
+ * @note Do not put module logic or business logic related functions here.
+ * The functions here are purely decoupled and low-level functions.
  */
 module.exports = {
     /**
-     * This function allows one to call another function by wrapping it within a try-catch block. The first parameter is
-     * the function itself, followed by the scope in which this function is to be executed. The third parameter onwards
-     * are blindly forwarded to the function being called
+     * This function allows one to call another function by wrapping it within a try-catch block.
+     * The first parameter is the function itself, followed by the scope in which this function is to be executed.
+     * The third parameter onwards are blindly forwarded to the function being called
      *
      * @param {Function} fn
      * @param {*} ctx
      *
-     * @returns {Error} If there was an error executing the function, the error is returned. Note that if the function
-     * called here is asynchronous, it's errors will not be returned (for obvious reasons!)
+     * @returns {Error} If there was an error executing the function, the error is returned.
+     * Note that if the function called here is asynchronous, it's errors will not be returned (for obvious reasons!)
      */
     safeCall: function (fn, ctx) {
         // extract the arguments that are to be forwarded to the function to be called
@@ -130,8 +131,8 @@ module.exports = {
 
     /**
      * Create readable stream for given file as well as detect possible file
-     * read issues. The resolver also attaches a clone function to the strea so that the stream can be restarted
-     * any time.
+     * read issues. The resolver also attaches a clone function to the stream
+     * so that the stream can be restarted any time.
      *
      * @param {Object} resolver - External file resolver module
      * @param {Function} resolver.stat - Resolver method to check for existence and permissions of file
@@ -156,8 +157,9 @@ module.exports = {
             return callback(new Error('invalid or missing file source'));
         }
 
-        // now that things are sanitised and validated, we transfer it to the stream reading utility function that does
-        // the heavy lifting of calling thre resolver to return the stream
+        // now that things are sanitized and validated, we transfer it to the
+        // stream reading utility function that does the heavy lifting of
+        // calling there resolver to return the stream
         return createReadStream(resolver, fileSrc, callback);
     }
 };

--- a/lib/runner/util.js
+++ b/lib/runner/util.js
@@ -70,6 +70,16 @@ module.exports = {
         return dest;
     },
 
+    /**
+     * Create readable stream for given file as well as detect possible file
+     * read issues.
+     *
+     * @param {Object} resolver - External file resolver module
+     * @param {Function} resolver.stat - Resolver method to check for existence and permissions of file
+     * @param {Function} resolver.createReadStream - Resolver method for creating read stream
+     * @param {String} fileSrc - File path
+     * @param {Function} callback - Final callback
+     */
     createReadStream: function (resolver, fileSrc, callback) {
         // bail out if resolver not found.
         if (!resolver) {
@@ -85,6 +95,9 @@ module.exports = {
         if (!fileSrc || typeof fileSrc !== STRING) {
             return callback(new Error('invalid or missing file source'));
         }
+
+        var self = this,
+            readStream;
 
         // check for the existence of the file before creating read stream.
         // eslint-disable-next-line security/detect-non-literal-fs-filename
@@ -112,7 +125,19 @@ module.exports = {
             //       listening on error requires listening on end event as well. which will make this sync.
             // @note In form-data mode stream error will be handled in postman-request but bails out ongoing request.
             // eslint-disable-next-line security/detect-non-literal-fs-filename
-            callback(null, resolver.createReadStream(fileSrc));
+            readStream = resolver.createReadStream(fileSrc);
+
+            // We might have to read the file before making the actual request
+            // e.g, while calculating body hash during AWS auth or redirecting form-data params
+            // So, this method wraps the `createReadStream` function with fixed arguments.
+            // This makes sure that we don't have to pass `fileResolver` to
+            // internal modules (like auth plugins) for security reasons.
+            readStream.cloneReadStream = function (cb) {
+                // eslint-disable-next-line security/detect-non-literal-fs-filename
+                return self.createReadStream(resolver, fileSrc, cb);
+            };
+
+            callback(null, readStream);
         });
     }
 };


### PR DESCRIPTION
- util.createReadStream: Add the ability to clone read stream
- Load file first in request presend helpers because auth helpers need to reset file stream.

```javascript
var fileReadStream;

// init
util.createReadStream(require('fs'), fileSrc, function (err, stream) {
    fileReadStream = stream;
});

// ... read file etc.

// reset
fileReadStream.cloneReadStream(function (err, stream) {
    fileReadStream = stream;
});
```