### PR TITLE
Avoid OOM in `normaliseIterationData`

### DIFF
--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -1,4 +1,6 @@
 master:
+  new features:
+    - GH-949 Improved performance for large number of iterations
   chores:
     - GH-943 Added `nyc` and `codecov` for code coverage checks
     - GH-951 Added sanity check for edgegrid auth params in sign function

--- a/lib/runner/extensions/waterfall.command.js
+++ b/lib/runner/extensions/waterfall.command.js
@@ -139,7 +139,9 @@ module.exports = {
                 this.queue('item', {
                     item: item,
                     coords: coords,
-                    data: this.state.data[coords.iteration],
+                    data: this.state.data[coords.iteration] === undefined ?
+                        this.state.data[this.state.data.length - 1] :
+                        this.state.data[coords.iteration],
                     environment: this.state.environment,
                     globals: this.state.globals,
                     collectionVariables: this.state.collectionVariables,

--- a/lib/runner/extensions/waterfall.command.js
+++ b/lib/runner/extensions/waterfall.command.js
@@ -3,7 +3,8 @@ var _ = require('lodash'),
     VariableScope = require('postman-collection').VariableScope,
 
     prepareLookupHash,
-    extractSNR;
+    extractSNR,
+    getIterationData;
 
 /**
  * Returns a hash of IDs and Names of items in an array
@@ -39,6 +40,21 @@ extractSNR = function (executions, previous) {
     });
 
     return snr;
+};
+
+/**
+ * Returns the data for the given iteration
+ *
+ * @function getIterationData
+ * @param {Array} data - The data array containing all iterations' data
+ * @param {Number} iteration - The iteration to get data for
+ * @return {Any} - The data for the iteration
+ */
+getIterationData = function (data, iteration) {
+    // check if data exists. if not, return the last member from the data
+    if (data && data.length) {
+        return iteration in data ? data[iteration] : data[data.length - 1];
+    }
 };
 
 /**
@@ -139,9 +155,7 @@ module.exports = {
                 this.queue('item', {
                     item: item,
                     coords: coords,
-                    data: this.state.data[coords.iteration] === undefined ?
-                        this.state.data[this.state.data.length - 1] :
-                        this.state.data[coords.iteration],
+                    data: getIterationData(this.state.data, coords.iteration),
                     environment: this.state.environment,
                     globals: this.state.globals,
                     collectionVariables: this.state.collectionVariables,

--- a/lib/runner/extensions/waterfall.command.js
+++ b/lib/runner/extensions/waterfall.command.js
@@ -51,10 +51,13 @@ extractSNR = function (executions, previous) {
  * @return {Any} - The data for the iteration
  */
 getIterationData = function (data, iteration) {
-    // check if data exists. if not, return the last member from the data
-    if (data && data.length) {
-        return iteration in data ? data[iteration] : data[data.length - 1];
+    // if iteration has a corresponding data element use that
+    if (iteration < data.length) {
+        return data[iteration];
     }
+
+    // otherwise use the last data element
+    return data[data.length - 1];
 };
 
 /**
@@ -84,7 +87,7 @@ module.exports = {
         // if the location in state is already normalised then go ahead and queue iteration, else normalise the
         // location
         state.cursor = Cursor.box(state.cursor, { // we pass bounds to ensure there is no stale state
-            cycles: state.data.length,
+            cycles: this.options.iterationCount,
             length: state.items.length
         });
         this.waterfall = state.cursor; // copy the location object to instance for quick access

--- a/lib/runner/index.js
+++ b/lib/runner/index.js
@@ -135,12 +135,12 @@ _.assign(Runner, {
         !_.isArray(data) && (data = [{}]);
         ((length < 1) || !_.isFinite(length)) && (length = data.length);
 
-        // if the iteration count is greater than the length of data, we repeat the last item in data. here, we are
-        // using a for-loop so that we do not have excessive spatial complexity
+        // if the iteration count is greater than the length of data, we
+        // increase the length of data to match the number of iterations.
+        // We set the last element of data as the one we will use for all
+        // elements of data which are undefined.
         if (length > data.length) {
-            for (var i = data.length, filler = data[i - 1]; i < length; i++) {
-                data[i] = filler;
-            }
+            data[length - 1] = data[data.length - 1];
         }
 
         // just to be sure that there are no extra items in array, we match the lengths and return the data

--- a/lib/runner/index.js
+++ b/lib/runner/index.js
@@ -102,9 +102,17 @@ _.assign(Runner.prototype, {
                 return callback(new Error(`Unable to find a folder or request: ${_.get(options, 'entrypoint.execute')}`));
             }
 
+            // ensure data is an array
+            !_.isArray(options.data) && (options.data = [{}]);
+
+            // get iterationCount from data if not set
+            if (!runOptions.iterationCount) {
+                runOptions.iterationCount = options.data.length;
+            }
+
             return callback(null, (new Run({
                 items: runnableItems,
-                data: Runner.normaliseIterationData(options.data, options.iterationCount),
+                data: options.data,
                 environment: options.environment,
                 globals: _.has(options, 'globals') ? options.globals : self.options.globals,
                 // @todo Move to item level to support Item and ItemGroup variables
@@ -122,32 +130,7 @@ _.assign(Runner, {
      *
      * @type {Run}
      */
-    Run: Run,
-
-    /**
-     * @private
-     *
-     * @param {Array} data
-     * @param {Number} length
-     * @returns {Array}
-     */
-    normaliseIterationData: function (data, length) {
-        !_.isArray(data) && (data = [{}]);
-        ((length < 1) || !_.isFinite(length)) && (length = data.length);
-
-        // if the iteration count is greater than the length of data, we
-        // increase the length of data to match the number of iterations.
-        // We set the last element of data as the one we will use for all
-        // elements of data which are undefined.
-        if (length > data.length) {
-            data[length - 1] = data[data.length - 1];
-        }
-
-        // just to be sure that there are no extra items in array, we match the lengths and return the data
-        data.length = length;
-
-        return data;
-    }
+    Run: Run
 });
 
 module.exports = Runner;

--- a/test/integration/runner-spec/iterationCount.test.js
+++ b/test/integration/runner-spec/iterationCount.test.js
@@ -5,7 +5,7 @@ var collection = {
             script: {
                 exec: `
                     pm.test('should contain data', function () {
-                        pm.expect(pm.variables.get('foo')).to.equal('bar');
+                        pm.expect(pm.iterationData.get('foo')).to.equal('bar');
                     });
                 `
             }
@@ -32,14 +32,16 @@ describe('Run option iterationCount', function () {
                 });
             });
 
-            it('should run collection specified number of times', function () {
+            it('should complete the run successfully', function () {
                 expect(testrun).to.be.ok;
                 expect(testrun.done.getCall(0).args[0]).to.not.exist;
                 expect(testrun).to.nested.include({
                     'done.calledOnce': true,
                     'start.calledOnce': true
                 });
+            });
 
+            it('should run collection specified number of times', function () {
                 expect(testrun.request.callCount).to.equal(3);
             });
         });
@@ -62,14 +64,20 @@ describe('Run option iterationCount', function () {
                 });
             });
 
-            it('should use last data value for iterations with no corresponding data', function () {
+            it('should complete the run successfully', function () {
                 expect(testrun).to.be.ok;
                 expect(testrun.done.getCall(0).args[0]).to.not.exist;
                 expect(testrun).to.nested.include({
                     'done.calledOnce': true,
                     'start.calledOnce': true
                 });
+            });
 
+            it('should run collection specified number of times', function () {
+                expect(testrun.request.callCount).to.equal(4);
+            });
+
+            it('should use last data value for iterations with no corresponding data', function () {
                 var assertions = [
                     testrun.assertion.getCall(0).args[1][0],
                     testrun.assertion.getCall(1).args[1][0],
@@ -104,7 +112,7 @@ describe('Run option iterationCount', function () {
                     iterationCount: 2,
                     data: [
                         {foo: 'bar'},
-                        {foo: 'bar'},
+                        {foo: 'not bar'},
                         {foo: 'bar'}
                     ],
                     collection
@@ -114,14 +122,20 @@ describe('Run option iterationCount', function () {
                 });
             });
 
-            it('should use last data value for iterations with no corresponding data', function () {
+            it('should complete the run successfully', function () {
                 expect(testrun).to.be.ok;
                 expect(testrun.done.getCall(0).args[0]).to.not.exist;
                 expect(testrun).to.nested.include({
                     'done.calledOnce': true,
                     'start.calledOnce': true
                 });
+            });
 
+            it('should run collection specified number of times', function () {
+                expect(testrun.request.callCount).to.equal(2);
+            });
+
+            it('should ignore the data items after the iteration count', function () {
                 var assertions = [
                     testrun.assertion.getCall(0).args[1][0],
                     testrun.assertion.getCall(1).args[1][0]
@@ -133,7 +147,7 @@ describe('Run option iterationCount', function () {
                 });
                 expect(assertions[1]).to.deep.include({
                     name: 'should contain data',
-                    passed: true
+                    passed: false
                 });
             });
         });
@@ -147,7 +161,7 @@ describe('Run option iterationCount', function () {
                 this.run({
                     data: [
                         {foo: 'bar'},
-                        {foo: 'bar'},
+                        {foo: 'not bar'},
                         {foo: 'bar'}
                     ],
                     collection
@@ -157,16 +171,20 @@ describe('Run option iterationCount', function () {
                 });
             });
 
-            it('should set iterations equal to the length of data', function () {
+            it('should complete the run successfully', function () {
                 expect(testrun).to.be.ok;
                 expect(testrun.done.getCall(0).args[0]).to.not.exist;
                 expect(testrun).to.nested.include({
                     'done.calledOnce': true,
                     'start.calledOnce': true
                 });
+            });
 
+            it('should run iterations equal to the length of data', function () {
                 expect(testrun.assertion.callCount).to.equal(3);
+            });
 
+            it('should use proper data elements for each iteration', function () {
                 var assertions = [
                     testrun.assertion.getCall(0).args[1][0],
                     testrun.assertion.getCall(1).args[1][0],
@@ -179,9 +197,9 @@ describe('Run option iterationCount', function () {
                 });
                 expect(assertions[1]).to.deep.include({
                     name: 'should contain data',
-                    passed: true
+                    passed: false
                 });
-                expect(assertions[1]).to.deep.include({
+                expect(assertions[2]).to.deep.include({
                     name: 'should contain data',
                     passed: true
                 });
@@ -200,14 +218,16 @@ describe('Run option iterationCount', function () {
                 });
             });
 
-            it('should run only 1 iteration', function () {
+            it('should complete the run successfully', function () {
                 expect(testrun).to.be.ok;
                 expect(testrun.done.getCall(0).args[0]).to.not.exist;
                 expect(testrun).to.nested.include({
                     'done.calledOnce': true,
                     'start.calledOnce': true
                 });
+            });
 
+            it('should run only 1 iteration', function () {
                 expect(testrun.assertion.callCount).to.equal(1);
 
                 var assertion = testrun.assertion.getCall(0).args[1][0];

--- a/test/integration/runner-spec/iterationCount.test.js
+++ b/test/integration/runner-spec/iterationCount.test.js
@@ -1,0 +1,222 @@
+var collection = {
+    item: [{
+        event: [{
+            listen: 'prerequest',
+            script: {
+                exec: `
+                    pm.test('should contain data', function () {
+                        pm.expect(pm.variables.get('foo')).to.equal('bar');
+                    });
+                `
+            }
+        }],
+        request: {
+            url: 'https://postman-echo.com/get',
+            method: 'GET'
+        }
+    }]
+};
+
+describe('Run option iterationCount', function () {
+    describe('when set', function () {
+        describe('without data', function () {
+            var testrun;
+
+            before(function (done) {
+                this.run({
+                    iterationCount: 3,
+                    collection
+                }, function (err, results) {
+                    testrun = results;
+                    done(err);
+                });
+            });
+
+            it('should run collection specified number of times', function () {
+                expect(testrun).to.be.ok;
+                expect(testrun.done.getCall(0).args[0]).to.not.exist;
+                expect(testrun).to.nested.include({
+                    'done.calledOnce': true,
+                    'start.calledOnce': true
+                });
+
+                expect(testrun.request.callCount).to.equal(3);
+            });
+        });
+
+        describe('with data items lesser than iteration count', function () {
+            var testrun;
+
+            before(function (done) {
+                this.run({
+                    iterationCount: 4,
+                    data: [
+                        {foo: 'bar'},
+                        undefined,
+                        {foo: 'bar'}
+                    ],
+                    collection
+                }, function (err, results) {
+                    testrun = results;
+                    done(err);
+                });
+            });
+
+            it('should use last data value for iterations with no corresponding data', function () {
+                expect(testrun).to.be.ok;
+                expect(testrun.done.getCall(0).args[0]).to.not.exist;
+                expect(testrun).to.nested.include({
+                    'done.calledOnce': true,
+                    'start.calledOnce': true
+                });
+
+                var assertions = [
+                    testrun.assertion.getCall(0).args[1][0],
+                    testrun.assertion.getCall(1).args[1][0],
+                    testrun.assertion.getCall(2).args[1][0],
+                    testrun.assertion.getCall(3).args[1][0]
+                ];
+
+                expect(assertions[0]).to.deep.include({
+                    name: 'should contain data',
+                    passed: true
+                });
+                expect(assertions[1]).to.deep.include({
+                    name: 'should contain data',
+                    passed: false
+                });
+                expect(assertions[2]).to.deep.include({
+                    name: 'should contain data',
+                    passed: true
+                });
+                expect(assertions[3]).to.deep.include({
+                    name: 'should contain data',
+                    passed: true
+                });
+            });
+        });
+
+        describe('with data items more than iteration count', function () {
+            var testrun;
+
+            before(function (done) {
+                this.run({
+                    iterationCount: 2,
+                    data: [
+                        {foo: 'bar'},
+                        {foo: 'bar'},
+                        {foo: 'bar'}
+                    ],
+                    collection
+                }, function (err, results) {
+                    testrun = results;
+                    done(err);
+                });
+            });
+
+            it('should use last data value for iterations with no corresponding data', function () {
+                expect(testrun).to.be.ok;
+                expect(testrun.done.getCall(0).args[0]).to.not.exist;
+                expect(testrun).to.nested.include({
+                    'done.calledOnce': true,
+                    'start.calledOnce': true
+                });
+
+                var assertions = [
+                    testrun.assertion.getCall(0).args[1][0],
+                    testrun.assertion.getCall(1).args[1][0]
+                ];
+
+                expect(assertions[0]).to.deep.include({
+                    name: 'should contain data',
+                    passed: true
+                });
+                expect(assertions[1]).to.deep.include({
+                    name: 'should contain data',
+                    passed: true
+                });
+            });
+        });
+    });
+
+    describe('when not set', function () {
+        describe('with data', function () {
+            var testrun;
+
+            before(function (done) {
+                this.run({
+                    data: [
+                        {foo: 'bar'},
+                        {foo: 'bar'},
+                        {foo: 'bar'}
+                    ],
+                    collection
+                }, function (err, results) {
+                    testrun = results;
+                    done(err);
+                });
+            });
+
+            it('should set iterations equal to the length of data', function () {
+                expect(testrun).to.be.ok;
+                expect(testrun.done.getCall(0).args[0]).to.not.exist;
+                expect(testrun).to.nested.include({
+                    'done.calledOnce': true,
+                    'start.calledOnce': true
+                });
+
+                expect(testrun.assertion.callCount).to.equal(3);
+
+                var assertions = [
+                    testrun.assertion.getCall(0).args[1][0],
+                    testrun.assertion.getCall(1).args[1][0],
+                    testrun.assertion.getCall(2).args[1][0]
+                ];
+
+                expect(assertions[0]).to.deep.include({
+                    name: 'should contain data',
+                    passed: true
+                });
+                expect(assertions[1]).to.deep.include({
+                    name: 'should contain data',
+                    passed: true
+                });
+                expect(assertions[1]).to.deep.include({
+                    name: 'should contain data',
+                    passed: true
+                });
+            });
+        });
+
+        describe('without data', function () {
+            var testrun;
+
+            before(function (done) {
+                this.run({
+                    collection
+                }, function (err, results) {
+                    testrun = results;
+                    done(err);
+                });
+            });
+
+            it('should run only 1 iteration', function () {
+                expect(testrun).to.be.ok;
+                expect(testrun.done.getCall(0).args[0]).to.not.exist;
+                expect(testrun).to.nested.include({
+                    'done.calledOnce': true,
+                    'start.calledOnce': true
+                });
+
+                expect(testrun.assertion.callCount).to.equal(1);
+
+                var assertion = testrun.assertion.getCall(0).args[1][0];
+
+                expect(assertion).to.deep.include({
+                    name: 'should contain data',
+                    passed: false
+                });
+            });
+        });
+    });
+});

--- a/test/unit/runner.test.js
+++ b/test/unit/runner.test.js
@@ -2,10 +2,6 @@ var expect = require('chai').expect,
     Runner = require('../../lib/runner/'),
     sdk = require('postman-collection');
 
-function getIterationData (data, iteration) {
-    return iteration in data ? data[iteration] : data[data.length - 1];
-}
-
 describe('runner', function () {
     describe('Run', function () {
         it('should be a constructor', function () {
@@ -319,27 +315,6 @@ describe('runner', function () {
                     });
                 });
             });
-        });
-    });
-
-    describe('normaliseIterationData', function () {
-        it('should handle insane arguments correctly', function () {
-            expect(Runner.normaliseIterationData()).to.eql([{}]);
-        });
-
-        it('should trim the provided data set to the specified length', function () {
-            expect(Runner.normaliseIterationData([{foo: 'alpha'}, {bar: 'beta'}], 1)).to.eql([{foo: 'alpha'}]);
-        });
-
-        it('should duplicate the last element of the data set if length is greater', function () {
-            var data = Runner.normaliseIterationData([{foo: 'alpha'}, undefined, {bar: 'beta'}], 6);
-
-            expect(getIterationData(data, 0)).to.eql({foo: 'alpha'});
-            expect(getIterationData(data, 1)).to.eql(undefined);
-            expect(getIterationData(data, 2)).to.eql({bar: 'beta'});
-            expect(getIterationData(data, 3)).to.eql({bar: 'beta'});
-            expect(getIterationData(data, 4)).to.eql({bar: 'beta'});
-            expect(getIterationData(data, 5)).to.eql({bar: 'beta'});
         });
     });
 });

--- a/test/unit/runner.test.js
+++ b/test/unit/runner.test.js
@@ -2,6 +2,10 @@ var expect = require('chai').expect,
     Runner = require('../../lib/runner/'),
     sdk = require('postman-collection');
 
+function getIterationData (data, iteration) {
+    return iteration in data ? data[iteration] : data[data.length - 1];
+}
+
 describe('runner', function () {
     describe('Run', function () {
         it('should be a constructor', function () {
@@ -328,7 +332,14 @@ describe('runner', function () {
         });
 
         it('should duplicate the last element of the data set if length is greater', function () {
-            expect(Runner.normaliseIterationData([{foo: 'alpha'}], 2)).to.eql([{foo: 'alpha'}, {foo: 'alpha'}]);
+            var data = Runner.normaliseIterationData([{foo: 'alpha'}, undefined, {bar: 'beta'}], 6);
+
+            expect(getIterationData(data, 0)).to.eql({foo: 'alpha'});
+            expect(getIterationData(data, 1)).to.eql(undefined);
+            expect(getIterationData(data, 2)).to.eql({bar: 'beta'});
+            expect(getIterationData(data, 3)).to.eql({bar: 'beta'});
+            expect(getIterationData(data, 4)).to.eql({bar: 'beta'});
+            expect(getIterationData(data, 5)).to.eql({bar: 'beta'});
         });
     });
 });


### PR DESCRIPTION
### Description

If iteration count is more than the length of `data`, the `normaliseIterationData` function fills the `data` array with the last element in `data` such that `data.length = iterationCount`.

When iteration count is a large number (e.g. 99999999), run creation takes a lot of time and sometimes even fails with "Out of Memory" error because the JS Heap is exhausted.

This change avoids the above situation by simply setting the `data[iterationCount - 1]` element as the value to be repeated. Later, when iteration data is to be fetched, if the element at `data[iteration]` exists, we use it; if not, we use the last element of the `data`.

---

### Performance increase
For `iterationCount` 9999999, time for `run` creation:
#### before
- 3s 417ms
- 3s 403ms
- 3s 505ms

#### after
- 0s 2.1ms
- 0s 1.9ms
- 0s 1.9ms