### PR TITLE
Handle duplicate system headers addition

### DIFF
--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -1,3 +1,11 @@
+master:
+  fixed bugs:
+    - >-
+      GH-889 Fixed a bug where system header was not updated correctly in case
+      of multiple `cookie` headers
+  chores:
+    - Updated dependencies
+
 7.17.0:
   date: 2019-09-04
   new features:

--- a/lib/requester/requester.js
+++ b/lib/requester/requester.js
@@ -238,10 +238,12 @@ _.assign(Requester.prototype, /** @lends Requester.prototype */ {
              */
             addMissingRequestHeaders = function (headers) {
                 var header,
-                    keepAlive;
+                    keepAlive,
+                    lowerCasedKey;
 
                 _.forOwn(headers, function (value, key) {
                     header = request.headers.one(key);
+                    lowerCasedKey = _.lowerCase(key);
 
                     // neither request nor runtime overwrites user-defined headers
                     // so instead of upsert, just add missing headers to the list
@@ -256,14 +258,27 @@ _.assign(Requester.prototype, /** @lends Requester.prototype */ {
                         return;
                     }
 
-                    // update headers which gets overwritten by the requester
-                    if (OVERWRITTEN_HEADERS[key.toLowerCase()] && value !== header.value) {
-                        header.update({
-                            key: key,
-                            value: value,
-                            system: true
+                    // bail out if
+                    // 1. header is not one of overwritten headers
+                    // 2. overwritten header value is not updated
+                    if (!(OVERWRITTEN_HEADERS[lowerCasedKey] && value !== header.value)) {
+                        return;
+                    }
+
+                    // in case of duplicate headers, remove all the duplicates
+                    // just keep the last item in the list.
+                    if (Array.isArray(_.get(request.headers, ['reference', lowerCasedKey]))) {
+                        request.headers.remove(function (h) {
+                            return _.lowerCase(h.key) === lowerCasedKey && h !== header;
                         });
                     }
+
+                    // update headers which gets overwritten by the requester
+                    header.update({
+                        key: key,
+                        value: value,
+                        system: true
+                    });
                 });
 
                 keepAlive = _.get(requestOptions, 'agentOptions.keepAlive');


### PR DESCRIPTION
Correctly update system headers in case of multiple headers with came key (`Cookie`) are present.

Bug: Previously it used to just update the last item in the list.
Fix: Remove all duplicates and just keep the final change.