### PR TITLE
URL encoding related changes

### DIFF
--- a/lib/authorizer/aws4.js
+++ b/lib/authorizer/aws4.js
@@ -216,7 +216,7 @@ module.exports = {
                     sessionToken: params.sessionToken || undefined
                 },
                 host: url.host,
-                path: url.path,
+                path: url.path, // path = pathname + query
                 service: params.service || 'execute-api', // AWS API Gateway is the default service.
                 region: params.region || 'us-east-1',
                 method: request.method,

--- a/lib/authorizer/aws4.js
+++ b/lib/authorizer/aws4.js
@@ -1,9 +1,8 @@
 var _ = require('lodash'),
     aws4 = require('aws4'),
     crypto = require('crypto'),
-    querystring = require('querystring'),
+    urlEncoder = require('postman-url-encoder'),
     RequestBody = require('postman-collection').RequestBody,
-    urlencodedBodyBuilder = require('../requester/core-body-builder').urlencoded,
 
     BODY_HASH_HEADER = 'X-Amz-Content-Sha256',
 
@@ -44,7 +43,7 @@ var _ = require('lodash'),
         }
 
         if (body.mode === RequestBody.MODES.urlencoded) {
-            urlencodedBody = rfc3986(querystring.stringify(urlencodedBodyBuilder(body.urlencoded).form));
+            urlencodedBody = body.urlencoded && urlEncoder.encodeQueryParams(body.urlencoded.all());
             hash.update(urlencodedBody);
 
             return callback(hash.digest(digestEncoding));
@@ -183,6 +182,7 @@ module.exports = {
                 'service',
                 'region'
             ]),
+            url = urlEncoder.toNodeUrl(request.url),
             self = this;
 
         // Clean up the request (if needed)
@@ -211,8 +211,8 @@ module.exports = {
                     secretAccessKey: params.secretKey,
                     sessionToken: params.sessionToken || undefined
                 },
-                host: request.url.getRemote(),
-                path: request.url.getPathWithQuery(),
+                host: url.host,
+                path: url.path,
                 service: params.service || 'execute-api', // AWS API Gateway is the default service.
                 region: params.region || 'us-east-1',
                 method: request.method,

--- a/lib/authorizer/aws4.js
+++ b/lib/authorizer/aws4.js
@@ -1,8 +1,10 @@
 var _ = require('lodash'),
     aws4 = require('aws4'),
     crypto = require('crypto'),
+    querystring = require('querystring'),
     urlEncoder = require('postman-url-encoder'),
     RequestBody = require('postman-collection').RequestBody,
+    urlencodedBodyBuilder = require('../requester/core-body-builder').urlencoded,
 
     BODY_HASH_HEADER = 'X-Amz-Content-Sha256',
 
@@ -43,7 +45,9 @@ var _ = require('lodash'),
         }
 
         if (body.mode === RequestBody.MODES.urlencoded) {
-            urlencodedBody = body.urlencoded && urlEncoder.encodeQueryParams(body.urlencoded.all());
+            urlencodedBody = urlencodedBodyBuilder(body.urlencoded).form;
+            urlencodedBody = querystring.stringify(urlencodedBody);
+            urlencodedBody = rfc3986(urlencodedBody);
             hash.update(urlencodedBody);
 
             return callback(hash.digest(digestEncoding));
@@ -182,7 +186,7 @@ module.exports = {
                 'service',
                 'region'
             ]),
-            url = urlEncoder.toNodeUrl(request.url),
+            url = urlEncoder.toNodeUrl(request.url.toString(true)),
             self = this;
 
         // Clean up the request (if needed)

--- a/lib/authorizer/digest.js
+++ b/lib/authorizer/digest.js
@@ -303,7 +303,7 @@ module.exports = {
     sign: function (auth, request, done) {
         var header,
             params = auth.get(AUTH_PARAMETERS),
-            url = urlEncoder.toNodeUrl(request.url);
+            url = urlEncoder.toNodeUrl(request.url.toString(true));
 
         if (!params.username || !params.realm) {
             return done(); // Nothing to do if required parameters are not present.

--- a/lib/authorizer/digest.js
+++ b/lib/authorizer/digest.js
@@ -1,5 +1,6 @@
-var crypto = require('crypto-js'),
-    _ = require('lodash'),
+var _ = require('lodash'),
+    crypto = require('crypto-js'),
+    urlEncoder = require('postman-url-encoder'),
 
     EMPTY = '',
     ONE = '00000001',
@@ -301,7 +302,8 @@ module.exports = {
      */
     sign: function (auth, request, done) {
         var header,
-            params = auth.get(AUTH_PARAMETERS);
+            params = auth.get(AUTH_PARAMETERS),
+            url = urlEncoder.toNodeUrl(request.url);
 
         if (!params.username || !params.realm) {
             return done(); // Nothing to do if required parameters are not present.
@@ -310,7 +312,7 @@ module.exports = {
         request.removeHeader(AUTHORIZATION, {ignoreCase: true});
 
         params.method = request.method;
-        params.uri = request.url.getPathWithQuery();
+        params.uri = url.path;
         params.body = request.body && request.body.toString();
 
         try {

--- a/lib/authorizer/hawk.js
+++ b/lib/authorizer/hawk.js
@@ -1,6 +1,7 @@
 var url = require('url'),
     _ = require('lodash'),
     Hawk = require('postman-request/lib/hawk'),
+    urlEncoder = require('postman-url-encoder'),
 
     ASCII_SOURCE = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789',
     ASCII_SOURCE_LENGTH = ASCII_SOURCE.length,
@@ -145,7 +146,7 @@ module.exports = {
             app: params.app,
             dlg: params.delegation,
             user: params.user,
-            url: request.url.toString(true), // force toString to add a protocol to the URL.
+            url: urlEncoder.encodeUrl(request.url, true), // force toString to add a protocol to the URL.
             method: request.method
         });
         request.addHeader({

--- a/lib/authorizer/hawk.js
+++ b/lib/authorizer/hawk.js
@@ -127,7 +127,10 @@ module.exports = {
                 'app',
                 'delegation',
                 'user'
-            ]);
+            ]),
+
+            // force toString to add a protocol to the URL.
+            url = urlEncoder.toNodeUrl(request.url.toString(true));
 
         if (!params.authId || !params.authKey) {
             return done(); // Nothing to do if required parameters are not present.
@@ -146,7 +149,7 @@ module.exports = {
             app: params.app,
             dlg: params.delegation,
             user: params.user,
-            url: urlEncoder.encodeUrl(request.url, true), // force toString to add a protocol to the URL.
+            url: url.href,
             method: request.method
         });
         request.addHeader({

--- a/lib/authorizer/oauth1.js
+++ b/lib/authorizer/oauth1.js
@@ -4,6 +4,7 @@ var _ = require('lodash'),
     RequestBody = require('postman-collection').RequestBody,
 
     EMPTY = '',
+    PROTOCOL_HTTP = 'http',
     PROTOCOL_SEPARATOR = '://',
     HTTPS_PORT = '443',
     HTTP_PORT = '80',

--- a/lib/authorizer/oauth1.js
+++ b/lib/authorizer/oauth1.js
@@ -5,6 +5,8 @@ var _ = require('lodash'),
 
     EMPTY = '',
     PROTOCOL_SEPARATOR = '://',
+    HTTPS_PORT = '443',
+    HTTP_PORT = '80',
 
     OAUTH1_PARAMS = {
         oauthConsumerKey: 'oauth_consumer_key',
@@ -35,7 +37,7 @@ function getOAuth1BaseUrl (url) {
         host = ((port === HTTP_PORT ||
             port === HTTPS_PORT ||
             port === undefined) && url.hostname) || url.host,
-        path = this.getPath(),
+        path = url.pathname,
 
         // trim to convert 'http:' to 'http' in Node's URL object
         protocol = _.trimEnd(url.protocol || PROTOCOL_HTTP, PROTOCOL_SEPARATOR);

--- a/lib/authorizer/oauth1.js
+++ b/lib/authorizer/oauth1.js
@@ -39,7 +39,7 @@ function getOAuth1BaseUrl (url) {
             port === undefined) && url.hostname) || url.host,
         path = url.pathname,
 
-        // trim to convert 'http:' to 'http' in Node's URL object
+        // trim to convert 'http:' from Node's URL object to 'http'
         protocol = _.trimEnd(url.protocol || PROTOCOL_HTTP, PROTOCOL_SEPARATOR);
 
     protocol = (_.endsWith(protocol, PROTOCOL_SEPARATOR) ? protocol : protocol + PROTOCOL_SEPARATOR);
@@ -236,7 +236,7 @@ module.exports = {
                 'addParamsToHeader',
                 'addEmptyParamsToSign'
             ]),
-            url = urlEncoder.toNodeUrl(request.url),
+            url = urlEncoder.toNodeUrl(request.url.toString(true)),
             signatureParams,
             header;
 
@@ -273,8 +273,8 @@ module.exports = {
             method: request.method,
             queryParams: request.url.query && request.url.query.count() ? request.url.query.map(function (qParam) {
                 return {
-                    key: urlEncoder.encodeString(qParam.key),
-                    value: urlEncoder.encodeString(qParam.value)
+                    key: qParam.key,
+                    value: qParam.value
                 };
             }) : [],
 
@@ -287,8 +287,8 @@ module.exports = {
                 request.body.urlencoded.count &&
                 request.body.urlencoded.count()) ? request.body.urlencoded.map(function (formParam) {
                     return {
-                        key: urlEncoder.encodeString(formParam.key),
-                        value: urlEncoder.encodeString(formParam.value)
+                        key: formParam.key,
+                        value: formParam.value
                     };
                 }) : [],
             helperParams: params

--- a/lib/authorizer/oauth1.js
+++ b/lib/authorizer/oauth1.js
@@ -1,8 +1,10 @@
 var _ = require('lodash'),
-    RequestBody = require('postman-collection').RequestBody,
     oAuth1 = require('node-oauth1'),
+    urlEncoder = require('postman-url-encoder'),
+    RequestBody = require('postman-collection').RequestBody,
 
     EMPTY = '',
+    PROTOCOL_SEPARATOR = '://',
 
     OAUTH1_PARAMS = {
         oauthConsumerKey: 'oauth_consumer_key',
@@ -13,6 +15,35 @@ var _ = require('lodash'),
         oauthVersion: 'oauth_version',
         oauthSignature: 'oauth_signature'
     };
+
+/**
+ * Returns a OAuth1.0-a compatible representation of the request URL, also called "Base URL".
+ * For details, http://oauth.net/core/1.0a/#anchor13
+ *
+ * todo: should we ignore the auth parameters of the URL or not? (the standard does not mention them)
+ * we currently are.
+ *
+ * @private
+ * @param {Url} url - Node's URL object
+ * @returns {String}
+ *
+ * @deprecated since v3.5 in favour of getBaseUrl
+ * @todo discontinue in v4.0
+ */
+function getOAuth1BaseUrl (url) {
+    var port = url.port ? url.port : undefined,
+        host = ((port === HTTP_PORT ||
+            port === HTTPS_PORT ||
+            port === undefined) && url.hostname) || url.host,
+        path = this.getPath(),
+
+        // trim to convert 'http:' to 'http' in Node's URL object
+        protocol = _.trimEnd(url.protocol || PROTOCOL_HTTP, PROTOCOL_SEPARATOR);
+
+    protocol = (_.endsWith(protocol, PROTOCOL_SEPARATOR) ? protocol : protocol + PROTOCOL_SEPARATOR);
+
+    return protocol.toLowerCase() + host.toLowerCase() + path;
+}
 
 /**
  * @implements {AuthHandlerInterface}
@@ -203,6 +234,7 @@ module.exports = {
                 'addParamsToHeader',
                 'addEmptyParamsToSign'
             ]),
+            url = urlEncoder.toNodeUrl(request.url),
             signatureParams,
             header;
 
@@ -235,12 +267,12 @@ module.exports = {
 
         // Generate a list of parameters associated with the signature.
         signatureParams = this.computeHeader({
-            url: request.url.getOAuth1BaseUrl(),
+            url: getOAuth1BaseUrl(url),
             method: request.method,
             queryParams: request.url.query && request.url.query.count() ? request.url.query.map(function (qParam) {
                 return {
-                    key: qParam.key,
-                    value: qParam.value
+                    key: urlEncoder.encodeString(qParam.key),
+                    value: urlEncoder.encodeString(qParam.value)
                 };
             }) : [],
 
@@ -253,8 +285,8 @@ module.exports = {
                 request.body.urlencoded.count &&
                 request.body.urlencoded.count()) ? request.body.urlencoded.map(function (formParam) {
                     return {
-                        key: formParam.key,
-                        value: formParam.value
+                        key: urlEncoder.encodeString(formParam.key),
+                        value: urlEncoder.encodeString(formParam.value)
                     };
                 }) : [],
             helperParams: params

--- a/lib/authorizer/oauth1.js
+++ b/lib/authorizer/oauth1.js
@@ -29,9 +29,6 @@ var _ = require('lodash'),
  * @private
  * @param {Url} url - Node's URL object
  * @returns {String}
- *
- * @deprecated since v3.5 in favour of getBaseUrl
- * @todo discontinue in v4.0
  */
 function getOAuth1BaseUrl (url) {
     var port = url.port ? url.port : undefined,

--- a/lib/requester/core-body-builder.js
+++ b/lib/requester/core-body-builder.js
@@ -22,7 +22,6 @@
  *                /___/___^//
  */
 var _ = require('lodash'),
-    urlEncoder = require('postman-url-encoder'),
 
     CONTENT_TYPE_HEADER = {
         key: 'Content-Type',
@@ -32,7 +31,41 @@ var _ = require('lodash'),
     STRING = 'string',
 
     // the following two are reducer functions. we keep it defined here to avoid redefinition upon each parse
+    urlEncodedBodyReducer,
     formDataBodyReducer;
+
+/**
+ * Reduces postman SDK url encoded form definition (flattened to array) into Node compatible body options
+ *
+ * @param {Object} form - url encoded form params accumulator
+ * @param {Object} param - url encoded form param
+ *
+ * @returns {Object}
+ */
+urlEncodedBodyReducer = function (form, param) {
+    if (!param || param.disabled) {
+        return form;
+    }
+
+    var key = param.key,
+        value = param.value;
+
+    // add the parameter to the form while accounting for duplicate values
+    if (!form.hasOwnProperty(key)) {
+        form[key] = value;
+
+        return form;
+    }
+
+    // at this point, we know that form has duplicate, so we need to accumulate it in an array
+    if (!Array.isArray(form[key])) {
+        form[key] = [form[key]];
+    }
+
+    form[key].push(value); // finally push the duplicate and return
+
+    return form;
+};
 
 /**
  * Reduces postman SDK multi-part form definition (flattened to array) into Node compatible body options
@@ -98,7 +131,7 @@ module.exports = {
         if (content && _.isFunction(content.all)) { content = content.all(); } // flatten the body content
 
         return {
-            body: urlEncoder.encodeQueryParams(content)
+            form: _.reduce(content, urlEncodedBodyReducer, {})
         };
     },
 

--- a/lib/requester/core-body-builder.js
+++ b/lib/requester/core-body-builder.js
@@ -22,6 +22,7 @@
  *                /___/___^//
  */
 var _ = require('lodash'),
+    urlEncoder = require('postman-url-encoder'),
 
     CONTENT_TYPE_HEADER = {
         key: 'Content-Type',
@@ -31,41 +32,7 @@ var _ = require('lodash'),
     STRING = 'string',
 
     // the following two are reducer functions. we keep it defined here to avoid redefinition upon each parse
-    urlEncodedBodyReducer,
     formDataBodyReducer;
-
-/**
- * Reduces postman SDK url encoded form definition (flattened to array) into Node compatible body options
- *
- * @param {Object} form - url encoded form params accumulator
- * @param {Object} param - url encoded form param
- *
- * @returns {Object}
- */
-urlEncodedBodyReducer = function (form, param) {
-    if (!param || param.disabled) {
-        return form;
-    }
-
-    var key = param.key,
-        value = param.value;
-
-    // add the parameter to the form while accounting for duplicate values
-    if (!form.hasOwnProperty(key)) {
-        form[key] = value;
-
-        return form;
-    }
-
-    // at this point, we know that form has duplicate, so we need to accumulate it in an array
-    if (!Array.isArray(form[key])) {
-        form[key] = [form[key]];
-    }
-
-    form[key].push(value); // finally push the duplicate and return
-
-    return form;
-};
 
 /**
  * Reduces postman SDK multi-part form definition (flattened to array) into Node compatible body options
@@ -131,7 +98,7 @@ module.exports = {
         if (content && _.isFunction(content.all)) { content = content.all(); } // flatten the body content
 
         return {
-            form: _.reduce(content, urlEncodedBodyReducer, {})
+            body: urlEncoder.encodeQueryParams(content)
         };
     },
 

--- a/lib/requester/core.js
+++ b/lib/requester/core.js
@@ -244,6 +244,7 @@ module.exports = {
         options.time = defaultOpts.timings;
         options.verbose = defaultOpts.verbose;
         options.extraCA = defaultOpts.extendedRootCA;
+        options.disablePostmanUrlEncoder = true;
 
         // Ensures that "request" creates URL encoded formdata or querystring as
         // foo=bar&foo=baz instead of foo[0]=bar&foo[1]=baz

--- a/lib/requester/core.js
+++ b/lib/requester/core.js
@@ -244,7 +244,10 @@ module.exports = {
         options.time = defaultOpts.timings;
         options.verbose = defaultOpts.verbose;
         options.extraCA = defaultOpts.extendedRootCA;
-        options.disablePostmanUrlEncoder = true;
+
+        // Disable encoding of URL in postman-request in order to use pre-encoded URL object returned from
+        // toNodeUrl() function of postman-url-encoder
+        options.disableUrlEncoding = true;
 
         // Ensures that "request" creates URL encoded formdata or querystring as
         // foo=bar&foo=baz instead of foo[0]=bar&foo[1]=baz
@@ -402,9 +405,9 @@ module.exports = {
             responseJSON.request && _.assign(responseJSON.request, {
                 data: requestOptions.form || requestOptions.formData || requestOptions.body || {},
                 uri: { // @todo remove this
-                    href: requestOptions.url
+                    href: requestOptions.url && requestOptions.url.href || requestOptions.url
                 },
-                url: requestOptions.url
+                url: requestOptions.url && requestOptions.url.href || requestOptions.url
             });
 
             rawResponse.rawHeaders &&
@@ -426,9 +429,9 @@ module.exports = {
                 method: requestOptions.method || 'GET',
                 headers: requestOptions.headers,
                 uri: { // @todo remove this
-                    href: requestOptions.url
+                    href: requestOptions.url && requestOptions.url.href || requestOptions.url
                 },
-                url: requestOptions.url,
+                url: requestOptions.url && requestOptions.url.href || requestOptions.url,
                 data: requestOptions.form || requestOptions.formData || requestOptions.body || {}
             }
         };

--- a/lib/requester/core.js
+++ b/lib/requester/core.js
@@ -4,6 +4,7 @@ var dns = require('dns'),
     _ = require('lodash'),
     uuid = require('uuid/v4'),
     sdk = require('postman-collection'),
+    urlEncoder = require('postman-url-encoder'),
 
     Socket = require('net').Socket,
 
@@ -224,19 +225,18 @@ module.exports = {
             networkOptions = defaultOpts.network || {},
             self = this,
             bodyParams,
-            url,
+            url = request.url && urlEncoder.toNodeUrl(request.url),
             isSSL,
             reqOption,
             portNumber,
             behaviorName,
-            port = request.url && request.url.port,
-            hostname = request.url && request.url.getHost();
+            port = url && url.port,
+            hostname = url && url.hostname;
 
         !defaultOpts && (defaultOpts = {});
         !protocolProfileBehavior && (protocolProfileBehavior = {});
 
-        url = request.url.toString();
-        options.url = (/^https?:\/\//i).test(url) ? url : 'http://' + url;
+        options.url = url;
         options.method = request.method;
         options.jar = defaultOpts.cookieJar || true;
         options.timeout = defaultOpts.timeout;
@@ -294,7 +294,7 @@ module.exports = {
 
         // The underlying Node client does add the host header by itself, but we add it anyway, so that
         // it is bubbled up to us after the request is made. If left to the underlying core, it's not :/
-        self.ensureHeaderExists(options.headers, 'Host', request.url.getRemote());
+        self.ensureHeaderExists(options.headers, 'Host', url.host);
 
         // override DNS lookup
         if (networkOptions.restrictedAddresses || hostname.toLowerCase() === LOCALHOST || networkOptions.hostLookup) {

--- a/lib/requester/core.js
+++ b/lib/requester/core.js
@@ -225,7 +225,7 @@ module.exports = {
             networkOptions = defaultOpts.network || {},
             self = this,
             bodyParams,
-            url = request.url && urlEncoder.toNodeUrl(request.url),
+            url = request.url && urlEncoder.toNodeUrl(request.url.toString(true)),
             isSSL,
             reqOption,
             portNumber,

--- a/package-lock.json
+++ b/package-lock.json
@@ -369,7 +369,7 @@
     },
     "bluebird": {
       "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
+      "resolved": "http://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
       "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE="
     },
     "brace-expansion": {
@@ -1033,7 +1033,7 @@
         },
         "source-map": {
           "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
           "integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
           "dev": true,
           "optional": true,
@@ -2209,7 +2209,7 @@
       "dependencies": {
         "async": {
           "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "resolved": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
           "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
           "dev": true
         },
@@ -2313,13 +2313,13 @@
         },
         "marked": {
           "version": "0.3.19",
-          "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.19.tgz",
+          "resolved": "http://registry.npmjs.org/marked/-/marked-0.3.19.tgz",
           "integrity": "sha512-ea2eGWOqNxPcXv8dyERdSr/6FmzvWwzjMxpfGB/sbMccXoct+xY+YukPD+QTUZwyvK7BZwcr4m21WBOW41pAkg==",
           "dev": true
         },
         "underscore": {
           "version": "1.8.3",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+          "resolved": "http://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
           "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
           "dev": true
         }
@@ -2651,7 +2651,7 @@
     },
     "minimist": {
       "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
       "dev": true
     },
@@ -2678,7 +2678,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "requires": {
@@ -3034,7 +3034,7 @@
     },
     "os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
@@ -3119,7 +3119,7 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
@@ -3347,7 +3347,7 @@
       "dependencies": {
         "array-back": {
           "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
+          "resolved": "http://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
           "integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
           "dev": true,
           "requires": {
@@ -3465,7 +3465,7 @@
       "dependencies": {
         "underscore": {
           "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
+          "resolved": "http://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
           "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag=",
           "dev": true
         }
@@ -3473,7 +3473,7 @@
     },
     "resolve": {
       "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+      "resolved": "http://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
       "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
       "dev": true
     },
@@ -3548,7 +3548,7 @@
     },
     "safe-regex": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "dev": true,
       "requires": {
@@ -3833,7 +3833,7 @@
       "dependencies": {
         "array-back": {
           "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
+          "resolved": "http://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
           "integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
           "dev": true,
           "requires": {
@@ -3877,7 +3877,7 @@
     },
     "sprintf-js": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "resolved": "http://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
@@ -3943,7 +3943,7 @@
       "dependencies": {
         "array-back": {
           "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
+          "resolved": "http://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
           "integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
           "dev": true,
           "requires": {
@@ -4096,7 +4096,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
@@ -4232,7 +4232,7 @@
     },
     "underscore": {
       "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
+      "resolved": "http://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
       "integrity": "sha1-a7rwh3UA02vjTsqlhODbn+8DUgk="
     },
     "underscore-contrib": {
@@ -4246,7 +4246,7 @@
       "dependencies": {
         "underscore": {
           "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
+          "resolved": "http://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
           "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag=",
           "dev": true
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -369,7 +369,7 @@
     },
     "bluebird": {
       "version": "2.11.0",
-      "resolved": "http://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
       "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE="
     },
     "brace-expansion": {
@@ -3201,6 +3201,11 @@
         "uuid": "3.3.2"
       },
       "dependencies": {
+        "postman-url-encoder": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/postman-url-encoder/-/postman-url-encoder-1.0.1.tgz",
+          "integrity": "sha1-oJSkLpQV/wu/3ODqqOYBHUSe6Dw="
+        },
         "semver": {
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.0.0.tgz",
@@ -3215,9 +3220,9 @@
       "dev": true
     },
     "postman-request": {
-      "version": "2.88.1-postman.8",
-      "resolved": "https://registry.npmjs.org/postman-request/-/postman-request-2.88.1-postman.8.tgz",
-      "integrity": "sha512-lXxc4R6+g4oiLPA937Thl5MGdFBV7FSBN4WnUhKNq2UWEt+YJrOEYv0UOP6pH7kPF5cg8IXG1lHls7IWf8if4A==",
+      "version": "2.88.1-postman.9",
+      "resolved": "https://registry.npmjs.org/postman-request/-/postman-request-2.88.1-postman.9.tgz",
+      "integrity": "sha512-rHJuOLGH3cZOFOPubjQ9Ho4H0YqZScjyLCBXQq7lwBgiFVnwk9DUc9rpdCSlJajJiLIN7fjyXkckP09erVGK/w==",
       "requires": {
         "aws-sign2": "~0.7.0",
         "aws4": "^1.8.0",
@@ -3241,6 +3246,13 @@
         "tough-cookie": "~2.5.0",
         "tunnel-agent": "^0.6.0",
         "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "postman-url-encoder": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/postman-url-encoder/-/postman-url-encoder-1.0.1.tgz",
+          "integrity": "sha1-oJSkLpQV/wu/3ODqqOYBHUSe6Dw="
+        }
       }
     },
     "postman-sandbox": {
@@ -3255,9 +3267,9 @@
       }
     },
     "postman-url-encoder": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/postman-url-encoder/-/postman-url-encoder-1.0.1.tgz",
-      "integrity": "sha1-oJSkLpQV/wu/3ODqqOYBHUSe6Dw="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/postman-url-encoder/-/postman-url-encoder-1.0.2.tgz",
+      "integrity": "sha512-PBGPIJnm9dqyUST/oX9mxTxT5seqWS4AdzAhGt4judiOh7xT4leTv2CLoGtHXUCHFuLLp9h9wDGAMN7Cm0Znyw=="
     },
     "prelude-ls": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -41,8 +41,9 @@
     "node-oauth1": "1.2.2",
     "performance-now": "2.1.0",
     "postman-collection": "3.4.7-beta.3",
-    "postman-request": "2.88.1-postman.8",
+    "postman-request": "2.88.1-postman.9",
     "postman-sandbox": "3.2.6",
+    "postman-url-encoder": "1.0.2",
     "resolve-from": "4.0.0",
     "serialised-error": "1.1.3",
     "uuid": "3.3.2"

--- a/test/integration/request-flow/unicode-url.test.js
+++ b/test/integration/request-flow/unicode-url.test.js
@@ -34,6 +34,12 @@ describe('UTF-8 hostname', function () {
         });
     });
 
+    it('should have the Host header with correct value in sent request', function () {
+        var request = testrun.request.getCall(0).args[3];
+
+        expect(request.headers.get('Host')).to.equal('xn--nstq34i.com');
+    });
+
     it('should have completed the run', function () {
         expect(testrun).to.be.ok;
         expect(testrun.done.getCall(0).args[0]).to.be.null;

--- a/test/integration/request-flow/unicode-url.test.js
+++ b/test/integration/request-flow/unicode-url.test.js
@@ -1,0 +1,56 @@
+var dns = require('dns'),
+    expect = require('chai').expect;
+
+describe('UTF-8 hostname', function () {
+    var testrun;
+
+    before(function (done) {
+        var self = this;
+
+        // Not hard-coding since this can change
+        dns.lookup('postman-echo.com', function (err, echoIp) {
+            if (err) {
+                return done(err);
+            }
+
+            return self.run({
+                collection: {
+                    item: {
+                        request: 'http://邮差.com/get?foo=bar'
+                    }
+                },
+                network: {
+                    hostLookup: {
+                        type: 'hostIpMap',
+                        hostIpMap: {
+                            'xn--nstq34i.com': echoIp // 邮差.com is encoded to xn--nstq34i.com while sending request
+                        }
+                    }
+                }
+            }, function (err, results) {
+                testrun = results;
+                done(err);
+            });
+        });
+    });
+
+    it('should have completed the run', function () {
+        expect(testrun).to.be.ok;
+        expect(testrun.done.getCall(0).args[0]).to.be.null;
+        expect(testrun).to.nested.include({
+            'done.calledOnce': true,
+            'start.calledOnce': true
+        });
+    });
+
+    it('should have used the provided hostIpMap for resolving UTF-8 hostname', function () {
+        expect(testrun.response.getCall(0).args[0]).to.be.null;
+
+        var response = testrun.response.firstCall.args[2];
+
+        expect(response).to.have.property('code', 200);
+        expect(response.json()).to.deep.include({
+            args: {foo: 'bar'}
+        });
+    });
+});

--- a/test/unit/requester-core.test.js
+++ b/test/unit/requester-core.test.js
@@ -1,5 +1,6 @@
 var expect = require('chai').expect,
     sdk = require('postman-collection'),
+    urlEncoder = require('postman-url-encoder'),
     runtimeVersion = require('../../package').version,
     requesterCore = require('../../lib/requester/core');
 
@@ -28,7 +29,7 @@ describe('requester util', function () {
                     Host: 'postman-echo.com'
                 },
                 body: '{"alpha": "foo"}',
-                url: 'http://postman-echo.com/post',
+                url: urlEncoder.toNodeUrl('http://postman-echo.com/post'),
                 method: 'POST',
                 jar: true,
                 timeout: undefined,
@@ -65,7 +66,7 @@ describe('requester util', function () {
                     Accept: '*/*',
                     Host: 'postman-echo.com'
                 },
-                url: 'https://postman-echo.com',
+                url: urlEncoder.toNodeUrl('https://postman-echo.com'),
                 method: 'GET',
                 jar: true,
                 timeout: undefined,
@@ -85,7 +86,8 @@ describe('requester util', function () {
             });
         });
 
-        describe('Should accept URL irrespective of the case', function () {
+        // skipping this because urlEncoder.toNodeUrl() doesn't preserve original case in URL
+        describe.skip('Should accept URL irrespective of the case', function () {
             it('should accept URL in uppercase', function () {
                 var request = new sdk.Request({
                     url: 'HTTP://POSTMAN-ECHO.COM/POST',
@@ -198,7 +200,7 @@ describe('requester util', function () {
                     Accept: '*/*',
                     Host: ''
                 },
-                url: 'http://',
+                url: urlEncoder.toNodeUrl('http://'),
                 method: 'GET',
                 jar: true,
                 timeout: undefined,

--- a/test/unit/requester-core.test.js
+++ b/test/unit/requester-core.test.js
@@ -45,7 +45,8 @@ describe('requester util', function () {
                 extraCA: undefined,
                 agentOptions: {keepAlive: undefined},
                 time: undefined,
-                verbose: undefined
+                verbose: undefined,
+                disablePostmanUrlEncoder: true
             });
         });
 
@@ -82,7 +83,8 @@ describe('requester util', function () {
                 extraCA: undefined,
                 agentOptions: {keepAlive: undefined},
                 time: undefined,
-                verbose: undefined
+                verbose: undefined,
+                disablePostmanUrlEncoder: true
             });
         });
 
@@ -216,7 +218,8 @@ describe('requester util', function () {
                 extraCA: undefined,
                 agentOptions: {keepAlive: undefined},
                 time: undefined,
-                verbose: undefined
+                verbose: undefined,
+                disablePostmanUrlEncoder: true
             });
         });
     });


### PR DESCRIPTION
- Use postman-url-encoder everywhere
- Use encoded URLs in auth helpers
- Send URL object to postman-request instead of string
- Encode body for URL-Encoded Forms in runtime itself