### PR TITLE
Added an option in OAuth1 to toggle parameter encoding in Authorization header

### DIFF
--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -1,4 +1,8 @@
 master:
+  new features:
+    - >-
+      GH-959 Added an option to disable parameter encoding in Authorization
+      header of OAuth1
   fixed bugs:
     - >-
       GH-957 Fixed a bug where expiry was wrong for cookies passed to response

--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -1,7 +1,7 @@
 master:
   new features:
     - >-
-      GH-959 Added an option to disable parameter encoding in Authorization
+      GH-959 Added an option to toggle parameter encoding in Authorization
       header of OAuth1
   fixed bugs:
     - >-

--- a/lib/authorizer/oauth1.js
+++ b/lib/authorizer/oauth1.js
@@ -233,7 +233,7 @@ module.exports = {
                 'realm',
                 'addParamsToHeader',
                 'addEmptyParamsToSign',
-                'disableAuthHeaderEncoding'
+                'encodeAuthHeaderParams'
             ]),
             url = urlEncoder.toNodeUrl(request.url.toString(true)),
             signatureParams,
@@ -302,7 +302,7 @@ module.exports = {
         if (params.addParamsToHeader) {
             header = oAuth1.getAuthorizationHeader(params.realm, _.map(signatureParams, function (param) {
                 return [param.key, param.value];
-            }), !params.disableAuthHeaderEncoding);
+            }), params.encodeAuthHeaderParams);
             request.addHeader({
                 key: 'Authorization',
                 value: header,

--- a/lib/authorizer/oauth1.js
+++ b/lib/authorizer/oauth1.js
@@ -232,7 +232,8 @@ module.exports = {
                 'version',
                 'realm',
                 'addParamsToHeader',
-                'addEmptyParamsToSign'
+                'addEmptyParamsToSign',
+                'disableAuthHeaderEncoding'
             ]),
             url = urlEncoder.toNodeUrl(request.url.toString(true)),
             signatureParams,
@@ -301,7 +302,7 @@ module.exports = {
         if (params.addParamsToHeader) {
             header = oAuth1.getAuthorizationHeader(params.realm, _.map(signatureParams, function (param) {
                 return [param.key, param.value];
-            }));
+            }), !params.disableAuthHeaderEncoding);
             request.addHeader({
                 key: 'Authorization',
                 value: header,

--- a/lib/authorizer/oauth1.js
+++ b/lib/authorizer/oauth1.js
@@ -233,7 +233,7 @@ module.exports = {
                 'realm',
                 'addParamsToHeader',
                 'addEmptyParamsToSign',
-                'encodeAuthHeaderParams'
+                'disableHeaderEncoding'
             ]),
             url = urlEncoder.toNodeUrl(request.url.toString(true)),
             signatureParams,
@@ -302,7 +302,7 @@ module.exports = {
         if (params.addParamsToHeader) {
             header = oAuth1.getAuthorizationHeader(params.realm, _.map(signatureParams, function (param) {
                 return [param.key, param.value];
-            }), params.encodeAuthHeaderParams);
+            }), params.disableHeaderEncoding);
             request.addHeader({
                 key: 'Authorization',
                 value: header,

--- a/package-lock.json
+++ b/package-lock.json
@@ -2557,9 +2557,9 @@
       }
     },
     "node-oauth1": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/node-oauth1/-/node-oauth1-1.2.2.tgz",
-      "integrity": "sha512-f2XC7Y68wJq6+s+LJn/yUq5Gqg9Y9zwIz2zY6vUyS8xzawnSWhXKOMJepLwvptjPl8IjVxtWh7iI9dbdKGSw4g==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/node-oauth1/-/node-oauth1-1.2.3.tgz",
+      "integrity": "sha512-xcGOedhmwKrkLPX0/jpgYi5QtZuhFc3cdptaNKnOgtIdBoNa3vt4DVdMBxRXRoOG5SfZ1f/tC17+jIq+2SeAFw==",
       "requires": {
         "crypto-js": "3.1.9-1"
       }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "httpntlm": "1.7.6",
     "inherits": "2.0.4",
     "lodash": "4.17.15",
-    "node-oauth1": "1.2.2",
+    "node-oauth1": "1.2.3",
     "performance-now": "2.1.0",
     "postman-collection": "3.5.5",
     "postman-request": "2.88.1-postman.18",

--- a/test/integration/auth-methods/oauth1.test.js
+++ b/test/integration/auth-methods/oauth1.test.js
@@ -3,76 +3,168 @@ var expect = require('chai').expect;
 describe('oauth 1', function () {
     var testrun;
 
-    before(function (done) {
-        // perform the collection run
-        this.run({
-            collection: {
-                item: {
-                    request: {
-                        auth: {
-                            type: 'oauth1',
-                            oauth1: {
-                                consumerKey: 'RKCGzna7bv9YD57c',
-                                consumerSecret: 'D+EdQ-gs$-%@2Nu7',
-                                token: '',
-                                tokenSecret: '',
-                                signatureMethod: 'HMAC-SHA1',
-                                timeStamp: 1461319769,
-                                nonce: 'ik3oT5',
-                                version: '1.0',
-                                realm: '',
-                                addParamsToHeader: true,
-                                addEmptyParamsToSign: false
-                            }
-                        },
-                        url: 'https://postman-echo.com/oauth1',
-                        method: 'GET'
+    describe('correct credentials', function () {
+        before(function (done) {
+            // perform the collection run
+            this.run({
+                collection: {
+                    item: {
+                        request: {
+                            auth: {
+                                type: 'oauth1',
+                                oauth1: {
+                                    consumerKey: 'RKCGzna7bv9YD57c',
+                                    consumerSecret: 'D+EdQ-gs$-%@2Nu7',
+                                    token: '',
+                                    tokenSecret: '',
+                                    signatureMethod: 'HMAC-SHA1',
+                                    timeStamp: 1461319769,
+                                    nonce: 'ik3oT5',
+                                    version: '1.0',
+                                    realm: '',
+                                    addParamsToHeader: true,
+                                    addEmptyParamsToSign: false
+                                }
+                            },
+                            url: 'https://postman-echo.com/oauth1',
+                            method: 'GET'
+                        }
                     }
                 }
-            }
-        }, function (err, results) {
-            testrun = results;
-            done(err);
+            }, function (err, results) {
+                testrun = results;
+                done(err);
+            });
+        });
+
+        it('should have completed the run', function () {
+            expect(testrun).to.be.ok;
+            expect(testrun.done.calledOnce).to.be.ok;
+            testrun.done.getCall(0).args[0] && console.error(testrun.done.getCall(0).args[0].stack);
+            expect(testrun.done.getCall(0).args[0]).to.be.null;
+            expect(testrun.start.calledOnce).to.be.ok;
+        });
+
+        it('should have sent the request once', function () {
+            expect(testrun.request.calledOnce).to.be.ok;
+
+            var request = testrun.request.getCall(0).args[3],
+                response = testrun.request.getCall(0).args[2];
+
+            expect(request.url.toString()).to.eql('https://postman-echo.com/oauth1');
+            expect(response).to.have.property('code', 200);
+        });
+
+        it('should have sent one request internally', function () {
+            expect(testrun.io.calledOnce).to.be.ok;
+
+            var firstError = testrun.io.firstCall.args[0],
+                firstRequest = testrun.io.firstCall.args[4],
+                firstResponse = testrun.io.firstCall.args[3];
+
+            expect(firstError).to.be.null;
+            expect(firstRequest.url.toString()).to.eql('https://postman-echo.com/oauth1');
+            expect(firstResponse).to.have.property('code', 200);
+        });
+
+        it('should have passed OAuth 1 authorization', function () {
+            expect(testrun.request.calledOnce).to.be.ok;
+
+            var request = testrun.request.getCall(0).args[3],
+                response = testrun.request.getCall(0).args[2];
+
+            expect(request.url.toString()).to.eql('https://postman-echo.com/oauth1');
+            expect(response).to.have.property('code', 200);
         });
     });
 
-    it('should have completed the run', function () {
-        expect(testrun).to.be.ok;
-        expect(testrun.done.calledOnce).to.be.ok;
-        testrun.done.getCall(0).args[0] && console.error(testrun.done.getCall(0).args[0].stack);
-        expect(testrun.done.getCall(0).args[0]).to.be.null;
-        expect(testrun.start.calledOnce).to.be.ok;
+    describe('disableAuthHeaderEncoding: false', function () {
+        before(function (done) {
+            // perform the collection run
+            this.run({
+                collection: {
+                    item: {
+                        request: {
+                            auth: {
+                                type: 'oauth1',
+                                oauth1: {
+                                    consumerKey: 'foo!bar',
+                                    consumerSecret: 'secret',
+                                    signatureMethod: 'HMAC-SHA1',
+                                    addParamsToHeader: true,
+                                    disableAuthHeaderEncoding: false
+                                }
+                            },
+                            url: 'https://postman-echo.com/get',
+                            method: 'GET'
+                        }
+                    }
+                }
+            }, function (err, results) {
+                testrun = results;
+                done(err);
+            });
+        });
+
+        it('should have completed the run', function () {
+            expect(testrun).to.be.ok;
+            expect(testrun).to.nested.include({
+                'done.calledOnce': true,
+                'start.calledOnce': true
+            });
+            expect(testrun.done.getCall(0).args[0]).to.be.null;
+        });
+
+        it('should encode params in Authorization header', function () {
+            var response = testrun.response.getCall(0).args[2];
+
+            expect(response).to.have.property('code', 200);
+            expect(response.json().headers.authorization).to.contain('oauth_consumer_key="foo%21bar"');
+        });
     });
 
-    it('should have sent the request once', function () {
-        expect(testrun.request.calledOnce).to.be.ok;
+    describe('disableAuthHeaderEncoding: true', function () {
+        before(function (done) {
+            // perform the collection run
+            this.run({
+                collection: {
+                    item: {
+                        request: {
+                            auth: {
+                                type: 'oauth1',
+                                oauth1: {
+                                    consumerKey: 'foo!bar',
+                                    consumerSecret: 'secret',
+                                    signatureMethod: 'HMAC-SHA1',
+                                    addParamsToHeader: true,
+                                    disableAuthHeaderEncoding: true
+                                }
+                            },
+                            url: 'https://postman-echo.com/get',
+                            method: 'GET'
+                        }
+                    }
+                }
+            }, function (err, results) {
+                testrun = results;
+                done(err);
+            });
+        });
 
-        var request = testrun.request.getCall(0).args[3],
-            response = testrun.request.getCall(0).args[2];
+        it('should have completed the run', function () {
+            expect(testrun).to.be.ok;
+            expect(testrun).to.nested.include({
+                'done.calledOnce': true,
+                'start.calledOnce': true
+            });
+            expect(testrun.done.getCall(0).args[0]).to.be.null;
+        });
 
-        expect(request.url.toString()).to.eql('https://postman-echo.com/oauth1');
-        expect(response).to.have.property('code', 200);
-    });
+        it('should not encode params in Authorization header', function () {
+            var response = testrun.response.getCall(0).args[2];
 
-    it('should have sent one request internally', function () {
-        expect(testrun.io.calledOnce).to.be.ok;
-
-        var firstError = testrun.io.firstCall.args[0],
-            firstRequest = testrun.io.firstCall.args[4],
-            firstResponse = testrun.io.firstCall.args[3];
-
-        expect(firstError).to.be.null;
-        expect(firstRequest.url.toString()).to.eql('https://postman-echo.com/oauth1');
-        expect(firstResponse).to.have.property('code', 200);
-    });
-
-    it('should have passed OAuth 1 authorization', function () {
-        expect(testrun.request.calledOnce).to.be.ok;
-
-        var request = testrun.request.getCall(0).args[3],
-            response = testrun.request.getCall(0).args[2];
-
-        expect(request.url.toString()).to.eql('https://postman-echo.com/oauth1');
-        expect(response).to.have.property('code', 200);
+            expect(response).to.have.property('code', 200);
+            expect(response.json().headers.authorization).to.contain('oauth_consumer_key="foo!bar"');
+        });
     });
 });

--- a/test/integration/auth-methods/oauth1.test.js
+++ b/test/integration/auth-methods/oauth1.test.js
@@ -78,7 +78,7 @@ describe('oauth 1', function () {
         });
     });
 
-    describe('disableAuthHeaderEncoding: false', function () {
+    describe('encodeAuthHeaderParams: false', function () {
         before(function (done) {
             // perform the collection run
             this.run({
@@ -92,7 +92,52 @@ describe('oauth 1', function () {
                                     consumerSecret: 'secret',
                                     signatureMethod: 'HMAC-SHA1',
                                     addParamsToHeader: true,
-                                    disableAuthHeaderEncoding: false
+                                    encodeAuthHeaderParams: false
+                                }
+                            },
+                            url: 'https://postman-echo.com/get',
+                            method: 'GET'
+                        }
+                    }
+                }
+            }, function (err, results) {
+                testrun = results;
+                done(err);
+            });
+        });
+
+        it('should have completed the run', function () {
+            expect(testrun).to.be.ok;
+            expect(testrun).to.nested.include({
+                'done.calledOnce': true,
+                'start.calledOnce': true
+            });
+            expect(testrun.done.getCall(0).args[0]).to.be.null;
+        });
+
+        it('should not encode params in Authorization header', function () {
+            var response = testrun.response.getCall(0).args[2];
+
+            expect(response).to.have.property('code', 200);
+            expect(response.json().headers.authorization).to.contain('oauth_consumer_key="foo!bar"');
+        });
+    });
+
+    describe('encodeAuthHeaderParams: true', function () {
+        before(function (done) {
+            // perform the collection run
+            this.run({
+                collection: {
+                    item: {
+                        request: {
+                            auth: {
+                                type: 'oauth1',
+                                oauth1: {
+                                    consumerKey: 'foo!bar',
+                                    consumerSecret: 'secret',
+                                    signatureMethod: 'HMAC-SHA1',
+                                    addParamsToHeader: true,
+                                    encodeAuthHeaderParams: true
                                 }
                             },
                             url: 'https://postman-echo.com/get',
@@ -123,7 +168,7 @@ describe('oauth 1', function () {
         });
     });
 
-    describe('disableAuthHeaderEncoding: true', function () {
+    describe('encodeAuthHeaderParams: undefined', function () {
         before(function (done) {
             // perform the collection run
             this.run({
@@ -137,7 +182,7 @@ describe('oauth 1', function () {
                                     consumerSecret: 'secret',
                                     signatureMethod: 'HMAC-SHA1',
                                     addParamsToHeader: true,
-                                    disableAuthHeaderEncoding: true
+                                    encodeAuthHeaderParams: undefined
                                 }
                             },
                             url: 'https://postman-echo.com/get',
@@ -160,11 +205,11 @@ describe('oauth 1', function () {
             expect(testrun.done.getCall(0).args[0]).to.be.null;
         });
 
-        it('should not encode params in Authorization header', function () {
+        it('should encode params in Authorization header', function () {
             var response = testrun.response.getCall(0).args[2];
 
             expect(response).to.have.property('code', 200);
-            expect(response.json().headers.authorization).to.contain('oauth_consumer_key="foo!bar"');
+            expect(response.json().headers.authorization).to.contain('oauth_consumer_key="foo%21bar"');
         });
     });
 });

--- a/test/integration/auth-methods/oauth1.test.js
+++ b/test/integration/auth-methods/oauth1.test.js
@@ -78,7 +78,7 @@ describe('oauth 1', function () {
         });
     });
 
-    describe('encodeAuthHeaderParams: false', function () {
+    describe('disableHeaderEncoding: true', function () {
         before(function (done) {
             // perform the collection run
             this.run({
@@ -92,7 +92,7 @@ describe('oauth 1', function () {
                                     consumerSecret: 'secret',
                                     signatureMethod: 'HMAC-SHA1',
                                     addParamsToHeader: true,
-                                    encodeAuthHeaderParams: false
+                                    disableHeaderEncoding: true
                                 }
                             },
                             url: 'https://postman-echo.com/get',
@@ -123,7 +123,7 @@ describe('oauth 1', function () {
         });
     });
 
-    describe('encodeAuthHeaderParams: true', function () {
+    describe('disableHeaderEncoding: false', function () {
         before(function (done) {
             // perform the collection run
             this.run({
@@ -137,7 +137,7 @@ describe('oauth 1', function () {
                                     consumerSecret: 'secret',
                                     signatureMethod: 'HMAC-SHA1',
                                     addParamsToHeader: true,
-                                    encodeAuthHeaderParams: true
+                                    disableHeaderEncoding: false
                                 }
                             },
                             url: 'https://postman-echo.com/get',
@@ -168,7 +168,7 @@ describe('oauth 1', function () {
         });
     });
 
-    describe('encodeAuthHeaderParams: undefined', function () {
+    describe('without disableHeaderEncoding option', function () {
         before(function (done) {
             // perform the collection run
             this.run({
@@ -181,8 +181,7 @@ describe('oauth 1', function () {
                                     consumerKey: 'foo!bar',
                                     consumerSecret: 'secret',
                                     signatureMethod: 'HMAC-SHA1',
-                                    addParamsToHeader: true,
-                                    encodeAuthHeaderParams: undefined
+                                    addParamsToHeader: true
                                 }
                             },
                             url: 'https://postman-echo.com/get',
@@ -205,7 +204,7 @@ describe('oauth 1', function () {
             expect(testrun.done.getCall(0).args[0]).to.be.null;
         });
 
-        it('should encode params in Authorization header', function () {
+        it('should encode params in Authorization header by default', function () {
             var response = testrun.response.getCall(0).args[2];
 
             expect(response).to.have.property('code', 200);


### PR DESCRIPTION
Parameters in OAuth1 Authorization header were percent-encoded by default. This PR adds an option to toggle percent-encoding while generating Authorization header for OAauth1.

Todo:
- [x] Bump `node-oauth1` version with following PR merged: https://github.com/postmanlabs/node-oauth1/pull/7

Issues:
- https://github.com/postmanlabs/postman-app-support/issues/3999
- https://github.com/postmanlabs/postman-app-support/issues/4300
- https://github.com/postmanlabs/postman-app-support/issues/5744