### PR TITLE
Fixed request headers updated by AWS auth in manifest

### DIFF
--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -7,6 +7,7 @@ master:
     - >-
       GH-957 Fixed a bug where expiry was wrong for cookies passed to response
       callback when cookies had `Max-Age` field
+    - GH-973 Fixed request headers updated by AWS auth in manifest
   chores:
     - GH-953 Updated dependencies
 

--- a/lib/authorizer/aws4.js
+++ b/lib/authorizer/aws4.js
@@ -90,6 +90,10 @@ module.exports = {
         },
         updates: [
             {
+                property: 'Host',
+                type: 'header'
+            },
+            {
                 property: 'Authorization',
                 type: 'header'
             },
@@ -102,15 +106,7 @@ module.exports = {
                 type: 'header'
             },
             {
-                property: 'Content-Length',
-                type: 'header'
-            },
-            {
-                property: 'Content-Type',
-                type: 'header'
-            },
-            {
-                property: 'Host',
+                property: 'X-Amz-Content-Sha256',
                 type: 'header'
             }
         ]

--- a/test/unit/auth-handlers.test.js
+++ b/test/unit/auth-handlers.test.js
@@ -935,6 +935,40 @@ describe('Auth Handler:', function () {
             expect(headers).to.include.keys(['x-amz-date', 'x-amz-security-token']);
         });
 
+        it.only('should list all modified headers in manifest', function (done) {
+            var requestJSON = _.assign({}, rawRequests.awsv4, {
+                    header: [],
+                    body: {
+                        mode: 'raw',
+                        raw: 'Hello'
+                    }
+                }),
+                request = new Request(requestJSON),
+                auth = request.auth,
+                authInterface = createAuthInterface(auth),
+                handler = AuthLoader.getHandler(auth.type),
+                headersInManifest = _.transform(handler.manifest.updates, function (acc, entity) {
+                    if (entity.type === 'header') {
+                        acc.push(entity.property.toLowerCase());
+                    }
+                }, []),
+                headers;
+
+            handler.sign(authInterface, request, function () {
+                headers = request.getHeaders({
+                    ignoreCase: true
+                });
+
+                // ensure that all the headers added are listed in manifest
+                expect(_.difference(Object.keys(headers), headersInManifest)).to.be.empty;
+
+                // ensure that there are no extra headers in manifest that
+                // are not added by the auth
+                expect(headers).to.include.keys(headersInManifest);
+                done();
+            });
+        });
+
         it('should use sensible defaults where applicable', function () {
             var headers,
                 rawReq = _.defaults(rawRequests.awsv4, {

--- a/test/unit/auth-handlers.test.js
+++ b/test/unit/auth-handlers.test.js
@@ -935,7 +935,7 @@ describe('Auth Handler:', function () {
             expect(headers).to.include.keys(['x-amz-date', 'x-amz-security-token']);
         });
 
-        it.only('should list all modified headers in manifest', function (done) {
+        it('should list all modified headers in manifest', function (done) {
             var requestJSON = _.assign({}, rawRequests.awsv4, {
                     header: [],
                     body: {


### PR DESCRIPTION
Changed updated headers in AWS auth manifest.

**Old headers:**
- Host
- Authorization
- X-Amz-Date
- X-Amz-Security-Token
- Content-Length
- Content-Type

**New headers:**
- Host
- Authorization
- X-Amz-Date
- X-Amz-Security-Token
- X-Amz-Content-Sha256