### PR TITLE
Added followOrder lookup strategy to extract runnable items

### DIFF
--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -1,3 +1,7 @@
+master:
+  new features:
+    - Added support for multi entrypoints by id or name which follows the given order
+
 7.13.0:
   date: 2019-04-26
   new features:

--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -1,6 +1,8 @@
 master:
   new features:
-    - Added support for multi entrypoints by id or name which follows the given order
+    - GH-832 Added support for multi entrypoints by id or name which follows the given order
+  chores:
+    - Updated dependencies
 
 7.13.0:
   date: 2019-04-26

--- a/lib/runner/extract-runnable-items.js
+++ b/lib/runner/extract-runnable-items.js
@@ -3,6 +3,7 @@ var sdk = require('postman-collection'),
     Item = sdk.Item,
 
     DEFAULT_LOOKUP_STRATEGY = 'idOrName',
+    FOLLOW_ORDER_LOOKUP_STRATEGY = 'followOrder',
     INVALID_LOOKUP_STRATEGY_ERROR = 'runtime~extractRunnableItems: Invalid entrypoint lookupStrategy',
 
     /**
@@ -68,13 +69,13 @@ var sdk = require('postman-collection'),
      * @param {ItemGroup} itemGroup - Composite list of Item or ItemGroup.
      * @param {Object} entrypointSubset - Entry-points reference passed across multiple recursive calls.
      * @param {Boolean} _continueAccumulation - Flag used to decide whether to accumulate items or not.
-     * @param {Array<String>} _accumulatedItems - Found Items or ItemGroups.
-     * @returns {Object}
+     * @param {Object} _accumulatedItems - Found Items or ItemGroups.
+     * @returns {Object} Found Items or ItemGroups.
      */
     findItemsOrGroups = function (itemGroup, entrypointSubset, _continueAccumulation, _accumulatedItems) {
-        if (!itemGroup || !itemGroup.items) { return; }
+        !_accumulatedItems && (_accumulatedItems = {members: [], reference: {}});
 
-        !_accumulatedItems && (_accumulatedItems = []);
+        if (!itemGroup || !itemGroup.items) { return _accumulatedItems; }
 
         var match;
 
@@ -89,7 +90,10 @@ var sdk = require('postman-collection'),
 
             if (match) {
                 // only accumulate items which are not previously got tracked from its parent entrypoint.
-                _continueAccumulation && _accumulatedItems.push(item);
+                if (_continueAccumulation) {
+                    _accumulatedItems.members.push(item);
+                    _accumulatedItems.reference[match] = item;
+                }
 
                 // delete looked-up entrypoint.
                 delete entrypointSubset[match];
@@ -153,8 +157,18 @@ var sdk = require('postman-collection'),
         callback(null, flattenNode(matched), matched);
     },
 
+    /**
+     * Finds items or item groups in a collection with matching list of ids or names.
+     *
+     * @param {Collection} collection
+     * @param {Object} options
+     * @param {Array} [options.execute]
+     * @param {String} [options.lookupStrategy]
+     * @param {Function} callback
+     */
     lookupByMultipleIdOrName = function (collection, options, callback) {
         var entrypoints = options.execute,
+            lookupStrategy = options.lookupStrategy,
             entrypointLookup = {},
             runnableItems = [],
             items,
@@ -182,8 +196,17 @@ var sdk = require('postman-collection'),
         }
 
         // extract runnable items from the searched items.
-        for (i = 0, ii = items.length; i < ii; i++) {
-            runnableItems = runnableItems.concat(flattenNode(items[i]));
+        // follow the order of entrypoints
+        if (lookupStrategy === FOLLOW_ORDER_LOOKUP_STRATEGY) {
+            entrypoints.forEach(function (entrypoint) {
+                runnableItems = runnableItems.concat(flattenNode(items.reference[entrypoint]));
+            });
+        }
+        // otherwise, follow the order in which the items are defined in the collection
+        else {
+            for (i = 0, ii = items.members.length; i < ii; i++) {
+                runnableItems = runnableItems.concat(flattenNode(items.members[i]));
+            }
         }
 
         callback(null, runnableItems, collection);
@@ -192,6 +215,7 @@ var sdk = require('postman-collection'),
     lookupStrategyMap = {
         path: lookupByPath,
         idOrName: lookupByIdOrName,
+        followOrder: lookupByMultipleIdOrName,
         multipleIdOrName: lookupByMultipleIdOrName
     },
 

--- a/lib/runner/extract-runnable-items.js
+++ b/lib/runner/extract-runnable-items.js
@@ -3,7 +3,6 @@ var sdk = require('postman-collection'),
     Item = sdk.Item,
 
     DEFAULT_LOOKUP_STRATEGY = 'idOrName',
-    FOLLOW_ORDER_LOOKUP_STRATEGY = 'followOrder',
     INVALID_LOOKUP_STRATEGY_ERROR = 'runtime~extractRunnableItems: Invalid entrypoint lookupStrategy',
 
     /**
@@ -160,15 +159,15 @@ var sdk = require('postman-collection'),
     /**
      * Finds items or item groups in a collection with matching list of ids or names.
      *
+     * @note runnable items follows the order in which the items are defined in the collection
+     *
      * @param {Collection} collection
      * @param {Object} options
-     * @param {Array} [options.execute]
-     * @param {String} [options.lookupStrategy]
+     * @param {Array<String>} [options.execute]
      * @param {Function} callback
      */
     lookupByMultipleIdOrName = function (collection, options, callback) {
         var entrypoints = options.execute,
-            lookupStrategy = options.lookupStrategy,
             entrypointLookup = {},
             runnableItems = [],
             items,
@@ -196,18 +195,55 @@ var sdk = require('postman-collection'),
         }
 
         // extract runnable items from the searched items.
-        // follow the order of entrypoints
-        if (lookupStrategy === FOLLOW_ORDER_LOOKUP_STRATEGY) {
-            entrypoints.forEach(function (entrypoint) {
-                runnableItems = runnableItems.concat(flattenNode(items.reference[entrypoint]));
-            });
+        for (i = 0, ii = items.members.length; i < ii; i++) {
+            runnableItems = runnableItems.concat(flattenNode(items.members[i]));
         }
-        // otherwise, follow the order in which the items are defined in the collection
-        else {
-            for (i = 0, ii = items.members.length; i < ii; i++) {
-                runnableItems = runnableItems.concat(flattenNode(items.members[i]));
-            }
+
+        callback(null, runnableItems, collection);
+    },
+
+    /**
+     * Finds items or item groups in a collection with matching list of ids or names.
+     *
+     * @note runnable items follows the order of entrypoints
+     *
+     * @param {Collection} collection
+     * @param {Object} options
+     * @param {Array<String>} [options.execute]
+     * @param {Function} callback
+     */
+    lookupByOrder = function (collection, options, callback) {
+        var entrypoints = options.execute,
+            entrypointLookup = {},
+            runnableItems = [],
+            items,
+            i,
+            ii;
+
+        if (!(Array.isArray(entrypoints) && entrypoints.length)) {
+            return callback(null, []);
         }
+
+        // add temp reference for faster lookup of entry-point name/id.
+        // entry-points with same name/id will be ignored.
+        for (i = 0, ii = entrypoints.length; i < ii; i++) {
+            entrypointLookup[entrypoints[i]] = true;
+        }
+
+        items = findItemsOrGroups(collection, entrypointLookup, true);
+
+        // at this point of time, we should have traversed all items mentioned in entrypoint and created a linear
+        // subset of items. However, if post that, we still have items remaining in lookup object, that implies that
+        // extra items were present in user input and corresponding items for those do not exist in collection. As such
+        // we need to bail out if any of the given entry-point is not found.
+        if (Object.keys(entrypointLookup).length) {
+            return callback(null, []);
+        }
+
+        // extract runnable items from the searched items.
+        entrypoints.forEach(function (entrypoint) {
+            runnableItems = runnableItems.concat(flattenNode(items.reference[entrypoint]));
+        });
 
         callback(null, runnableItems, collection);
     },
@@ -215,7 +251,7 @@ var sdk = require('postman-collection'),
     lookupStrategyMap = {
         path: lookupByPath,
         idOrName: lookupByIdOrName,
-        followOrder: lookupByMultipleIdOrName,
+        followOrder: lookupByOrder,
         multipleIdOrName: lookupByMultipleIdOrName
     },
 

--- a/test/unit/extract-runnable-items.test.js
+++ b/test/unit/extract-runnable-items.test.js
@@ -18,6 +18,7 @@ describe('extractRunnableItems', function () {
                     id: 'ID4',
                     name: 'F1.F1',
                     item: [{
+                        id: 'IDx',
                         name: 'F1.F1.R1',
                         request: 'https://postman-echo.com/cookies'
                     }]
@@ -482,6 +483,221 @@ describe('extractRunnableItems', function () {
                     expect(runnableItems).to.have.lengthOf(1);
                     expect(_.map(runnableItems, 'id')).to.eql(['ID1']);
                     expect(entrypoint).to.have.property('name', 'Collection C2');
+                    done();
+                }
+            );
+        });
+    });
+
+    describe('lookupStrategy: followOrder', function () {
+        it('should handle invalid entry points', function (done) {
+            extractRunnableItems(
+                collection, {
+                    execute: 'random',
+                    lookupStrategy: 'followOrder'
+                },
+                function (err, runnableItems, entrypoint) {
+                    expect(err).to.be.null;
+                    expect(runnableItems).to.eql([]);
+                    expect(entrypoint).to.be.undefined;
+                    done();
+                }
+            );
+        });
+
+        it('should bail out if any of the given entrypoint is not found. ', function (done) {
+            extractRunnableItems(
+                collection, {
+                    execute: ['ID3', 'RANDOM'],
+                    lookupStrategy: 'followOrder'
+                },
+                function (err, runnableItems, entrypoint) {
+                    expect(err).to.be.null;
+                    expect(runnableItems).to.eql([]);
+                    expect(entrypoint).to.be.undefined;
+                    done();
+                }
+            );
+        });
+
+        it('should filter single item group by id', function (done) {
+            extractRunnableItems(
+                collection, {
+                    execute: ['ID2'],
+                    lookupStrategy: 'followOrder'
+                },
+                function (err, runnableItems, entrypoint) {
+                    expect(err).to.be.null;
+                    expect(_.map(runnableItems, 'name')).to.eql(['F2.R1']);
+                    expect(entrypoint).to.have.property('name', 'Collection C1');
+                    done();
+                }
+            );
+        });
+
+        it('should filter multiple item groups by id and follow the order', function (done) {
+            extractRunnableItems(
+                collection, {
+                    execute: ['ID2', 'ID1'],
+                    lookupStrategy: 'followOrder'
+                },
+                function (err, runnableItems, entrypoint) {
+                    expect(err).to.be.null;
+                    expect(_.map(runnableItems, 'name')).to.eql(['F2.R1', 'F1.R1', 'F1.F1.R1']);
+                    expect(entrypoint).to.have.property('name', 'Collection C1');
+                    done();
+                }
+            );
+        });
+
+        it('should filter single item by id', function (done) {
+            extractRunnableItems(
+                collection, {
+                    execute: ['ID3'],
+                    lookupStrategy: 'followOrder'
+                },
+                function (err, runnableItems, entrypoint) {
+                    expect(err).to.be.null;
+                    expect(_.map(runnableItems, 'name')).to.eql(['F1.R1']);
+                    expect(entrypoint).to.have.property('name', 'Collection C1');
+                    done();
+                }
+            );
+        });
+
+        it('should filter multiple items by id and follow the order', function (done) {
+            extractRunnableItems(
+                collection, {
+                    execute: ['ID3', 'ID6', 'ID4'],
+                    lookupStrategy: 'followOrder'
+                },
+                function (err, runnableItems, entrypoint) {
+                    expect(err).to.be.null;
+                    expect(_.map(runnableItems, 'name')).to.eql(['F1.R1', 'R1', 'F1.F1.R1']);
+                    expect(entrypoint).to.have.property('name', 'Collection C1');
+                    done();
+                }
+            );
+        });
+
+        it('should filter single item group by name', function (done) {
+            extractRunnableItems(
+                collection, {
+                    execute: ['F1'],
+                    lookupStrategy: 'followOrder'
+                },
+                function (err, runnableItems, entrypoint) {
+                    expect(err).to.be.null;
+                    expect(_.map(runnableItems, 'name')).to.eql(['F1.R1', 'F1.F1.R1']);
+                    expect(entrypoint).to.have.property('name', 'Collection C1');
+                    done();
+                }
+            );
+        });
+
+        it('should filter multiple item groups by name and follow the order', function (done) {
+            extractRunnableItems(
+                collection, {
+                    execute: ['F2', 'F1'],
+                    lookupStrategy: 'followOrder'
+                },
+                function (err, runnableItems, entrypoint) {
+                    expect(err).to.be.null;
+                    expect(_.map(runnableItems, 'name')).to.eql(['F2.R1', 'F1.R1', 'F1.F1.R1']);
+                    expect(entrypoint).to.have.property('name', 'Collection C1');
+                    done();
+                }
+            );
+        });
+
+        it('should filter single item by name', function (done) {
+            extractRunnableItems(
+                collection, {
+                    execute: ['F1.R1'],
+                    lookupStrategy: 'followOrder'
+                },
+                function (err, runnableItems, entrypoint) {
+                    expect(err).to.be.null;
+                    expect(runnableItems).to.have.lengthOf(1);
+                    expect(_.map(runnableItems, 'name')).to.eql(['F1.R1']);
+                    expect(entrypoint).to.have.property('name', 'Collection C1');
+                    done();
+                }
+            );
+        });
+
+        it('should filter multiple items by name and follow the order', function (done) {
+            extractRunnableItems(
+                collection, {
+                    execute: ['F2.R1', 'F1.R1'],
+                    lookupStrategy: 'followOrder'
+                },
+                function (err, runnableItems, entrypoint) {
+                    expect(err).to.be.null;
+                    expect(_.map(runnableItems, 'name')).to.eql(['F2.R1', 'F1.R1']);
+                    expect(entrypoint).to.have.property('name', 'Collection C1');
+                    done();
+                }
+            );
+        });
+
+        it('should filter by combination of id and name and follow the order', function (done) {
+            extractRunnableItems(
+                collection, {
+                    execute: ['F2', 'ID1'],
+                    lookupStrategy: 'followOrder'
+                },
+                function (err, runnableItems, entrypoint) {
+                    expect(err).to.be.null;
+                    expect(_.map(runnableItems, 'name')).to.eql(['F2.R1', 'F1.R1', 'F1.F1.R1']);
+                    expect(entrypoint).to.have.property('name', 'Collection C1');
+                    done();
+                }
+            );
+        });
+
+        it('should avoid nested entrypoints', function (done) {
+            extractRunnableItems(
+                collection, {
+                    execute: ['F1', 'F1.F1', 'F1.F1.R1'],
+                    lookupStrategy: 'followOrder'
+                },
+                function (err, runnableItems, entrypoint) {
+                    expect(err).to.be.null;
+                    expect(_.map(runnableItems, 'name')).to.eql(['F1.R1', 'F1.F1.R1']);
+                    expect(entrypoint).to.have.property('name', 'Collection C1');
+                    done();
+                }
+            );
+        });
+
+        it('should choose the first match in collection order', function (done) {
+            extractRunnableItems(
+                collectionWithDuplicates, {
+                    execute: ['R1'],
+                    lookupStrategy: 'followOrder'
+                },
+                function (err, runnableItems, entrypoint) {
+                    expect(err).to.be.null;
+                    expect(runnableItems).to.have.lengthOf(1);
+                    expect(_.map(runnableItems, 'id')).to.eql(['ID1']);
+                    expect(entrypoint).to.have.property('name', 'Collection C2');
+                    done();
+                }
+            );
+        });
+
+        it('should follow the order for duplicates', function (done) {
+            extractRunnableItems(
+                collection, {
+                    execute: ['R1', 'ID4', 'R1'],
+                    lookupStrategy: 'followOrder'
+                },
+                function (err, runnableItems, entrypoint) {
+                    expect(err).to.be.null;
+                    expect(runnableItems).to.have.lengthOf(3);
+                    expect(_.map(runnableItems, 'id')).to.eql(['ID6', 'IDx', 'ID6']);
+                    expect(entrypoint).to.have.property('name', 'Collection C1');
                     done();
                 }
             );


### PR DESCRIPTION
Added `followOrder` lookup strategy which supports:
- multiple id or name lookup
- enforce the order to follow
- supports duplicates i.e, iterate the same item multiple times