### PR TITLE
Handle disabled formdata and urlencoded body

### DIFF
--- a/lib/requester/core.js
+++ b/lib/requester/core.js
@@ -440,7 +440,9 @@ module.exports = {
             return;
         }
 
-        var requestBody = request.body,
+        var i,
+            property,
+            requestBody = request.body,
             requestBodyType = requestBody.mode,
             requestMethod = (typeof request.method === STRING) ? request.method.toLowerCase() : undefined,
             bodyIsEmpty = requestBody.isEmpty(),
@@ -454,6 +456,26 @@ module.exports = {
         // early bailout for empty or disabled body (this area has some legacy shenanigans)
         if (bodyIsEmpty || bodyIsDisabled) {
             return;
+        }
+
+        // body is empty if all the params in urlencoded and formdata body are disabled
+        // @todo update Collection SDK isEmpty method to account for this
+        if (sdk.PropertyList.isPropertyList(bodyContent)) {
+            bodyIsEmpty = true;
+
+            for (i = bodyContent.members.length - 1; i >= 0; i--) {
+                property = bodyContent.members[i];
+                // bail out if a single enabled property is present
+                if (property && !property.disabled) {
+                    bodyIsEmpty = false;
+                    break;
+                }
+            }
+
+            // bail out if body is empty
+            if (bodyIsEmpty) {
+                return;
+            }
         }
 
         // bail out if request method doesn't support body and pruneBody is true.

--- a/test/integration/request-body/form-data.test.js
+++ b/test/integration/request-body/form-data.test.js
@@ -261,4 +261,49 @@ describe('Request Body Mode: formdata', function () {
             expect(responseBody).to.have.deep.property('files', {'': 'data:application/octet-stream;base64,'});
         });
     });
+
+    describe('with disabled params', function () {
+        before(function (done) {
+            this.run({
+                collection: {
+                    item: [{
+                        request: {
+                            url: HOST,
+                            method: 'POST',
+                            body: {
+                                mode: 'formdata',
+                                formdata: [
+                                    {key: 'foo', value: 'bar', disabled: true},
+                                    {key: 'bar', value: 'foo', disabled: true}
+                                ]
+                            }
+                        }
+                    }]
+                }
+            }, function (err, results) {
+                testrun = results;
+                done(err);
+            });
+        });
+
+        it('should have completed the run', function () {
+            expect(testrun).to.be.ok;
+            expect(testrun.done.getCall(0).args[0]).to.be.null;
+            expect(testrun).to.nested.include({
+                'done.calledOnce': true,
+                'start.calledOnce': true,
+                'request.calledOnce': true,
+                'response.calledOnce': true
+            });
+        });
+
+        it('should not post form-data', function () {
+            var response = testrun.response.getCall(0).args[2],
+                responseBody = response.json();
+
+            expect(response).to.have.property('code', 200);
+            expect(responseBody).to.have.deep.property('form', {});
+            expect(responseBody.headers).to.not.have.property('content-type');
+        });
+    });
 });


### PR DESCRIPTION
Fixes a bug where `content-type` header was sent even if all the params are disabled.