### PR TITLE
Refactored requester to avoid duplicate computation for response object

### DIFF
--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -1,6 +1,14 @@
 master:
   new features:
     - GH-839 Added `includePayloadHash` option in Hawk auth to make payload hash optional
+  fixed bugs:
+    - Fixed a bug where non-string raw bodies crash the process
+    - >-
+      Fixed a bug where disabled headers with the same name as of system headers
+      don't get overwritten in the original request
+  chores:
+    - Refactored requester to avoid duplicate computation for response object
+    - Updated dependencies
 
 7.15.0:
   date: 2019-06-07

--- a/lib/requester/core-body-builder.js
+++ b/lib/requester/core-body-builder.js
@@ -119,6 +119,10 @@ module.exports = {
      * @returns {Object}
      */
     raw: function (content) {
+        if (typeof content !== STRING) {
+            content = JSON.stringify(content);
+        }
+
         return {
             body: content
         };

--- a/lib/requester/core.js
+++ b/lib/requester/core.js
@@ -423,6 +423,7 @@ module.exports = {
 
         responseBody = responseBody || '';
 
+        // @todo drop support or isolate XHR requester in v8
         // XHR :/
         return {
             statusCode: rawResponse.status,

--- a/lib/requester/requester.js
+++ b/lib/requester/requester.js
@@ -167,6 +167,8 @@ _.assign(Requester.prototype, /** @lends Requester.prototype */ {
             startTime = Date.now(),
             startTimer = now(), // high-resolution time
             cookies = [],
+            responseHeaders = [],
+            responseJSON = {},
 
             // Refer: https://github.com/postmanlabs/postman-runtime/blob/v7.14.0/docs/history.md
             getExecutionHistory = function (debugInfo) {
@@ -219,40 +221,22 @@ _.assign(Requester.prototype, /** @lends Requester.prototype */ {
                 return history;
             },
 
-            onComplete = function (error, response, history) {
-                self.emit(RESPONSE_END_EVENT_BASE + id, error, self.trace.cursor,
-                    self.trace, response, request, cookies, history);
-
-                return callback(error, response, request, cookies, history);
-            },
-
-            onStart = function (response) {
-                // @todo get rid of jsonifyResponse
-                var responseJSON = core.jsonifyResponse(response, requestOptions),
-                    responseStartEventName = RESPONSE_START_EVENT_BASE + id,
-                    sdkResponse = new sdk.Response({
-                        status: response && response.statusMessage,
-                        code: responseJSON.statusCode,
-                        header: _.transform(responseJSON.headers, transformMultiValueHeaders, [])
-                    }),
-                    history = getExecutionHistory(_.get(response, 'request._debug')),
-                    header,
+            /**
+             * Add the missing/system headers in the request object
+             *
+             * @param {Object[]} headers
+             */
+            addMissingRequestHeaders = function (headers) {
+                var header,
                     keepAlive;
 
-                // Pull out cookies from the cookie jar, and make them chrome compatible.
-                cookies = (cookieJar && _.isFunction(cookieJar.getCookies)) ?
-                    _.transform(cookieJar.getCookies(requestOptions.url), function (acc, cookie) {
-                        acc.push(toChromeCookie(cookie));
-                    }, []) : [];
-
-                // Insert the missing sent headers in the request object, so that they get bubbled up into the UI
-                _.forOwn(responseJSON.request && responseJSON.request.headers, function (value, key) {
+                _.forOwn(headers, function (value, key) {
                     header = request.headers.one(key);
 
                     // neither request nor runtime overwrites user-defined headers
                     // so instead of upsert, just add missing headers to the list
                     // with system: true flag.
-                    if (!header) {
+                    if (!header || header.disabled) {
                         request.headers.add({
                             key: key,
                             value: value,
@@ -283,8 +267,63 @@ _.assign(Requester.prototype, /** @lends Requester.prototype */ {
                         system: true
                     });
                 }
+            },
 
-                // @todo add history object for request timing information
+            /**
+             * Helper function to trigger `callback` and complete the request function
+             *
+             * @param {Error} error - error while requesting
+             * @param {Response} response - SDK Response instance
+             * @param {Object} history - Request-Response History
+             */
+            onComplete = function (error, response, history) {
+                self.emit(RESPONSE_END_EVENT_BASE + id, error, self.trace.cursor,
+                    self.trace, response, request, cookies, history);
+
+                return callback(error, response, request, cookies, history);
+            },
+
+            /**
+             * Helper function to trigger `responseStart` callback and
+             * - transform postman-request response instance to SDK Response
+             * - filter cookies
+             * - filter response headers
+             * - add missing request headers
+             *
+             * @param {Object} response - Postman-Request response instance
+             */
+            onStart = function (response) {
+                var responseStartEventName = RESPONSE_START_EVENT_BASE + id,
+                    sdkResponse,
+                    history;
+
+                // @todo get rid of jsonifyResponse
+                responseJSON = core.jsonifyResponse(response, requestOptions);
+
+                // transform response headers to SDK compatible HeaderList
+                responseHeaders = _.transform(responseJSON.headers, transformMultiValueHeaders, []);
+
+                // initialize SDK Response instance
+                sdkResponse = new sdk.Response({
+                    status: response && response.statusMessage,
+                    code: responseJSON.statusCode,
+                    header: responseHeaders
+                });
+
+                // add missing request headers so that they get bubbled up into the UI
+                addMissingRequestHeaders(responseJSON.request && responseJSON.request.headers);
+
+                // Pull out cookies from the cookie jar, and make them chrome compatible.
+                cookies = (cookieJar && _.isFunction(cookieJar.getCookies)) ?
+                    _.transform(cookieJar.getCookies(requestOptions.url), function (acc, cookie) {
+                        acc.push(toChromeCookie(cookie));
+                    }, []) : [];
+
+                // prepare history from request debug data
+                history = getExecutionHistory(_.get(response, 'request._debug'));
+
+                // finally, emit the response.start event which eventually
+                // triggers responseStart callback
                 self.emit(responseStartEventName, null, sdkResponse, request, cookies, history);
             };
 
@@ -311,23 +350,9 @@ _.assign(Requester.prototype, /** @lends Requester.prototype */ {
                 return onComplete(err);
             }
 
-            var responseString,
-                responseTime,
-                responseJSON,
+            var responseTime,
                 response,
                 history;
-
-            // holds the response as a string
-            // eslint-disable-next-line lodash/prefer-is-nil
-            responseString = ((resBody !== null && resBody !== undefined) && resBody.toString) ?
-                resBody.toString() : resBody;
-            if (responseString === '[object ArrayBuffer]') {
-                responseString = core.arrayBufferToString(resBody);
-            }
-
-            // This helps us to unify the information from XHR or Node calls.
-            // @todo avoid jsonifyResponse twice
-            responseJSON = core.jsonifyResponse(res, requestOptions, responseString);
 
             // Calculate the time taken for us to get the response.
             responseTime = Date.now() - startTime;
@@ -342,10 +367,11 @@ _.assign(Requester.prototype, /** @lends Requester.prototype */ {
             history = getExecutionHistory(debug);
 
             // Response in the SDK format
-            response = new sdk.Response({ // @todo get rid of jsonifyResponse
+            // @todo reuse same response instance used for responseStart callback
+            response = new sdk.Response({
                 code: responseJSON.statusCode,
                 status: res && res.statusMessage,
-                header: _.transform(responseJSON.headers, transformMultiValueHeaders, []),
+                header: responseHeaders,
                 stream: resBody,
                 responseTime: responseTime
             });

--- a/test/integration/request-body/raw.test.js
+++ b/test/integration/request-body/raw.test.js
@@ -1,0 +1,216 @@
+var expect = require('chai').expect;
+
+describe('Request Body Mode: raw', function () {
+    var testrun,
+        HOST = 'https://postman-echo.com/post';
+
+    describe('with string', function () {
+        before(function (done) {
+            this.run({
+                collection: {
+                    item: [{
+                        request: {
+                            url: HOST,
+                            method: 'POST',
+                            body: {
+                                mode: 'raw',
+                                raw: 'POSTMAN'
+                            }
+                        }
+                    }]
+                }
+            }, function (err, results) {
+                testrun = results;
+                done(err);
+            });
+        });
+
+        it('should have completed the run', function () {
+            expect(testrun).to.be.ok;
+            expect(testrun.done.getCall(0).args[0]).to.be.null;
+            expect(testrun).to.nested.include({
+                'done.calledOnce': true,
+                'start.calledOnce': true,
+                'request.calledOnce': true,
+                'response.calledOnce': true
+            });
+        });
+
+        it('should post raw string', function () {
+            var response = testrun.response.getCall(0).args[2],
+                responseBody = JSON.parse(response.stream.toString());
+
+            expect(response).to.have.property('code', 200);
+            expect(responseBody).to.have.property('data', 'POSTMAN');
+        });
+    });
+
+    describe('with object', function () {
+        before(function (done) {
+            this.run({
+                collection: {
+                    item: [{
+                        request: {
+                            url: HOST,
+                            method: 'POST',
+                            body: {
+                                mode: 'raw',
+                                raw: {
+                                    name: 'POSTMAN'
+                                }
+                            }
+                        }
+                    }]
+                }
+            }, function (err, results) {
+                testrun = results;
+                done(err);
+            });
+        });
+
+        it('should have completed the run', function () {
+            expect(testrun).to.be.ok;
+            expect(testrun.done.getCall(0).args[0]).to.be.null;
+            expect(testrun).to.nested.include({
+                'done.calledOnce': true,
+                'start.calledOnce': true,
+                'request.calledOnce': true,
+                'response.calledOnce': true
+            });
+        });
+
+        it('should post stringified object', function () {
+            var response = testrun.response.getCall(0).args[2],
+                responseBody = JSON.parse(response.stream.toString());
+
+            expect(response).to.have.property('code', 200);
+            expect(responseBody).to.have.property('data', JSON.stringify({
+                name: 'POSTMAN'
+            }));
+        });
+    });
+
+    describe('with number', function () {
+        before(function (done) {
+            this.run({
+                collection: {
+                    item: [{
+                        request: {
+                            url: HOST,
+                            method: 'POST',
+                            body: {
+                                mode: 'raw',
+                                raw: 12345
+                            }
+                        }
+                    }]
+                }
+            }, function (err, results) {
+                testrun = results;
+                done(err);
+            });
+        });
+
+        it('should have completed the run', function () {
+            expect(testrun).to.be.ok;
+            expect(testrun.done.getCall(0).args[0]).to.be.null;
+            expect(testrun).to.nested.include({
+                'done.calledOnce': true,
+                'start.calledOnce': true,
+                'request.calledOnce': true,
+                'response.calledOnce': true
+            });
+        });
+
+        // @note RequestBody~isEmpty returns true for number
+        it('should post empty body', function () {
+            var response = testrun.response.getCall(0).args[2],
+                responseBody = JSON.parse(response.stream.toString());
+
+            expect(response).to.have.property('code', 200);
+            expect(responseBody).to.have.property('data').that.is.empty;
+        });
+    });
+
+    describe('with null', function () {
+        before(function (done) {
+            this.run({
+                collection: {
+                    item: [{
+                        request: {
+                            url: HOST,
+                            method: 'POST',
+                            body: {
+                                mode: 'raw',
+                                raw: null
+                            }
+                        }
+                    }]
+                }
+            }, function (err, results) {
+                testrun = results;
+                done(err);
+            });
+        });
+
+        it('should have completed the run', function () {
+            expect(testrun).to.be.ok;
+            expect(testrun.done.getCall(0).args[0]).to.be.null;
+            expect(testrun).to.nested.include({
+                'done.calledOnce': true,
+                'start.calledOnce': true,
+                'request.calledOnce': true,
+                'response.calledOnce': true
+            });
+        });
+
+        it('should post empty body', function () {
+            var response = testrun.response.getCall(0).args[2],
+                responseBody = JSON.parse(response.stream.toString());
+
+            expect(response).to.have.property('code', 200);
+            expect(responseBody).to.have.property('data').that.is.empty;
+        });
+    });
+
+    describe('with undefined', function () {
+        before(function (done) {
+            this.run({
+                collection: {
+                    item: [{
+                        request: {
+                            url: HOST,
+                            method: 'POST',
+                            body: {
+                                mode: 'raw',
+                                raw: undefined
+                            }
+                        }
+                    }]
+                }
+            }, function (err, results) {
+                testrun = results;
+                done(err);
+            });
+        });
+
+        it('should have completed the run', function () {
+            expect(testrun).to.be.ok;
+            expect(testrun.done.getCall(0).args[0]).to.be.null;
+            expect(testrun).to.nested.include({
+                'done.calledOnce': true,
+                'start.calledOnce': true,
+                'request.calledOnce': true,
+                'response.calledOnce': true
+            });
+        });
+
+        it('should post empty body', function () {
+            var response = testrun.response.getCall(0).args[2],
+                responseBody = JSON.parse(response.stream.toString());
+
+            expect(response).to.have.property('code', 200);
+            expect(responseBody).to.have.property('data').that.is.empty;
+        });
+    });
+});

--- a/test/integration/request-flow/headers.test.js
+++ b/test/integration/request-flow/headers.test.js
@@ -91,6 +91,10 @@ describe('request headers', function () {
                                 key: 'Header-Name-0',
                                 value: 'value0'
                             }, {
+                                key: 'accept-encoding',
+                                value: 'disabled-system-header',
+                                disabled: true
+                            }, {
                                 key: 'User-Agent',
                                 value: 'PostmanRuntime/test'
                             }, {
@@ -197,6 +201,9 @@ describe('request headers', function () {
         ]);
 
         // system headers should be added correctly
+        // @note currently, only `Connection` header is added by NodeJS which
+        // is handled by the requester. This test will fail if any other
+        // header will be added by NodeJS.
         expect(request.headers.members).to.have.deep.members([
             // user-defined headers
             new Header({key: 'Header-Name-0', value: 'value0'}),
@@ -205,6 +212,8 @@ describe('request headers', function () {
             new Header({key: 'Postman-Token', value: 'someCustomToken'}),
             // requester header(overwritten) not added as system if value is unchanged
             new Header({key: 'referer', value: HOST}),
+            // user-defined, disabled header same as one-of system header
+            new Header({key: 'accept-encoding', value: 'disabled-system-header', disabled: true}),
             // system headers
             new Header({key: 'Accept', value: '*/*', system: true}),
             new Header({key: 'Cache-Control', value: 'no-cache', system: true}),
@@ -212,10 +221,5 @@ describe('request headers', function () {
             new Header({key: 'accept-encoding', value: 'gzip, deflate', system: true}),
             new Header({key: 'Connection', value: 'keep-alive', system: true})
         ]);
-
-        // @note currently, only `Connection` header is added by NodeJS which
-        // is handled by the requester. This test will fail if any other
-        // header will be added by NodeJS.
-        expect(request.headers.count()).to.equal(requestHeaders.length);
     });
 });


### PR DESCRIPTION
- Refactored requester to avoid duplicate computation for response object
- Fixed a bug where non-string raw bodies crash the process https://github.com/postmanlabs/postman-app-support/issues/6651
- Fixed a bug where disabled headers with the same name as of system headers don't get overwritten in the original request