### PR TITLE
Used URL object instead of serialized URL for proxy option of postman-request

### DIFF
--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -6,6 +6,9 @@ master:
     - >-
       GH-928 Fixed a bug where Basic Auth was failing if credentials had
       non-ASCII characters
+    - >-
+      GH-932 Fixed a bug where special characters in proxy auth credentials
+      caused connection failure to the proxy server
 
 7.20.1:
   date: 2019-11-13

--- a/lib/requester/request-wrapper.js
+++ b/lib/requester/request-wrapper.js
@@ -1,6 +1,13 @@
 var _ = require('lodash'),
     async = require('async'),
     requests = require('postman-request'),
+    urlEncoder = require('postman-url-encoder'),
+
+    E = '',
+    COLON = ':',
+    DEFAULT_PROTOCOL = 'http',
+    PROTOCOL_HOST_SEPARATOR = '://',
+    AUTH_CREDENTIALS_SEPARATOR = '@',
 
     /**
      * Sets the Proxy and tunnel to the options
@@ -10,25 +17,45 @@ var _ = require('lodash'),
      * @param cb
      */
     setProxy = function (request, options, cb) {
-        var proxyConfig;
+        var proxyConfig = _.get(request, 'proxy'),
+            proxyUrl,
+            proxyAuth;
 
-        if ((proxyConfig = _.get(request, 'proxy'))) {
-            options.proxy = proxyConfig.getProxyUrl(request.url);
-            // TODO: Use tri-state var for tunnel in SDK and update here
-            // for now determine the tunnel value from the URL unless explicitly set to true
-            options.tunnel = proxyConfig.tunnel ? true : _.startsWith(request.url, 'https://');
+        if (!proxyConfig) {
+            // if proxy is not set, postman-request implicitly fallbacks to proxy
+            // environment variables. To opt-out of this, set `ignoreProxyEnvironmentVariables`
+            // requester option.
+            // Setting proxy to `false` opt out of the implicit proxy configuration
+            // of the other environment variables.
+            options.ignoreProxyEnvironmentVariables && (options.proxy = false);
+
+            return cb(null, request, options);
         }
 
-        // if proxy is not set, postman-request implicitly fallbacks to proxy
-        // environment variables. To opt-out of this, set `ignoreProxyEnvironmentVariables`
-        // requester option.
-        // Setting proxy to `false` opt out of the implicit proxy configuration
-        // of the other environment variables.
-        if (!options.proxy && options.ignoreProxyEnvironmentVariables) {
-            options.proxy = false;
+        proxyUrl = DEFAULT_PROTOCOL + PROTOCOL_HOST_SEPARATOR + proxyConfig.host + COLON + proxyConfig.port;
+        options.proxy = urlEncoder.toNodeUrl(proxyUrl);
+
+        if (proxyConfig.authenticate) {
+            proxyAuth = proxyConfig.username || E;
+
+            if (proxyConfig.password) {
+                proxyAuth += COLON + proxyConfig.password;
+            }
+
+            if (proxyAuth) {
+                options.proxy.auth = proxyAuth;
+
+                // assign serialized URL with auth to href.
+                options.proxy.href = DEFAULT_PROTOCOL + PROTOCOL_HOST_SEPARATOR + proxyAuth +
+                                     AUTH_CREDENTIALS_SEPARATOR + proxyConfig.host + COLON + proxyConfig.port;
+            }
         }
 
-        cb(null, request, options);
+        // TODO: Use tri-state var for tunnel in SDK and update here
+        // for now determine the tunnel value from the URL unless explicitly set to true
+        options.tunnel = proxyConfig.tunnel ? true : _.startsWith(request.url, 'https://');
+
+        return cb(null, request, options);
     },
 
     /**


### PR DESCRIPTION
Solves: https://github.com/postmanlabs/postman-app-support/issues/6227

Note: This change doesn't require any additional changes in `postman-request`. 