### PR TITLE
Override lookup function for *.localhost

### DIFF
--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -1,3 +1,9 @@
+master:
+  fixed bugs:
+    - >-
+      GH-855 Fixed resolution of all `*.localhost` names to the loopback address
+      (127.0.0.1)
+
 7.15.2:
   date: 2019-06-25
   chores:

--- a/lib/requester/core.js
+++ b/lib/requester/core.js
@@ -77,6 +77,24 @@ var dns = require('dns'),
     },
 
     /**
+     * Helper function to extract top level domain for the given hostname
+     *
+     * @private
+     *
+     * @param {String} hostname
+     * @returns {String}
+     */
+    getTLD = function (hostname) {
+        if (!hostname) {
+            return '';
+        }
+
+        hostname = String(hostname);
+
+        return hostname.substring(hostname.lastIndexOf('.') + 1);
+    },
+
+    /**
      * Abstracts out the logic for domain resolution
      *
      * @param options
@@ -157,14 +175,12 @@ var dns = require('dns'),
         var self = this,
             lowercaseHost = hostname && hostname.toLowerCase(),
             networkOpts = lookupOptions.network || {},
-            hostLookup = networkOpts.hostLookup,
-            host_tld;
+            hostLookup = networkOpts.hostLookup;
 
-        // Get the top level domain
-        host_tld = String(lowercaseHost).split('.');
-        host_tld = host_tld[host_tld.length - 1];
-
-        if (host_tld !== LOCALHOST) {
+        // do dns.lookup if hostname is not one of:
+        // - localhost
+        // - *.localhost
+        if (getTLD(lowercaseHost) !== LOCALHOST) {
             return _lookup(options, hostLookup, lowercaseHost, function (err, addr, family) {
                 if (err) { return callback(err); }
 
@@ -237,11 +253,17 @@ module.exports = {
             portNumber,
             behaviorName,
             port = url && url.port,
-            hostname = url && url.hostname && url.hostname.toLowerCase(),
-            host_tld;
+            hostname = url && url.hostname && url.hostname.toLowerCase();
 
         !defaultOpts && (defaultOpts = {});
         !protocolProfileBehavior && (protocolProfileBehavior = {});
+
+        // resolve all *.localhost to localhost itself
+        // RFC: 6761 section 6.3 (https://tools.ietf.org/html/rfc6761#section-6.3)
+        if (getTLD(hostname) === LOCALHOST) {
+            // @note setting hostname to localhost ensures that we override lookup function
+            hostname = LOCALHOST;
+        }
 
         options.url = url;
         options.method = request.method;
@@ -311,12 +333,8 @@ module.exports = {
         // it is bubbled up to us after the request is made. If left to the underlying core, it's not :/
         self.ensureHeaderExists(options.headers, 'Host', url.host);
 
-        // get the top level domain
-        host_tld = String(hostname).split('.');
-        host_tld = host_tld[host_tld.length - 1];
-
         // override DNS lookup
-        if (networkOptions.restrictedAddresses || host_tld === LOCALHOST || networkOptions.hostLookup) {
+        if (networkOptions.restrictedAddresses || hostname === LOCALHOST || networkOptions.hostLookup) {
             isSSL = _.startsWith(request.url.protocol, HTTPS);
             portNumber = Number(port) || (isSSL ? HTTPS_DEFAULT_PORT : HTTP_DEFAULT_PORT);
 

--- a/lib/requester/core.js
+++ b/lib/requester/core.js
@@ -157,9 +157,14 @@ var dns = require('dns'),
         var self = this,
             lowercaseHost = hostname && hostname.toLowerCase(),
             networkOpts = lookupOptions.network || {},
-            hostLookup = networkOpts.hostLookup;
+            hostLookup = networkOpts.hostLookup,
+            host_tld;
 
-        if (lowercaseHost !== LOCALHOST) {
+        // Get the top level domain
+        host_tld = String(lowercaseHost).split('.');
+        host_tld = host_tld[host_tld.length - 1];
+
+        if (host_tld !== LOCALHOST) {
             return _lookup(options, hostLookup, lowercaseHost, function (err, addr, family) {
                 if (err) { return callback(err); }
 
@@ -232,7 +237,8 @@ module.exports = {
             portNumber,
             behaviorName,
             port = url && url.port,
-            hostname = url && url.hostname && url.hostname.toLowerCase();
+            hostname = url && url.hostname && url.hostname.toLowerCase(),
+            host_tld;
 
         !defaultOpts && (defaultOpts = {});
         !protocolProfileBehavior && (protocolProfileBehavior = {});
@@ -305,8 +311,12 @@ module.exports = {
         // it is bubbled up to us after the request is made. If left to the underlying core, it's not :/
         self.ensureHeaderExists(options.headers, 'Host', url.host);
 
+        // get the top level domain
+        host_tld = String(hostname).split('.');
+        host_tld = host_tld[host_tld.length - 1];
+
         // override DNS lookup
-        if (networkOptions.restrictedAddresses || hostname === LOCALHOST || networkOptions.hostLookup) {
+        if (networkOptions.restrictedAddresses || host_tld === LOCALHOST || networkOptions.hostLookup) {
             isSSL = _.startsWith(request.url.protocol, HTTPS);
             portNumber = Number(port) || (isSSL ? HTTPS_DEFAULT_PORT : HTTP_DEFAULT_PORT);
 

--- a/test/integration/request-flow/resolve-localhost.test.js
+++ b/test/integration/request-flow/resolve-localhost.test.js
@@ -1,0 +1,81 @@
+var expect = require('chai').expect,
+    sinon = require('sinon'),
+    server = require('../../fixtures/server');
+
+describe('request to *.localhost', function () {
+    var httpServer,
+        testrun,
+        port;
+
+    before(function (done) {
+        httpServer = server.createHTTPServer();
+
+        httpServer.on('/', function (req, res) {
+            res.writeHead(200);
+            res.end('POSTMAN');
+        });
+
+
+        httpServer.listen(0, function (err) {
+            if (err) { return done(err); }
+
+            port = httpServer.port;
+
+            this.run({
+                collection: {
+                    item: [{
+                        request: {
+                            url: 'localhost:' + port,
+                            method: 'POST'
+                        }
+                    }, {
+                        request: {
+                            url: 'subdomain.localhost:' + port,
+                            method: 'POST'
+                        }
+                    }]
+                }
+            }, function (err, result) {
+                testrun = result;
+                done(err);
+            });
+        }.bind(this));
+    });
+
+    after(function (done) {
+        httpServer.destroy(done);
+    });
+
+    it('should complete the run', function () {
+        expect(testrun).to.be.ok;
+        sinon.assert.calledOnce(testrun.start);
+        sinon.assert.calledOnce(testrun.done);
+        sinon.assert.calledTwice(testrun.request);
+        sinon.assert.calledTwice(testrun.response);
+        sinon.assert.calledWith(testrun.done.getCall(0), null);
+    });
+
+    it('should send correct request and response for localhost', function () {
+        var request = testrun.response.getCall(0).args[3],
+            response = testrun.response.getCall(0).args[2];
+
+        sinon.assert.calledWith(testrun.request.getCall(0), null);
+        sinon.assert.calledWith(testrun.response.getCall(0), null);
+
+        expect(request).to.be.ok;
+        expect(request.url.toString()).to.equal('localhost:' + port);
+        expect(response.text()).to.equal('POSTMAN');
+    });
+
+    it('should send correct request and response for subdomain.localhost', function () {
+        var request = testrun.response.getCall(1).args[3],
+            response = testrun.response.getCall(1).args[2];
+
+        sinon.assert.calledWith(testrun.request.getCall(1), null);
+        sinon.assert.calledWith(testrun.response.getCall(1), null);
+
+        expect(request).to.be.ok;
+        expect(request.url.toString()).to.equal('subdomain.localhost:' + port);
+        expect(response.text()).to.equal('POSTMAN');
+    });
+});

--- a/test/unit/requester-core.test.js
+++ b/test/unit/requester-core.test.js
@@ -179,6 +179,14 @@ describe('requester util', function () {
             expect(requesterCore.getRequestOptions(request, {}).lookup).to.be.a('function');
         });
 
+        it('should override lookup function for *.localhost', function () {
+            var request = new sdk.Request({
+                url: 'http://subdomain.localhost:8080/random/path'
+            });
+
+            expect(requesterCore.getRequestOptions(request, {}).lookup).to.be.a('function');
+        });
+
         it('should override lookup function for restricted addresses', function () {
             var request = new sdk.Request({
                     url: 'https://postman-echo.com/get'

--- a/test/unit/requester-core.test.js
+++ b/test/unit/requester-core.test.js
@@ -187,6 +187,14 @@ describe('requester util', function () {
             expect(requesterCore.getRequestOptions(request, {}).lookup).to.be.a('function');
         });
 
+        it('should not override lookup function for *.localhost.com', function () {
+            var request = new sdk.Request({
+                url: 'http://subdomain.localhost.com:8080/random/path'
+            });
+
+            expect(requesterCore.getRequestOptions(request, {}).lookup).to.not.be.a('function');
+        });
+
         it('should override lookup function for restricted addresses', function () {
             var request = new sdk.Request({
                     url: 'https://postman-echo.com/get'


### PR DESCRIPTION
Resolve all `*.localhost` addresses to `127.0.0.1` by overriding lookup function.
RFC: [6761 section 6.3](https://tools.ietf.org/html/rfc6761#section-6.3)

Ref: https://github.com/postmanlabs/postman-app-support/issues/2638