### PR TITLE
Update NTLM auth to find correct type2 header before parsing

### DIFF
--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -6,6 +6,9 @@ master:
     - >-
       GH-928 Fixed a bug where Basic Auth was failing if credentials had
       non-ASCII characters
+    - >-
+      GH-933 Fixed a bug where NTLM could not complete authentication if
+      multiple `www-authenticate` headers were sent
 
 7.20.1:
   date: 2019-11-13

--- a/lib/authorizer/ntlm.js
+++ b/lib/authorizer/ntlm.js
@@ -100,7 +100,8 @@ module.exports = {
             password = auth.get(NTLM_PARAMETERS.PASSWORD) || EMPTY,
             negotiateMessage, // type 1
             challengeMessage, // type 2
-            authenticateMessage; // type 3
+            authenticateMessage, // type 3
+            ntlmType2Header;
 
         if (response.code !== 401 && response.code !== 403) {
             return done(null, true);
@@ -130,7 +131,20 @@ module.exports = {
         }
         else if (state === STATES.T1_MSG_CREATED) {
             // At this point, we can assume that the type 1 message was sent to the server
-            challengeMessage = ntlmUtil.parseType2Message(response.headers.get(WWW_AUTHENTICATE) || EMPTY, _.noop);
+
+            // there can be multiple headers present with key `www-authenticate`.
+            // iterate to get the one which has the NTLM hash. if multiple
+            // headers have the NTLM hash, use the first one.
+            ntlmType2Header = response.headers.find(function (header) {
+                return String(header.key).toLowerCase() === WWW_AUTHENTICATE &&
+                    header.valueOf().startsWith('NTLM ');
+            });
+
+            if (!ntlmType2Header) {
+                return done(new Error('ntlm: server did not send NTLM type 2 message'));
+            }
+
+            challengeMessage = ntlmUtil.parseType2Message(ntlmType2Header.valueOf(), _.noop);
 
             if (!challengeMessage) {
                 return done(new Error('ntlm: server did not correctly process authentication request'));

--- a/test/integration/auth-methods/ntlm.test.js
+++ b/test/integration/auth-methods/ntlm.test.js
@@ -1,20 +1,24 @@
 var expect = require('chai').expect,
-    _ = require('lodash');
+    _ = require('lodash'),
 
-describe.skip('NTLM', function () {
+    server = require('../../fixtures/server');
+
+describe('NTLM', function () {
     // @todo Add '/ntlm' endpoint in echo server
-    var ntlmServerIP = '34.214.154.175',
+    var PORT = 2000,
         USERNAME = 'postman',
         PASSWORD = 'NTLM@123',
-        DOMAIN = '',
-        WORKSTATION = '',
+        DOMAIN = 'domain',
+        WORKSTATION = 'workstation',
+        ntlmServerURL = 'http://localhost:' + PORT,
+        ntlmServer,
         testrun,
         runOptions = {
             collection: {
                 item: {
                     name: 'NTLM Sample Request',
                     request: {
-                        url: ntlmServerIP,
+                        url: ntlmServerURL,
                         auth: {
                             type: 'ntlm',
                             ntlm: {
@@ -28,6 +32,20 @@ describe.skip('NTLM', function () {
                 }
             }
         };
+
+    before(function (done) {
+        ntlmServer = server.createNTLMServer({
+            // debug: true,
+            username: USERNAME,
+            password: PASSWORD,
+            domain: DOMAIN,
+            workstation: WORKSTATION
+        }).listen(PORT, done);
+    });
+
+    after(function (done) {
+        ntlmServer.destroy(done);
+    });
 
     describe('with request server not supporting NTLM', function () {
         before(function (done) {
@@ -96,7 +114,7 @@ describe.skip('NTLM', function () {
                     item: {
                         name: 'NTLM Sample Request',
                         request: {
-                            url: ntlmServerIP,
+                            url: ntlmServerURL,
                             auth: {
                                 type: 'ntlm'
                             }


### PR DESCRIPTION
Also added a local NTLM server which sends `www-authenticate: Negotiate` along with type2 message. Adding this takes care of this bug.