### PR TITLE
Fix throwing of error on empty NTLM parameters

### DIFF
--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -1,3 +1,9 @@
+master:
+  fixed bugs:
+    - >-
+      GH-929 Fixed a bug where error was thrown when `username` or `password`
+      fields were empty for NTLM auth
+
 7.20.1:
   date: 2019-11-13
   chores:

--- a/lib/authorizer/ntlm.js
+++ b/lib/authorizer/ntlm.js
@@ -96,8 +96,8 @@ module.exports = {
         var state = auth.get(STATE),
             domain = auth.get(NTLM_PARAMETERS.DOMAIN) || EMPTY,
             workstation = auth.get(NTLM_PARAMETERS.WORKSTATION) || EMPTY,
-            username = auth.get(NTLM_PARAMETERS.USERNAME),
-            password = auth.get(NTLM_PARAMETERS.PASSWORD),
+            username = auth.get(NTLM_PARAMETERS.USERNAME) || EMPTY,
+            password = auth.get(NTLM_PARAMETERS.PASSWORD) || EMPTY,
             negotiateMessage, // type 1
             challengeMessage, // type 2
             authenticateMessage; // type 3

--- a/test/integration/auth-methods/ntlm.test.js
+++ b/test/integration/auth-methods/ntlm.test.js
@@ -87,6 +87,58 @@ describe.skip('NTLM', function () {
         });
     });
 
+    describe('with empty details', function () {
+        before(function (done) {
+            // creating local copy of collection because we don't want to send
+            // any parameters for NTLM auth
+            var localRunOptions = {
+                collection: {
+                    item: {
+                        name: 'NTLM Sample Request',
+                        request: {
+                            url: ntlmServerIP,
+                            auth: {
+                                type: 'ntlm'
+                            }
+                        }
+                    }
+                }
+            };
+
+            // perform the collection run
+            this.run(localRunOptions, function (err, results) {
+                testrun = results;
+                done(err);
+            });
+        });
+
+        it('should have completed the run', function () {
+            expect(testrun).to.be.ok;
+            expect(testrun).to.nested.include({
+                'done.callCount': 1
+            });
+
+            var err = testrun.request.firstCall.args[0];
+
+            err && console.error(err.stack);
+            expect(err).to.be.null;
+
+            expect(testrun).to.nested.include({
+                'start.callCount': 1
+            });
+        });
+
+        it('should have sent the request thrice', function () {
+            expect(testrun).to.nested.include({
+                'request.callCount': 3
+            });
+
+            var response = testrun.request.firstCall.args[2];
+
+            expect(response).to.have.property('code', 401);
+        });
+    });
+
     describe('with in-correct details', function () {
         before(function (done) {
             var clonedRunOptions = _.merge({}, runOptions, {


### PR DESCRIPTION
Tests have been verified to run perfectly with a locally setup NTLM server.