### PR TITLE
Non-bearer OAuth2 tokens

### DIFF
--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -1,4 +1,8 @@
 master:
+  new features:
+    - >-
+      GH-937 Added ability to use OAuth2 tokens with unknown types as Bearer
+      token in OAuth2 authentication
   fixed bugs:
     - >-
       GH-929 Fixed a bug where error was thrown when `username` or `password`

--- a/lib/authorizer/oauth2.js
+++ b/lib/authorizer/oauth2.js
@@ -3,6 +3,7 @@ var _ = require('lodash'),
     HEADER = 'header',
     QUERY_PARAMS = 'queryParams',
     BEARER = 'bearer',
+    MAC = 'mac',
     AUTHORIZATION = 'Authorization',
     ACCESS_TOKEN = 'access_token',
     AUTHORIZATION_PREFIX = 'Bearer ',
@@ -94,27 +95,31 @@ module.exports = {
         tokenType = _.toLower(params.tokenType);
 
         // @TODO Add support for HMAC
-        if (tokenType === BEARER) {
-            // clean conflicting headers and query params
-            // @todo: we should be able to get conflicting params from auth manifest
-            // and clear them before the sign step for any auth
-            request.removeHeader(AUTHORIZATION, {ignoreCase: true});
-            request.removeQueryParams([ACCESS_TOKEN]);
+        if (tokenType === MAC) {
+            return done();
+        }
 
-            if (params.addTokenTo === QUERY_PARAMS) {
-                request.addQueryParams({
-                    key: ACCESS_TOKEN,
-                    value: params.accessToken,
-                    system: true
-                });
-            }
-            else if (params.addTokenTo === HEADER) {
-                request.addHeader({
-                    key: AUTHORIZATION,
-                    value: AUTHORIZATION_PREFIX + params.accessToken,
-                    system: true
-                });
-            }
+        // treat every token types (other than MAC) as bearer token
+
+        // clean conflicting headers and query params
+        // @todo: we should be able to get conflicting params from auth manifest
+        // and clear them before the sign step for any auth
+        request.removeHeader(AUTHORIZATION, {ignoreCase: true});
+        request.removeQueryParams([ACCESS_TOKEN]);
+
+        if (params.addTokenTo === QUERY_PARAMS) {
+            request.addQueryParams({
+                key: ACCESS_TOKEN,
+                value: params.accessToken,
+                system: true
+            });
+        }
+        else if (params.addTokenTo === HEADER) {
+            request.addHeader({
+                key: AUTHORIZATION,
+                value: AUTHORIZATION_PREFIX + params.accessToken,
+                system: true
+            });
         }
 
         return done();


### PR DESCRIPTION
- Treat non-Bearer OAuth2 tokens(except MAC) as Bearer tokens.

Solves: https://github.com/postmanlabs/postman-app-support/issues/5434