### PR TITLE
Add option `script.serializeLogs` to send serialized logs

### DIFF
--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -1,4 +1,9 @@
 master:
+  new features:
+    - GH-921 Added ability to preserve non-JSON data types in console logs
+    - >-
+      GH-921 Added an option `script.serializeLogs` to allow sending logs as a
+      serialized string which can be parsed using `teleport-javascript`
   fixed bugs:
     - >-
       GH-918 Fixed a bug where requests having binary body with AWS, Hawk or 

--- a/README.md
+++ b/README.md
@@ -135,6 +135,14 @@ runner.run(collection, {
         }
     },
 
+    // Options specific to the script execution
+    script: {
+
+        // Option to set whether to send console logs in serialized format which can be parsed
+        // using the `teleport-javascript` serialization library.
+        serializeLogs: false
+    },
+
     // A ProxyConfigList, from the SDK
     proxies: new sdk.ProxyConfigList(),
 

--- a/lib/runner/extensions/event.command.js
+++ b/lib/runner/extensions/event.command.js
@@ -428,6 +428,7 @@ module.exports = {
                     timeout: payload.scriptTimeout, // @todo: Expose this as a property in Collection SDK's Script
                     cursor: scriptCursor,
                     context: _.pick(payload.context, SAFE_CONTEXT_VARIABLES),
+                    serializeLogs: _.get(this, 'options.script.serializeLogs'),
 
                     // legacy options
                     legacy: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -579,7 +579,7 @@
     "comment-parser": {
       "version": "0.5.5",
       "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-0.5.5.tgz",
-      "integrity": "sha1-wlhMrnwvCvx3Ppay7pj4wQy9aT0=",
+      "integrity": "sha512-oB3TinFT+PV3p8UwDQt71+HkG03+zwPwikDlKU6ZDmql6QX2zFlQ+G0GGSDqyJhdZi4PSlzFBm+YJ+ebOX3Vgw==",
       "dev": true
     },
     "common-sequence": {
@@ -935,7 +935,7 @@
     "eslint-plugin-jsdoc": {
       "version": "8.7.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-8.7.0.tgz",
-      "integrity": "sha1-72G7eWYThXayOqzySelY6aCgEv8=",
+      "integrity": "sha512-4UzO2Yw+5s1DOfQCTaasUx8Ng/h6/nTtrO3gGiCD086pOAcDFkbVHKdGrGnGuXd90MPDE9bHD92xJ5ke3cMrRA==",
       "dev": true,
       "requires": {
         "comment-parser": "^0.5.5",
@@ -1878,7 +1878,7 @@
     "jsdoctypeparser": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsdoctypeparser/-/jsdoctypeparser-4.0.0.tgz",
-      "integrity": "sha1-8l4hL/iw4+ntdmJ1VDknh81SQSg=",
+      "integrity": "sha512-Bh6AW8eJ1bVdofhYUuqgFOVo0FE9qII+a+Go+juEnAfaDS5lZAiIqBAFm9gDu80OqBcQ1UI3v/8cP+3D5IGVww==",
       "dev": true
     },
     "json-schema": {
@@ -2425,7 +2425,7 @@
     "parse-gitignore": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/parse-gitignore/-/parse-gitignore-0.5.1.tgz",
-      "integrity": "sha1-A3DQqfoJN/GCeCGeVMJcKD3VUhg=",
+      "integrity": "sha512-Ls8RQQrYC0HqaIugZ0lwKl+dcIeuaV+8iQwrsQFNHCEnodTXaEAM2+RxQFFv2xDaJ1gM4C05eY4u6KzIHvNayQ==",
       "dev": true,
       "requires": {
         "array-unique": "^0.3.2",
@@ -2511,6 +2511,7 @@
         "marked": "0.7.0",
         "mime-format": "2.0.0",
         "mime-types": "2.1.24",
+        "postman-url-encoder": "1.0.2",
         "sanitize-html": "1.20.1",
         "semver": "6.3.0",
         "uuid": "3.3.3"
@@ -2523,6 +2524,11 @@
           "requires": {
             "safer-buffer": ">= 2.1.2 < 3"
           }
+        },
+        "postman-url-encoder": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/postman-url-encoder/-/postman-url-encoder-1.0.2.tgz",
+          "integrity": "sha512-PBGPIJnm9dqyUST/oX9mxTxT5seqWS4AdzAhGt4judiOh7xT4leTv2CLoGtHXUCHFuLLp9h9wDGAMN7Cm0Znyw=="
         },
         "semver": {
           "version": "6.3.0",
@@ -2583,12 +2589,13 @@
       }
     },
     "postman-sandbox": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/postman-sandbox/-/postman-sandbox-3.4.0.tgz",
-      "integrity": "sha512-nlUUNQuCa9wuq+ypLEEryzhGTnSknZFtbC5mAoIvmOwBJoeImX0PykRHNqwg3YsfQHN4F4MbcPPbBtnU3NcnvA==",
+      "version": "3.5.0-beta.1",
+      "resolved": "https://registry.npmjs.org/postman-sandbox/-/postman-sandbox-3.5.0-beta.1.tgz",
+      "integrity": "sha512-6idUNmZuR8pITGg3yB3LFbXyQpUclgJAJxDraW5xzfPdVF9MgmdHBa9rtA2bfmV2yIh0UUPpkR1MBaiZsCdwcQ==",
       "requires": {
         "inherits": "2.0.4",
         "lodash": "4.17.15",
+        "teleport-javascript": "0.1.0",
         "tough-cookie": "3.0.1",
         "uuid": "3.3.3",
         "uvm": "1.7.8"
@@ -3160,6 +3167,11 @@
       "resolved": "https://registry.npmjs.org/taffydb/-/taffydb-2.6.2.tgz",
       "integrity": "sha1-fLy2S1oUG2ou/CxdLGe04VCyomg=",
       "dev": true
+    },
+    "teleport-javascript": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/teleport-javascript/-/teleport-javascript-0.1.0.tgz",
+      "integrity": "sha512-ovZglnoWIaH0Zqz1qiYwbWrlYhwfYQt3MDjTMB4SGpttsD9maWuV3aW0RvMLohUNj7zdJ4jICOyXkRDD4UCtAQ=="
     },
     "temp-path": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "performance-now": "2.1.0",
     "postman-collection": "3.5.4",
     "postman-request": "2.88.1-postman.15",
-    "postman-sandbox": "3.4.0",
+    "postman-sandbox": "3.5.0-beta.1",
     "postman-url-encoder": "1.0.3",
     "resolve-from": "5.0.0",
     "serialised-error": "1.1.3",
@@ -73,6 +73,7 @@
     "server-destroy": "1.0.1",
     "shelljs": "0.8.3",
     "sinon": "7.5.0",
+    "teleport-javascript": "0.1.0",
     "tmp": "0.1.0",
     "yankee": "1.0.8"
   },

--- a/test/integration/sandbox-libraries/console.test.js
+++ b/test/integration/sandbox-libraries/console.test.js
@@ -1,0 +1,167 @@
+var expect = require('chai').expect,
+    sinon = require('sinon'),
+    teleportJS = require('teleport-javascript');
+
+describe('Console', function () {
+    describe('with default options', function () {
+        var testrun;
+
+        before(function (done) {
+            this.run({
+                collection: {
+                    item: [{
+                        request: 'https://postman-echo.com/get',
+                        event: [{
+                            listen: 'test',
+                            script: {
+                                type: 'text/javascript',
+                                exec: `
+                                    console.log({
+                                        regex: /a-z/g,
+                                        nil: null,
+                                        undef: undefined,
+                                        string: 'some str',
+                                        number: 1234,
+                                        boolean: true,
+                                        arr: [1, 2, 3],
+                                        obj: {
+                                            a: 1,
+                                            b: 2
+                                        },
+                                        map: new Map([[1, 'one'], [2, 'two']]),
+                                        set: new Set([1, 2, 3])
+                                    }, /a-z/g);
+                                    console.info(Infinity);
+                                `
+                            }
+                        }]
+                    }]
+                }
+            }, function (err, results) {
+                testrun = results;
+                done(err);
+            });
+        });
+
+        it('should complete the run', function () {
+            expect(testrun).to.be.ok;
+            sinon.assert.calledOnce(testrun.start);
+            sinon.assert.calledOnce(testrun.done);
+            sinon.assert.calledWith(testrun.done.getCall(0), null);
+
+            sinon.assert.calledOnce(testrun.request);
+            sinon.assert.calledWith(testrun.request.getCall(0), null);
+
+            sinon.assert.calledOnce(testrun.response);
+            sinon.assert.calledWith(testrun.response.getCall(0), null);
+        });
+
+        it('should run the test script successfully', function () {
+            sinon.assert.calledOnce(testrun.script);
+            sinon.assert.calledWith(testrun.script.getCall(0), null);
+
+            sinon.assert.calledOnce(testrun.test);
+            sinon.assert.calledWith(testrun.script.getCall(0), null);
+        });
+
+        it('should not mutate any data-types', function () {
+            sinon.assert.calledTwice(testrun.console);
+
+            var expectedResult = {
+                    regex: /a-z/g,
+                    nil: null,
+                    undef: undefined,
+                    string: 'some str',
+                    number: 1234,
+                    boolean: true,
+                    arr: [1, 2, 3],
+                    obj: {
+                        a: 1,
+                        b: 2
+                    },
+                    map: new Map([[1, 'one'], [2, 'two']]),
+                    set: new Set([1, 2, 3])
+                },
+                args0 = testrun.console.getCall(0).args,
+                args1 = testrun.console.getCall(1).args;
+
+            expect(args0[0]).to.be.an('object');
+            expect(args0[1]).to.equal('log');
+            expect(args0[2]).to.eql(expectedResult);
+            expect(args0[3]).to.eql(/a-z/g);
+
+            expect(args1[0]).to.be.an('object');
+            expect(args1[1]).to.equal('info');
+            expect(args1[2]).to.eql(Infinity);
+        });
+    });
+
+    describe('with serializeLogs true', function () {
+        var testrun;
+
+        before(function (done) {
+            this.run({
+                script: {
+                    serializeLogs: true
+                },
+                collection: {
+                    item: [{
+                        request: 'https://postman-echo.com/get',
+                        event: [{
+                            listen: 'test',
+                            script: {
+                                type: 'text/javascript',
+                                exec: `
+                                    console.log({
+                                        undef: undefined,
+                                        map: new Map([['s', new Set([1, /a-z/g, -Infinity])], ['n', 123]])
+                                    }, undefined);
+                                `
+                            }
+                        }]
+                    }]
+                }
+            }, function (err, results) {
+                testrun = results;
+                done(err);
+            });
+        });
+
+        it('should complete the run', function () {
+            expect(testrun).to.be.ok;
+            sinon.assert.calledOnce(testrun.start);
+            sinon.assert.calledOnce(testrun.done);
+            sinon.assert.calledWith(testrun.done.getCall(0), null);
+
+            sinon.assert.calledOnce(testrun.request);
+            sinon.assert.calledWith(testrun.request.getCall(0), null);
+
+            sinon.assert.calledOnce(testrun.response);
+            sinon.assert.calledWith(testrun.response.getCall(0), null);
+        });
+
+        it('should run the test script successfully', function () {
+            sinon.assert.calledOnce(testrun.script);
+            sinon.assert.calledWith(testrun.script.getCall(0), null);
+
+            sinon.assert.calledOnce(testrun.test);
+            sinon.assert.calledWith(testrun.script.getCall(0), null);
+        });
+
+        it('should not mutate any data-types', function () {
+            sinon.assert.calledOnce(testrun.console);
+
+            var logData = [{
+                    undef: undefined,
+                    map: new Map([['s', new Set([1, /a-z/g, -Infinity])], ['n', 123]])
+                }, undefined],
+                args = testrun.console.getCall(0).args,
+                expectedResult = teleportJS.stringify(logData);
+
+            expect(args[0]).to.be.an('object');
+            expect(args[1]).to.equal('log');
+            expect(args[2], 'serialized logs').to.equal(expectedResult);
+            expect(teleportJS.parse(expectedResult)).to.eql(logData);
+        });
+    });
+});


### PR DESCRIPTION
This change allows preserving non-JSON data types in console logs. It also adds
an option `script.serializeLogs` to allow sending logs as a serialized string
which can be parsed using `teleport-javascript` library.