### PR TITLE
Handle disabled content-type for raw and graphql body

### DIFF
--- a/lib/requester/core-body-builder.js
+++ b/lib/requester/core-body-builder.js
@@ -42,9 +42,48 @@ var _ = require('lodash'),
     STRING = 'string',
     E = '',
 
+    oneNormalizedHeader,
+
     // the following two are reducer functions. we keep it defined here to avoid redefinition upon each parse
     urlEncodedBodyReducer,
     formDataBodyReducer;
+
+/**
+ * Find the enabled header with the given name.
+ *
+ * @todo Add this helper in Collection SDK.
+ *
+ * @private
+ * @param {HeaderList} headers
+ * @param {String} name
+ * @returns {Header|undefined}
+ */
+oneNormalizedHeader = function oneNormalizedHeader (headers, name) {
+    var i,
+        header;
+
+    // get all headers with `name`
+    headers = headers.reference[name.toLowerCase()];
+
+    if (Array.isArray(headers)) {
+        // traverse the headers list in reverse direction in order to find the last enabled
+        for (i = headers.length - 1; i >= 0; i--) {
+            header = headers[i];
+
+            if (header && !header.disabled) {
+                return header;
+            }
+        }
+
+        // bail out if no enabled header was found
+        return;
+    }
+
+    // return the single enabled header
+    if (headers && !headers.disabled) {
+        return headers;
+    }
+};
 
 /**
  * Reduces postman SDK url encoded form definition (flattened to array) into Node compatible body options
@@ -151,7 +190,7 @@ module.exports = {
         var contentLanguage = _.get(request, 'body.options.raw.language', 'text');
 
         // Add `Content-Type` header from body options if not set already
-        if (request && !request.headers.has(CONTENT_TYPE_HEADER_KEY)) {
+        if (request && !oneNormalizedHeader(request.headers, CONTENT_TYPE_HEADER_KEY)) {
             request.headers.add({
                 key: CONTENT_TYPE_HEADER_KEY,
                 value: CONTENT_TYPE_LANGUAGE[contentLanguage] || CONTENT_TYPE_LANGUAGE.text,
@@ -211,7 +250,7 @@ module.exports = {
         var body;
 
         // implicitly add `Content-Type` header if not set already
-        if (request && !request.headers.has(CONTENT_TYPE_HEADER_KEY)) {
+        if (request && !oneNormalizedHeader(request.headers, CONTENT_TYPE_HEADER_KEY)) {
             request.headers.add({
                 key: CONTENT_TYPE_HEADER_KEY,
                 value: CONTENT_TYPE_LANGUAGE.json,

--- a/test/integration/request-body/graphql.test.js
+++ b/test/integration/request-body/graphql.test.js
@@ -335,4 +335,103 @@ describe('Request Body Mode: graphql', function () {
             });
         });
     });
+
+    describe('custom content-type', function () {
+        before(function (done) {
+            this.run({
+                collection: {
+                    item: [{
+                        request: {
+                            url: graphqlServer.url,
+                            header: [{
+                                key: 'content-type',
+                                value: 'something/else'
+                            }],
+                            method: 'POST',
+                            body: {
+                                mode: 'graphql',
+                                graphql: {
+                                    query: '{ hello }'
+                                }
+                            }
+                        }
+                    }]
+                }
+            }, function (err, results) {
+                testrun = results;
+                done(err);
+            });
+        });
+
+        it('should have completed the run', function () {
+            expect(testrun).to.be.ok;
+            expect(testrun.done.getCall(0).args[0]).to.be.null;
+            expect(testrun).to.nested.include({
+                'done.calledOnce': true,
+                'start.calledOnce': true,
+                'request.calledOnce': true,
+                'response.calledOnce': true
+            });
+        });
+
+        it('should honor custom content-type header', function () {
+            var response = testrun.response.getCall(0).args[2],
+                responseBody = JSON.parse(response.stream.toString());
+
+            expect(response).to.have.property('code', 200);
+
+            expect(responseBody.request).to.have.property('headers');
+            expect(responseBody.request.headers).to.have.property('content-type', 'something/else');
+        });
+    });
+
+    describe('disabled content-type', function () {
+        before(function (done) {
+            this.run({
+                collection: {
+                    item: [{
+                        request: {
+                            url: graphqlServer.url,
+                            header: [{
+                                key: 'content-type',
+                                value: 'something/else',
+                                disabled: true
+                            }],
+                            method: 'POST',
+                            body: {
+                                mode: 'graphql',
+                                graphql: {
+                                    query: '{ hello }'
+                                }
+                            }
+                        }
+                    }]
+                }
+            }, function (err, results) {
+                testrun = results;
+                done(err);
+            });
+        });
+
+        it('should have completed the run', function () {
+            expect(testrun).to.be.ok;
+            expect(testrun.done.getCall(0).args[0]).to.be.null;
+            expect(testrun).to.nested.include({
+                'done.calledOnce': true,
+                'start.calledOnce': true,
+                'request.calledOnce': true,
+                'response.calledOnce': true
+            });
+        });
+
+        it('should handle disabled content-type header', function () {
+            var response = testrun.response.getCall(0).args[2],
+                responseBody = JSON.parse(response.stream.toString());
+
+            expect(response).to.have.property('code', 200);
+
+            expect(responseBody.request).to.have.property('headers');
+            expect(responseBody.request.headers).to.have.property('content-type', 'application/json');
+        });
+    });
 });

--- a/test/integration/request-body/raw.test.js
+++ b/test/integration/request-body/raw.test.js
@@ -42,6 +42,7 @@ describe('Request Body Mode: raw', function () {
 
             expect(response).to.have.property('code', 200);
             expect(responseBody).to.have.property('data', 'POSTMAN');
+            expect(responseBody.headers).to.have.property('content-type', 'text/plain');
         });
     });
 
@@ -52,6 +53,10 @@ describe('Request Body Mode: raw', function () {
                     item: [{
                         request: {
                             url: HOST,
+                            header: [{
+                                key: 'content-type',
+                                value: 'text/plain'
+                            }],
                             method: 'POST',
                             body: {
                                 mode: 'raw',
@@ -87,6 +92,7 @@ describe('Request Body Mode: raw', function () {
             expect(responseBody).to.have.property('data', JSON.stringify({
                 name: 'POSTMAN'
             }));
+            expect(responseBody.headers).to.have.property('content-type', 'text/plain');
         });
     });
 
@@ -211,6 +217,107 @@ describe('Request Body Mode: raw', function () {
 
             expect(response).to.have.property('code', 200);
             expect(responseBody).to.have.property('data').that.is.empty;
+        });
+    });
+
+    describe('with custom content-type', function () {
+        before(function (done) {
+            this.run({
+                collection: {
+                    item: [{
+                        request: {
+                            url: HOST,
+                            header: [{
+                                key: 'content-type',
+                                value: 'application/xml'
+                            }, {
+                                key: 'content-type',
+                                value: 'application/json',
+                                disabled: true
+                            }],
+                            method: 'POST',
+                            body: {
+                                mode: 'raw',
+                                raw: 'POSTMAN'
+                            }
+                        }
+                    }]
+                }
+            }, function (err, results) {
+                testrun = results;
+                done(err);
+            });
+        });
+
+        it('should have completed the run', function () {
+            expect(testrun).to.be.ok;
+            expect(testrun.done.getCall(0).args[0]).to.be.null;
+            expect(testrun).to.nested.include({
+                'done.calledOnce': true,
+                'start.calledOnce': true,
+                'request.calledOnce': true,
+                'response.calledOnce': true
+            });
+        });
+
+        it('should honor custom content-type header', function () {
+            var response = testrun.response.getCall(0).args[2],
+                responseBody = JSON.parse(response.stream.toString());
+
+            expect(response).to.have.property('code', 200);
+            expect(responseBody).to.have.property('data', 'POSTMAN');
+            expect(responseBody.headers).to.have.property('content-type', 'application/xml');
+        });
+    });
+
+    describe('with disabled content-type', function () {
+        before(function (done) {
+            this.run({
+                collection: {
+                    item: [{
+                        request: {
+                            url: HOST,
+                            header: [{
+                                key: 'content-type',
+                                value: 'application/xml',
+                                disabled: true
+                            }, {
+                                key: 'content-type',
+                                value: 'application/json',
+                                disabled: true
+                            }],
+                            method: 'POST',
+                            body: {
+                                mode: 'raw',
+                                raw: 'POSTMAN'
+                            }
+                        }
+                    }]
+                }
+            }, function (err, results) {
+                testrun = results;
+                done(err);
+            });
+        });
+
+        it('should have completed the run', function () {
+            expect(testrun).to.be.ok;
+            expect(testrun.done.getCall(0).args[0]).to.be.null;
+            expect(testrun).to.nested.include({
+                'done.calledOnce': true,
+                'start.calledOnce': true,
+                'request.calledOnce': true,
+                'response.calledOnce': true
+            });
+        });
+
+        it('should handle disabled content-type header', function () {
+            var response = testrun.response.getCall(0).args[2],
+                responseBody = JSON.parse(response.stream.toString());
+
+            expect(response).to.have.property('code', 200);
+            expect(responseBody).to.have.property('data', 'POSTMAN');
+            expect(responseBody.headers).to.have.property('content-type', 'text/plain');
         });
     });
 });


### PR DESCRIPTION
Fixes a bug where the system added `content-type` header was not added when the given header is disabled.