### PR TITLE
Added maxResponseSize requester option

### DIFF
--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -2,6 +2,9 @@
   date: 2019-06-07
   new features:
     - GH-840 Added responseStart callback
+    - >-
+      GH-844 Added `maxResponseSize` requester option which aborts the request
+      if the response size exceeds the threshold
   fixed bugs:
     - GH-837 Fixed a bug where invalid url crashes the process
   chores:

--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -3,7 +3,7 @@
   new features:
     - GH-840 Added responseStart callback
     - >-
-      GH-844 Added `maxResponseSize` requester option which aborts the request
+      GH-845 Added `maxResponseSize` requester option which aborts the request
       if the response size exceeds the threshold
   fixed bugs:
     - GH-837 Fixed a bug where invalid url crashes the process

--- a/README.md
+++ b/README.md
@@ -95,6 +95,9 @@ runner.run(collection, {
         // Maximum number of redirects to follow (only supported on Node, ignored in the browser)
         maxRedirects: 10,
 
+        // Maximum allowed response size in bytes (only supported on Node, ignored in the browser)
+        maxResponseSize: 1000000,
+
         // Removes the `referer` header when a redirect happens (only supported on Node, ignored in the browser)
         removeRefererHeaderOnRedirect: false,
 

--- a/lib/requester/core.js
+++ b/lib/requester/core.js
@@ -279,6 +279,10 @@ module.exports = {
             options.ciphers = protocolProfileBehavior.tlsCipherSelection.join(':');
         }
 
+        if (typeof defaultOpts.maxResponseSize === 'number') {
+            options.maxResponseSize = defaultOpts.maxResponseSize;
+        }
+
         // Request body may return different options depending on the type of the body.
         bodyParams = self.getRequestBody(request, protocolProfileBehavior);
 

--- a/lib/requester/core.js
+++ b/lib/requester/core.js
@@ -213,6 +213,7 @@ module.exports = {
      * @param defaultOpts.followRedirects
      * @param defaultOpts.followOriginalHttpMethod
      * @param defaultOpts.maxRedirects
+     * @param defaultOpts.maxResponseSize
      * @param defaultOpts.implicitCacheControl
      * @param defaultOpts.implicitTraceHeader
      * @param defaultOpts.removeRefererHeaderOnRedirect

--- a/lib/requester/requester-pool.js
+++ b/lib/requester/requester-pool.js
@@ -22,6 +22,7 @@ RequesterPool = function (options, callback) {
         keepAlive: _.get(options, 'requester.keepAlive', true),
         cookieJar: _.get(options, 'requester.cookieJar'), // default set later in this constructor
         strictSSL: _.get(options, 'requester.strictSSL'),
+        maxResponseSize: _.get(options, 'requester.maxResponseSize'),
         followRedirects: _.get(options, 'requester.followRedirects', true),
         followOriginalHttpMethod: _.get(options, 'requester.followOriginalHttpMethod'),
         maxRedirects: _.get(options, 'requester.maxRedirects'),

--- a/test/integration/requester-spec/maxResponseSize.test.js
+++ b/test/integration/requester-spec/maxResponseSize.test.js
@@ -1,0 +1,208 @@
+var sinon = require('sinon'),
+    expect = require('chai').expect;
+
+describe('Requester Spec: maxResponseSize', function () {
+    var testrun,
+        HOST = 'https://httpbin.org/bytes/10';
+
+    describe('with response > maxResponseSize', function () {
+        before(function (done) {
+            this.run({
+                requester: {
+                    maxResponseSize: 9
+                },
+                collection: {
+                    item: [{
+                        request: {
+                            url: HOST
+                        }
+                    }]
+                }
+            }, function (err, results) {
+                testrun = results;
+                done(err);
+            });
+        });
+
+        it('should complete the run', function () {
+            expect(testrun).to.be.ok;
+            sinon.assert.calledOnce(testrun.start);
+            sinon.assert.calledOnce(testrun.done);
+            sinon.assert.calledWith(testrun.done.getCall(0), null);
+        });
+
+        it('should abort the request', function () {
+            sinon.assert.calledOnce(testrun.request);
+            sinon.assert.calledOnce(testrun.response);
+            sinon.assert.calledOnce(testrun.responseStart);
+
+            sinon.assert.calledWith(testrun.responseStart.getCall(0), null);
+            expect(testrun.request.getCall(0).args[0]).to.have.property('message')
+                .that.equal('Maximum response size reached');
+            expect(testrun.response.getCall(0).args[0]).to.have.property('message')
+                .that.equal('Maximum response size reached');
+        });
+    });
+
+    describe('with response = maxResponseSize', function () {
+        before(function (done) {
+            this.run({
+                requester: {
+                    maxResponseSize: 10
+                },
+                collection: {
+                    item: [{
+                        request: {
+                            url: HOST
+                        }
+                    }]
+                }
+            }, function (err, results) {
+                testrun = results;
+                done(err);
+            });
+        });
+
+        it('should complete the run', function () {
+            expect(testrun).to.be.ok;
+            sinon.assert.calledOnce(testrun.start);
+            sinon.assert.calledOnce(testrun.done);
+            sinon.assert.calledWith(testrun.done.getCall(0), null);
+        });
+
+        it('should receive response body', function () {
+            sinon.assert.calledOnce(testrun.request);
+            sinon.assert.calledOnce(testrun.response);
+            sinon.assert.calledOnce(testrun.responseStart);
+
+            sinon.assert.calledWith(testrun.request.getCall(0), null);
+            sinon.assert.calledWith(testrun.response.getCall(0), null);
+            sinon.assert.calledWith(testrun.responseStart.getCall(0), null);
+
+            var response = testrun.response.getCall(0).args[2];
+
+            expect(response.size()).to.have.property('body', 10);
+        });
+    });
+
+    describe('with response < maxResponseSize', function () {
+        before(function (done) {
+            this.run({
+                requester: {
+                    maxResponseSize: 100
+                },
+                collection: {
+                    item: [{
+                        request: {
+                            url: HOST
+                        }
+                    }]
+                }
+            }, function (err, results) {
+                testrun = results;
+                done(err);
+            });
+        });
+
+        it('should complete the run', function () {
+            expect(testrun).to.be.ok;
+            sinon.assert.calledOnce(testrun.start);
+            sinon.assert.calledOnce(testrun.done);
+            sinon.assert.calledWith(testrun.done.getCall(0), null);
+        });
+
+        it('should receive response body', function () {
+            sinon.assert.calledOnce(testrun.request);
+            sinon.assert.calledOnce(testrun.response);
+            sinon.assert.calledOnce(testrun.responseStart);
+
+            sinon.assert.calledWith(testrun.request.getCall(0), null);
+            sinon.assert.calledWith(testrun.response.getCall(0), null);
+            sinon.assert.calledWith(testrun.responseStart.getCall(0), null);
+
+            var response = testrun.response.getCall(0).args[2];
+
+            expect(response.size()).to.have.property('body', 10);
+        });
+    });
+
+    describe('with maxResponseSize 0', function () {
+        before(function (done) {
+            this.run({
+                requester: {
+                    maxResponseSize: 0
+                },
+                collection: {
+                    item: [{
+                        request: {
+                            url: HOST
+                        }
+                    }]
+                }
+            }, function (err, results) {
+                testrun = results;
+                done(err);
+            });
+        });
+
+        it('should complete the run', function () {
+            expect(testrun).to.be.ok;
+            sinon.assert.calledOnce(testrun.start);
+            sinon.assert.calledOnce(testrun.done);
+            sinon.assert.calledWith(testrun.done.getCall(0), null);
+        });
+
+        it('should abort the request', function () {
+            sinon.assert.calledOnce(testrun.request);
+            sinon.assert.calledOnce(testrun.response);
+            sinon.assert.calledOnce(testrun.responseStart);
+
+            sinon.assert.calledWith(testrun.responseStart.getCall(0), null);
+            expect(testrun.request.getCall(0).args[0]).to.have.property('message')
+                .that.equal('Maximum response size reached');
+            expect(testrun.response.getCall(0).args[0]).to.have.property('message')
+                .that.equal('Maximum response size reached');
+        });
+    });
+
+    describe('with maxResponseSize Infinity', function () {
+        before(function (done) {
+            this.run({
+                requester: {
+                    maxResponseSize: Infinity
+                },
+                collection: {
+                    item: [{
+                        request: {
+                            url: HOST
+                        }
+                    }]
+                }
+            }, function (err, results) {
+                testrun = results;
+                done(err);
+            });
+        });
+
+        it('should complete the run', function () {
+            expect(testrun).to.be.ok;
+            sinon.assert.calledOnce(testrun.start);
+            sinon.assert.calledOnce(testrun.done);
+            sinon.assert.calledWith(testrun.done.getCall(0), null);
+        });
+
+        it('should receive response body', function () {
+            sinon.assert.calledOnce(testrun.request);
+            sinon.assert.calledOnce(testrun.response);
+            sinon.assert.calledOnce(testrun.responseStart);
+
+            sinon.assert.calledWith(testrun.request.getCall(0), null);
+            sinon.assert.calledWith(testrun.response.getCall(0), null);
+            sinon.assert.calledWith(testrun.responseStart.getCall(0), null);
+
+            var response = testrun.response.getCall(0).args[2];
+
+            expect(response.size()).to.have.property('body', 10);
+        });
+    });
+});


### PR DESCRIPTION
- Added `maxResponseSize` requester option which aborts the request if the response size exceeds the threshold
- default: `undefined`