### PR TITLE
Fix NTLM auth state when `iterationCount` is more than 2

### DIFF
--- a/lib/authorizer/ntlm.js
+++ b/lib/authorizer/ntlm.js
@@ -128,7 +128,10 @@ module.exports = {
      * @param {AuthHandlerInterface~authPreHookCallback} done
      */
     pre: function (auth, done) {
-        !auth.get(STATE) && auth.set(STATE, STATES.INITIALIZED);
+        if (!auth.get(STATE)) {
+            auth.set(STATE, STATES.INITIALIZED);
+            auth.set(NTLM_HEADER, undefined);
+        }
 
         done(null, true);
     },
@@ -157,6 +160,9 @@ module.exports = {
             parsedParameters;
 
         if (response.code !== 401 && response.code !== 403) {
+            auth.set(STATE, STATES.INITIALIZED);
+            auth.set(NTLM_HEADER, undefined);
+
             return done(null, true);
         }
 

--- a/lib/runner/extensions/item.command.js
+++ b/lib/runner/extensions/item.command.js
@@ -188,7 +188,8 @@ module.exports = {
 
                         var request = result.request,
                             response = result.response,
-                            cookies = result.cookies;
+                            cookies = result.cookies,
+                            auth = result.item.getAuth();
 
                         if ((stopOnError || stopOnFailure) && requestError) {
                             this.triggers.item(null, coords, item); // @todo - should this trigger receive error?
@@ -210,6 +211,11 @@ module.exports = {
 
                         // set cookies for this transaction
                         cookies && (ctxTemplate.cookies = cookies);
+
+                        // update the item auth to prevent loss of auth state
+                        // @note this is a hack because the auth architecture is messy, and there is some confusion
+                        // between `originalItem` and `item`.
+                        auth && (item.auth = auth);
 
                         // the context template also has a test object to store assertions
                         ctxTemplate.tests = {}; // @todo remove

--- a/test/integration/auth-methods/ntlm.test.js
+++ b/test/integration/auth-methods/ntlm.test.js
@@ -479,4 +479,330 @@ describe('NTLM', function () {
             expect(response).to.have.property('code', 401);
         });
     });
+
+    describe('with NTLM auth set at collection level', function () {
+        before(function (done) {
+            var localRunOptions = {
+                collection: {
+                    item: {
+                        name: 'NTLM Sample Request',
+                        request: {
+                            url: ntlmServerURL
+                        }
+                    },
+                    auth: {
+                        type: 'ntlm',
+                        ntlm: {
+                            username: USERNAME,
+                            password: PASSWORD,
+                            domain: DOMAIN,
+                            workstation: WORKSTATION
+                        }
+                    }
+                }
+            };
+
+            // perform the collection run
+            this.run(localRunOptions, function (err, results) {
+                testrun = results;
+                done(err);
+            });
+        });
+
+        it('should have completed the run', function () {
+            expect(testrun).to.be.ok;
+            expect(testrun).to.nested.include({
+                'done.callCount': 1
+            });
+
+            var err = testrun.request.firstCall.args[0];
+
+            err && console.error(err.stack);
+            expect(err).to.be.null;
+
+            expect(testrun).to.nested.include({
+                'start.callCount': 1
+            });
+        });
+
+        it('should have sent the request thrice', function () {
+            expect(testrun).to.nested.include({
+                'request.callCount': 3
+            });
+
+            var response = testrun.request.lastCall.args[2];
+
+            expect(response).to.have.property('code', 200);
+        });
+    });
+
+    describe('with NTLM auth set at folder level', function () {
+        before(function (done) {
+            var localRunOptions = {
+                collection: {
+                    item: {
+                        name: 'NTLM folder',
+                        item: {
+                            name: 'NTLM Sample Request',
+                            request: {
+                                url: ntlmServerURL
+                            }
+                        },
+                        auth: {
+                            type: 'ntlm',
+                            ntlm: {
+                                username: USERNAME,
+                                password: PASSWORD,
+                                domain: DOMAIN,
+                                workstation: WORKSTATION
+                            }
+                        }
+                    }
+                }
+            };
+
+            // perform the collection run
+            this.run(localRunOptions, function (err, results) {
+                testrun = results;
+                done(err);
+            });
+        });
+
+        it('should have completed the run', function () {
+            expect(testrun).to.be.ok;
+            expect(testrun).to.nested.include({
+                'done.callCount': 1
+            });
+
+            var err = testrun.request.firstCall.args[0];
+
+            err && console.error(err.stack);
+            expect(err).to.be.null;
+
+            expect(testrun).to.nested.include({
+                'start.callCount': 1
+            });
+        });
+
+        it('should have sent the request thrice', function () {
+            expect(testrun).to.nested.include({
+                'request.callCount': 3
+            });
+
+            var response = testrun.request.lastCall.args[2];
+
+            expect(response).to.have.property('code', 200);
+        });
+    });
+
+    describe('with NTLM auth set at request level and 5 iterations', function () {
+        before(function (done) {
+            var localRunOptions = {
+                collection: {
+                    item: {
+                        name: 'NTLM Sample Request',
+                        request: {
+                            url: ntlmServerURL
+                        }
+                    },
+                    auth: {
+                        type: 'ntlm',
+                        ntlm: {
+                            username: USERNAME,
+                            password: PASSWORD,
+                            domain: DOMAIN,
+                            workstation: WORKSTATION
+                        }
+                    }
+                },
+                iterationCount: 5
+            };
+
+            // perform the collection run
+            this.run(localRunOptions, function (err, results) {
+                testrun = results;
+                done(err);
+            });
+        });
+
+        it('should have completed the run', function () {
+            expect(testrun).to.be.ok;
+            expect(testrun).to.nested.include({
+                'done.callCount': 1
+            });
+
+            var err = testrun.request.firstCall.args[0];
+
+            err && console.error(err.stack);
+            expect(err).to.be.null;
+
+            expect(testrun).to.nested.include({
+                'start.callCount': 1
+            });
+        });
+
+        it('should have sent the request 3 * 5 = 15 times', function () {
+            expect(testrun).to.nested.include({
+                'request.callCount': 15
+            });
+
+            var response0 = testrun.request.getCall(0).args[2],
+                response1 = testrun.request.getCall(1).args[2],
+                response2 = testrun.request.getCall(2).args[2],
+                response5 = testrun.request.getCall(5).args[2],
+                response8 = testrun.request.getCall(8).args[2],
+                response11 = testrun.request.getCall(11).args[2],
+                response14 = testrun.request.getCall(14).args[2];
+
+            expect(response0, 'iteration 1, request 1').to.have.property('code', 401);
+            expect(response1, 'iteration 1, request 2').to.have.property('code', 401);
+            expect(response2, 'iteration 1, request 3').to.have.property('code', 200);
+            expect(response5, 'iteration 2, request 3').to.have.property('code', 200);
+            expect(response8, 'iteration 3, request 3').to.have.property('code', 200);
+            expect(response11, 'iteration 4, request 3').to.have.property('code', 200);
+            expect(response14, 'iteration 5, request 3').to.have.property('code', 200);
+        });
+    });
+
+
+    describe('with NTLM auth set at collection level and 5 iterations', function () {
+        before(function (done) {
+            var localRunOptions = {
+                collection: {
+                    item: {
+                        name: 'NTLM Sample Request',
+                        request: {
+                            url: ntlmServerURL
+                        }
+                    },
+                    auth: {
+                        type: 'ntlm',
+                        ntlm: {
+                            username: USERNAME,
+                            password: PASSWORD,
+                            domain: DOMAIN,
+                            workstation: WORKSTATION
+                        }
+                    }
+                },
+                iterationCount: 5
+            };
+
+            // perform the collection run
+            this.run(localRunOptions, function (err, results) {
+                testrun = results;
+                done(err);
+            });
+        });
+
+        it('should have completed the run', function () {
+            expect(testrun).to.be.ok;
+            expect(testrun).to.nested.include({
+                'done.callCount': 1
+            });
+
+            var err = testrun.request.firstCall.args[0];
+
+            err && console.error(err.stack);
+            expect(err).to.be.null;
+
+            expect(testrun).to.nested.include({
+                'start.callCount': 1
+            });
+        });
+
+        it('should have sent the request 3 * 5 = 15 times', function () {
+            expect(testrun).to.nested.include({
+                'request.callCount': 15
+            });
+
+            var response0 = testrun.request.getCall(0).args[2],
+                response1 = testrun.request.getCall(1).args[2],
+                response2 = testrun.request.getCall(2).args[2],
+                response5 = testrun.request.getCall(5).args[2],
+                response8 = testrun.request.getCall(8).args[2],
+                response11 = testrun.request.getCall(11).args[2],
+                response14 = testrun.request.getCall(14).args[2];
+
+            expect(response0, 'iteration 1, request 1').to.have.property('code', 401);
+            expect(response1, 'iteration 1, request 2').to.have.property('code', 401);
+            expect(response2, 'iteration 1, request 3').to.have.property('code', 200);
+            expect(response5, 'iteration 2, request 3').to.have.property('code', 200);
+            expect(response8, 'iteration 3, request 3').to.have.property('code', 200);
+            expect(response11, 'iteration 4, request 3').to.have.property('code', 200);
+            expect(response14, 'iteration 5, request 3').to.have.property('code', 200);
+        });
+    });
+
+    describe('with NTLM auth set at folder level and 5 iterations', function () {
+        before(function (done) {
+            var localRunOptions = {
+                collection: {
+                    item: {
+                        name: 'NTLM folder',
+                        item: {
+                            name: 'NTLM Sample Request',
+                            request: {
+                                url: ntlmServerURL
+                            }
+                        },
+                        auth: {
+                            type: 'ntlm',
+                            ntlm: {
+                                username: USERNAME,
+                                password: PASSWORD,
+                                domain: DOMAIN,
+                                workstation: WORKSTATION
+                            }
+                        }
+                    }
+                },
+                iterationCount: 5
+            };
+
+            // perform the collection run
+            this.run(localRunOptions, function (err, results) {
+                testrun = results;
+                done(err);
+            });
+        });
+
+        it('should have completed the run', function () {
+            expect(testrun).to.be.ok;
+            expect(testrun).to.nested.include({
+                'done.callCount': 1
+            });
+
+            var err = testrun.request.firstCall.args[0];
+
+            err && console.error(err.stack);
+            expect(err).to.be.null;
+
+            expect(testrun).to.nested.include({
+                'start.callCount': 1
+            });
+        });
+
+        it('should have sent the request 3 * 5 = 15 times', function () {
+            expect(testrun).to.nested.include({
+                'request.callCount': 15
+            });
+
+            var response0 = testrun.request.getCall(0).args[2],
+                response1 = testrun.request.getCall(1).args[2],
+                response2 = testrun.request.getCall(2).args[2],
+                response5 = testrun.request.getCall(5).args[2],
+                response8 = testrun.request.getCall(8).args[2],
+                response11 = testrun.request.getCall(11).args[2],
+                response14 = testrun.request.getCall(14).args[2];
+
+            expect(response0, 'iteration 1, request 1').to.have.property('code', 401);
+            expect(response1, 'iteration 1, request 2').to.have.property('code', 401);
+            expect(response2, 'iteration 1, request 3').to.have.property('code', 200);
+            expect(response5, 'iteration 2, request 3').to.have.property('code', 200);
+            expect(response8, 'iteration 3, request 3').to.have.property('code', 200);
+            expect(response11, 'iteration 4, request 3').to.have.property('code', 200);
+            expect(response14, 'iteration 5, request 3').to.have.property('code', 200);
+        });
+    });
 });


### PR DESCRIPTION
This fix is kind of a hack because the architecture is not ideal.
Verified that tests fail before the fix.