### PR TITLE
Always add reused session data to history object

### DIFF
--- a/lib/requester/requester.js
+++ b/lib/requester/requester.js
@@ -200,8 +200,9 @@ _.assign(Requester.prototype, /** @lends Requester.prototype */ {
                 debugInfo.forEach(function (debugData) {
                     if (!debugData) { return; }
 
-                    // cache connection sessions, to be referred later
-                    if (debugData.session && !debugData.session.reused) {
+                    // @todo cache connection sessions and fetch reused session
+                    // from the requester pool.
+                    if (debugData.session && !requestSessions[debugData.session.id]) {
                         requestSessions[debugData.session.id] = debugData.session.data;
                     }
 


### PR DESCRIPTION
- Update history object to always have the session data (previously reused session are not stored).
- An ideal solution should be to cache all the sessions in the requester's socket pool and fetch session details from there. (TODO)