### PR TITLE
Fixed expiry of cookies with `Max-Age` field

### DIFF
--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -1,3 +1,9 @@
+master:
+  fixed bugs:
+    - >-
+      GH-957 Fixed a bug where expiry was wrong for cookies passed to response
+      callback when cookies had `Max-Age` field
+
 7.22.0:
   date: 2020-01-10
   new features:

--- a/lib/requester/requester.js
+++ b/lib/requester/requester.js
@@ -46,12 +46,30 @@ var _ = require('lodash'),
      * @returns {Object}
      */
     toPostmanCookie = function (cookie) {
+        var expires = cookie.expiryTime();
+
         cookie.toJSON && (cookie = cookie.toJSON());
+
+        switch (expires) {
+            case Infinity:
+                expires = null;
+                break;
+            case -Infinity:
+                // this code will never be executed because it only happens when
+                // maxAge <= 0 but cookieJar.getCookies() does not return cookies
+                // with maxAge <= 0
+
+                // set past date because cookie is expired due to maxAge <= 0
+                expires = new Date(0);
+                break;
+            default:
+                expires = new Date(expires);
+        }
 
         return new sdk.Cookie({
             name: cookie.key,
             value: cookie.value,
-            expires: cookie.expires === 'Infinity' ? null : cookie.expires,
+            expires: expires,
             maxAge: cookie.maxAge,
             domain: cookie.domain,
             path: cookie.path,

--- a/lib/requester/requester.js
+++ b/lib/requester/requester.js
@@ -50,26 +50,10 @@ var _ = require('lodash'),
 
         cookie.toJSON && (cookie = cookie.toJSON());
 
-        switch (expires) {
-            case Infinity:
-                expires = null;
-                break;
-            case -Infinity:
-                // this code will never be executed because it only happens when
-                // maxAge <= 0 but cookieJar.getCookies() does not return cookies
-                // with maxAge <= 0
-
-                // set past date because cookie is expired due to maxAge <= 0
-                expires = new Date(0);
-                break;
-            default:
-                expires = new Date(expires);
-        }
-
         return new sdk.Cookie({
             name: cookie.key,
             value: cookie.value,
-            expires: expires,
+            expires: Number.isFinite(expires) ? new Date(expires) : null,
             maxAge: cookie.maxAge,
             domain: cookie.domain,
             path: cookie.path,

--- a/test/integration/request-flow/response-cookies.test.js
+++ b/test/integration/request-flow/response-cookies.test.js
@@ -1,0 +1,71 @@
+var sinon = require('sinon'),
+    expect = require('chai').expect,
+    server = require('../../fixtures/server');
+
+describe('Cookies expiry in response callback', function () {
+    var testrun,
+        httpServer;
+
+    before(function (done) {
+        var self = this;
+
+        httpServer = server.createHTTPServer();
+
+        httpServer.on('/', function (req, res) {
+            var cookies = [
+                // session cookie (without Max-Age and Expires)
+                'cookie_1=value_1; path=/',
+
+                // with Max-Age > 0
+                'cookie_2=value_2; path=/; Max-Age=1000'
+            ];
+
+            res.writeHead(200, {
+                'Set-Cookie': cookies
+            });
+
+            res.end();
+        });
+
+        httpServer.listen(0, function () {
+            self.run({
+                collection: {
+                    item: [{
+                        request: {
+                            url: httpServer.url,
+                            method: 'GET'
+                        }
+                    }]
+                }
+            }, function (err, result) {
+                testrun = result;
+                done(err);
+            });
+        });
+    });
+
+    after(function (done) {
+        httpServer.destroy(done);
+    });
+
+    it('should complete the run', function () {
+        expect(testrun).to.be.ok;
+        sinon.assert.calledOnce(testrun.start);
+        sinon.assert.calledOnce(testrun.done);
+        sinon.assert.calledWith(testrun.done.getCall(0), null);
+    });
+
+    it('should have null expiry for session cookie', function () {
+        var cookie = testrun.response.getCall(0).args[5].find({name: 'cookie_1'});
+
+        expect(cookie.expires).to.be.null;
+    });
+
+
+    it('should have expiry for cookie with Max-Age>0', function () {
+        var cookie = testrun.response.getCall(0).args[5].find({name: 'cookie_2'});
+
+        expect(cookie.expires).to.be.ok;
+        expect(cookie.expires).to.be.instanceOf(Date);
+    });
+});

--- a/test/integration/request-flow/response-cookies.test.js
+++ b/test/integration/request-flow/response-cookies.test.js
@@ -12,16 +12,14 @@ describe('Cookies expiry in response callback', function () {
         httpServer = server.createHTTPServer();
 
         httpServer.on('/', function (req, res) {
-            var cookies = [
-                // session cookie (without Max-Age and Expires)
-                'cookie_1=value_1; path=/',
-
-                // with Max-Age > 0
-                'cookie_2=value_2; path=/; Max-Age=1000'
-            ];
-
             res.writeHead(200, {
-                'Set-Cookie': cookies
+                'Set-Cookie': [
+                    // session cookie (without Max-Age and Expires)
+                    'cookie_1=value_1; path=/',
+
+                    // with Max-Age > 0
+                    'cookie_2=value_2; path=/; Max-Age=1000'
+                ]
             });
 
             res.end();
@@ -31,10 +29,7 @@ describe('Cookies expiry in response callback', function () {
             self.run({
                 collection: {
                     item: [{
-                        request: {
-                            url: httpServer.url,
-                            method: 'GET'
-                        }
+                        request: httpServer.url
                     }]
                 }
             }, function (err, result) {


### PR DESCRIPTION
Fixed a bug where cookies in `response` callback were having `null` expiry when the cookie received from the server only had `Max-Age` field without `Expires` field.

Fixes: https://github.com/postmanlabs/postman-app-support/issues/7738