### PR TITLE
Added method Requester~dryRun

### DIFF
--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -1,3 +1,9 @@
+master:
+  new features:
+    - GH-985 Added method `Requester~dryRun` to dry run the given request instance
+  chores:
+    - Updated dependencies
+
 7.23.0:
   date: 2020-03-02
   new features:

--- a/lib/requester/core.js
+++ b/lib/requester/core.js
@@ -472,9 +472,6 @@ module.exports = {
             (!header || header.system) && (options.setHost = false);
         }
 
-        // Finally, get headers object
-        options.headers = request.getHeaders({enabled: true, sanitizeKeys: true});
-
         // Set `allowContentTypeOverride` if content-type header is disabled,
         // this allows overriding (if invalid) the content-type for form-data
         // and urlencoded request body.
@@ -488,6 +485,9 @@ module.exports = {
 
             header = oneNormalizedHeader(request.headers, headerKey);
 
+            // content-type added by body helper
+            header && header.system && (header.disabled = true);
+
             // blacklist only if it's missing or part of system added headers
             (!header || header.system) && options.blacklistHeaders.push(headerKey);
 
@@ -500,6 +500,9 @@ module.exports = {
                 (!header || header.system) && options.blacklistHeaders.push('transfer-encoding');
             }
         });
+
+        // Finally, get headers object
+        options.headers = request.getHeaders({enabled: true, sanitizeKeys: true});
 
         // override URL parser to WhatWG URL parser
         if (useWhatWGUrlParser) {

--- a/lib/requester/core.js
+++ b/lib/requester/core.js
@@ -457,16 +457,23 @@ module.exports = {
         // Add additional system headers to the request instance
         addSystemHeaders(request, options, disabledSystemHeaders);
 
-        // Finally, get headers object
-        options.headers = request.getHeaders({enabled: true, sanitizeKeys: true});
-
         // Don't add `Host` header if disabled using disabledSystemHeaders
         // @note This can't be part of `blacklistHeaders` option as `setHost` is
         // a Node.js http.request option to specifies whether or not to
         // automatically add the Host header or not.
-        if (disabledSystemHeaders.host && !oneNormalizedHeader(request.headers, 'host')) {
-            options.setHost = false;
+        if (disabledSystemHeaders.host) {
+            header = oneNormalizedHeader(request.headers, 'host');
+
+            // only possible with AWS auth
+            header && header.system && (header.disabled = true);
+
+            // set `setHost` to false if there's no host header defined by the user
+            // or, the present host is added by the system.
+            (!header || header.system) && (options.setHost = false);
         }
+
+        // Finally, get headers object
+        options.headers = request.getHeaders({enabled: true, sanitizeKeys: true});
 
         // Set `allowContentTypeOverride` if content-type header is disabled,
         // this allows overriding (if invalid) the content-type for form-data

--- a/lib/requester/dry-run.js
+++ b/lib/requester/dry-run.js
@@ -1,4 +1,8 @@
 /* istanbul ignore file */
+// @todo
+// 1. Return with annotations like (overridden headers, auth headers etc.)
+// 2. Utilize requester (core.js) methods for dryRun
+// 3. Add tests
 const _ = require('lodash'),
     async = require('async'),
     mime = require('mime-types'),
@@ -7,10 +11,11 @@ const _ = require('lodash'),
     authHandlers = require('../authorizer').AuthLoader.handlers,
     version = require('../../package.json').version,
 
-    CALCULATED_AT_RUNTIME = '<calculated at runtime>',
+    CALCULATED_AT_RUNTIME = '<calculated when request is sent>',
     COOKIE = 'Cookie',
     FUNCTION = 'function',
     CONTENT_TYPE = 'Content-Type',
+    DEFAULT_MIME_TYPE = 'application/octet-stream',
     CONTENT_TYPE_URLENCODED = 'application/x-www-form-urlencoded',
     CONTENT_TYPE_FORMDATA = 'multipart/form-data; boundary=' + CALCULATED_AT_RUNTIME,
 
@@ -45,9 +50,9 @@ function bodyIsEmpty (body) {
         return true;
     }
 
-    var mode = body.mode,
-        i,
-        param;
+    var i,
+        param,
+        mode = body.mode;
 
     if (!(mode === BODY_MODE.formdata || mode === BODY_MODE.urlencoded)) {
         return false;
@@ -173,7 +178,8 @@ function setContentType (request, callback) {
             addSystemHeader(headers, CONTENT_TYPE, CONTENT_TYPE_LANGUAGE.json);
             break;
         case BODY_MODE.file:
-            addSystemHeader(headers, CONTENT_TYPE, mime.lookup(request.body.file && request.body.file.src));
+            addSystemHeader(headers, CONTENT_TYPE,
+                mime.lookup(request.body.file && request.body.file.src) || DEFAULT_MIME_TYPE);
             break;
         default: break;
     }
@@ -235,8 +241,8 @@ function dryRun (request, options, done) {
     var cookieJar = options.cookieJar,
         implicitCacheControl = options.implicitCacheControl,
         implicitTraceHeader = options.implicitTraceHeader,
-        disabledSystemHeaders = _.get(options, 'protocolProfileBehavior.disabledSystemHeaders', {}),
-        disableCookies = _.get(options, 'protocolProfileBehavior.disableCookies');
+        disabledSystemHeaders = _.get(options.protocolProfileBehavior, 'disabledSystemHeaders') || {},
+        disableCookies = _.get(options.protocolProfileBehavior, 'disableCookies');
 
     async.waterfall([
         function setAuthorizationHeaders (next) {
@@ -244,6 +250,30 @@ function dryRun (request, options, done) {
         },
         function setContentTypeHeader (request, next) {
             setContentType(request, next);
+        },
+        function setContentLength (request, next) {
+            var headers = request.headers,
+                header = headers.one('content-length');
+
+            // bail out if header added by body helper
+            if (header && header.system) {
+                return next(null, request);
+            }
+
+            switch (String(request.method).toUpperCase()) {
+                case 'GET':
+                case 'HEAD':
+                case 'TRACE':
+                case 'DELETE':
+                case 'CONNECT':
+                case 'OPTIONS':
+                    break;
+                default:
+                    addSystemHeader(headers, 'Content-Length', '0');
+                    break;
+            }
+
+            next(null, request);
         },
         function setCookieHeader (request, next) {
             if (disableCookies || !cookieJar) {
@@ -255,12 +285,14 @@ function dryRun (request, options, done) {
         function setStaticHeaders (request, next) {
             var headers = request.headers;
 
+            // remove header added by auth helpers
+            headers.remove(function (header) {
+                return header.system && header.key.toLowerCase() === 'host';
+            });
+
             addSystemHeader(headers, 'User-Agent', 'PostmanRuntime/' + version);
             addSystemHeader(headers, 'Accept', '*/*');
             addSystemHeader(headers, 'Accept-Encoding', 'gzip, deflate, br');
-            request.headers.remove(function (header) {
-                return header.system && header.key.toLowerCase() === 'host';
-            });
             addSystemHeader(headers, 'Host', CALCULATED_AT_RUNTIME);
             addSystemHeader(headers, 'Connection', 'keep-alive');
             implicitCacheControl && addSystemHeader(headers, 'Cache-Control', 'no-cache');

--- a/lib/requester/dry-run.js
+++ b/lib/requester/dry-run.js
@@ -1,0 +1,293 @@
+/* istanbul ignore file */
+const _ = require('lodash'),
+    async = require('async'),
+    mime = require('mime-types'),
+    Request = require('postman-collection').Request,
+    authorizeRequest = require('../authorizer').authorizeRequest,
+    authHandlers = require('../authorizer').AuthLoader.handlers,
+    version = require('../../package.json').version,
+
+    CALCULATED_AT_RUNTIME = '<calculated at runtime>',
+    COOKIE = 'Cookie',
+    FUNCTION = 'function',
+    CONTENT_TYPE = 'Content-Type',
+    CONTENT_TYPE_URLENCODED = 'application/x-www-form-urlencoded',
+    CONTENT_TYPE_FORMDATA = 'multipart/form-data; boundary=' + CALCULATED_AT_RUNTIME,
+
+    CONTENT_TYPE_LANGUAGE = {
+        'html': 'text/html',
+        'text': 'text/plain',
+        'json': 'application/json',
+        'javascript': 'application/javascript',
+        'xml': 'application/xml'
+    },
+
+    BODY_MODE = {
+        raw: 'raw',
+        file: 'file',
+        graphql: 'graphql',
+        formdata: 'formdata',
+        urlencoded: 'urlencoded'
+    };
+
+/**
+ * Check if request body is empty and also handles disabled params for urlencoded
+ * and formdata bodies.
+ *
+ * @todo Update Collection SDK isEmpty method to account for this.
+ *
+ * @private
+ * @param {RequestBody} body
+ * @returns {Boolean}
+ */
+function bodyIsEmpty (body) {
+    if (!body || body.disabled || body.isEmpty()) {
+        return true;
+    }
+
+    var mode = body.mode,
+        i,
+        param;
+
+    if (!(mode === BODY_MODE.formdata || mode === BODY_MODE.urlencoded)) {
+        return false;
+    }
+
+    for (i = body[mode].members.length - 1; i >= 0; i--) {
+        param = body[mode].members[i];
+        // bail out if a single enabled param is present
+        if (param && !param.disabled) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+/**
+ * Add new System header.
+ *
+ * @param {object} headers
+ * @param {String} key
+ * @param {String} value
+ */
+function addSystemHeader (headers, key, value) {
+    headers.add({
+        key: key,
+        value: value,
+        system: true
+    });
+}
+
+/**
+ * Authorize the given request.
+ *
+ * @private
+ * @param {Request} request
+ * @param {Function} callback
+ */
+function setAuthorization (request, callback) {
+    authorizeRequest(request, function (err, clonedRequest) {
+        // @note authorizeRequest returns a cloned request.
+        !clonedRequest && (clonedRequest = new Request(request.toJSON()));
+
+        if (err) {
+            return callback(null, clonedRequest);
+        }
+
+        var auth = request.auth,
+            authType = auth && auth.type,
+            manifest = _.get(authHandlers, [authType, 'manifest']),
+            headers = _.get(clonedRequest, 'headers.reference') || {},
+            queryParams = _.get(clonedRequest, 'url.query.reference') || {},
+            bodyParams = _.get(clonedRequest, 'body.urlencoded.reference') || {},
+            propertyList,
+            propertyKey,
+            property;
+
+        if (authType === 'apikey' && (auth = auth.apikey)) {
+            propertyKey = String(auth.get('key')).toLowerCase();
+            propertyList = auth.get('in') === 'query' ? queryParams : headers;
+
+            if ((property = propertyList[propertyKey])) {
+                Array.isArray(property) && (property = property[property.length - 1]);
+                property.auth = true;
+            }
+
+            return callback(null, clonedRequest);
+        }
+
+        if (!(manifest && manifest.updates)) {
+            return callback(null, clonedRequest);
+        }
+
+        manifest.updates.forEach(function (update) {
+            propertyKey = update.property.toLowerCase();
+
+            switch (update.type) {
+                case 'header': propertyList = headers; break;
+                case 'url.param': propertyList = queryParams; break;
+                case 'body.urlencoded': propertyList = bodyParams; break;
+                default: return;
+            }
+
+            if ((property = propertyList[propertyKey])) {
+                Array.isArray(property) && (property = property[property.length - 1]);
+                property.auth = true;
+            }
+        });
+
+        callback(null, clonedRequest);
+    });
+}
+
+/**
+ * Adds Content-Type header based on selected request body.
+ *
+ * @private
+ * @param {Request} request
+ * @param {Function} callback
+ */
+function setContentType (request, callback) {
+    // bail out if body is empty
+    if (bodyIsEmpty(request.body)) {
+        return callback(null, request);
+    }
+
+    var headers = request.headers,
+        contentLanguage;
+
+    switch (request.body.mode) {
+        case BODY_MODE.raw:
+            contentLanguage = _.get(request, 'body.options.raw.language', 'text');
+            addSystemHeader(headers, CONTENT_TYPE, CONTENT_TYPE_LANGUAGE[contentLanguage] ||
+                CONTENT_TYPE_LANGUAGE.text);
+            break;
+        case BODY_MODE.urlencoded:
+            addSystemHeader(headers, CONTENT_TYPE, CONTENT_TYPE_URLENCODED);
+            break;
+        case BODY_MODE.formdata:
+            addSystemHeader(headers, CONTENT_TYPE, CONTENT_TYPE_FORMDATA);
+            break;
+        case BODY_MODE.graphql:
+            addSystemHeader(headers, CONTENT_TYPE, CONTENT_TYPE_LANGUAGE.json);
+            break;
+        case BODY_MODE.file:
+            addSystemHeader(headers, CONTENT_TYPE, mime.lookup(request.body.file && request.body.file.src));
+            break;
+        default: break;
+    }
+
+    addSystemHeader(headers, 'Content-Length', CALCULATED_AT_RUNTIME);
+
+    callback(null, request);
+}
+
+/**
+ * Adds Cookie header for the given request url.
+ *
+ * @private
+ * @param {Request} request
+ * @param {Object} cookieJar
+ * @param {Function} callback
+ */
+function setCookie (request, cookieJar, callback) {
+    // bail out if not a valid instance of CookieJar
+    if (!(cookieJar && cookieJar.getCookieString)) {
+        return callback(null, request);
+    }
+
+    cookieJar.getCookieString(request.url.toString(true), function (err, cookies) {
+        if (err) {
+            return callback(null, request);
+        }
+
+        if (cookies && cookies.length) {
+            addSystemHeader(request.headers, COOKIE, cookies);
+        }
+
+        callback(null, request);
+    });
+}
+
+/**
+ * A helper method to dry run the given request instance.
+ * It returns the cloned request instance with the system added properties.
+ *
+ * @param {Request} request
+ * @param {Object} options
+ * @param {Object} options.cookieJar
+ * @param {Object} options.protocolProfileBehavior
+ * @param {Function} done
+ */
+function dryRun (request, options, done) {
+    if (!done && typeof options === FUNCTION) {
+        done = options;
+        options = {};
+    }
+
+    if (!Request.isRequest(request)) {
+        return done(new Error('Invalid Request instance'));
+    }
+
+    !options && (options = {});
+
+    var cookieJar = options.cookieJar,
+        implicitCacheControl = options.implicitCacheControl,
+        implicitTraceHeader = options.implicitTraceHeader,
+        disabledSystemHeaders = _.get(options, 'protocolProfileBehavior.disabledSystemHeaders', {}),
+        disableCookies = _.get(options, 'protocolProfileBehavior.disableCookies');
+
+    async.waterfall([
+        function setAuthorizationHeaders (next) {
+            setAuthorization(request, next);
+        },
+        function setContentTypeHeader (request, next) {
+            setContentType(request, next);
+        },
+        function setCookieHeader (request, next) {
+            if (disableCookies || !cookieJar) {
+                return next(null, request);
+            }
+
+            setCookie(request, cookieJar, next);
+        },
+        function setStaticHeaders (request, next) {
+            var headers = request.headers;
+
+            addSystemHeader(headers, 'User-Agent', 'PostmanRuntime/' + version);
+            addSystemHeader(headers, 'Accept', '*/*');
+            addSystemHeader(headers, 'Accept-Encoding', 'gzip, deflate, br');
+            request.headers.remove(function (header) {
+                return header.system && header.key.toLowerCase() === 'host';
+            });
+            addSystemHeader(headers, 'Host', CALCULATED_AT_RUNTIME);
+            addSystemHeader(headers, 'Connection', 'keep-alive');
+            implicitCacheControl && addSystemHeader(headers, 'Cache-Control', 'no-cache');
+            implicitTraceHeader && addSystemHeader(headers, 'Postman-Token', CALCULATED_AT_RUNTIME);
+
+            next(null, request);
+        },
+        function disableSystemHeaders (request, next) {
+            var headersReference = request.headers.reference,
+                header;
+
+            _.forEach(disabledSystemHeaders, function (disabled, headerKey) {
+                if (!disabled) { return; }
+
+                if ((header = headersReference[headerKey.toLowerCase()])) {
+                    Array.isArray(header) && (header = header[header.length - 1]);
+                    header.system && (header.disabled = true);
+                }
+            });
+
+            next(null, request);
+        }
+    ], function (err, request) {
+        if (err) { return done(err); }
+
+        done(null, request);
+    });
+}
+
+module.exports = dryRun;

--- a/lib/requester/requester.js
+++ b/lib/requester/requester.js
@@ -5,6 +5,7 @@ var _ = require('lodash'),
     now = require('performance-now'),
     sdk = require('postman-collection'),
     requests = require('./request-wrapper'),
+    dryRun = require('./dry-run'),
 
     RESPONSE_START_EVENT_BASE = 'response.start.',
     RESPONSE_END_EVENT_BASE = 'response.end.',
@@ -502,7 +503,21 @@ _.assign(Requester, /** @lends Requester */ {
      */
     create: function (trace, options, callback) {
         return callback(null, new Requester(trace, options));
-    }
+    },
+
+    /**
+     * A helper method to dry run the given request instance.
+     * It returns the cloned request instance with the system added properties.
+     *
+     * @param {Request} request
+     * @param {Object} options
+     * @param {Object} options.cookieJar
+     * @param {Object} options.protocolProfileBehavior
+     * @param {Object} options.implicitCacheControl
+     * @param {Object} options.implicitTraceHeader
+     * @param {Function} done
+     */
+    dryRun
 });
 
 module.exports.Requester = Requester;

--- a/lib/requester/requester.js
+++ b/lib/requester/requester.js
@@ -28,19 +28,6 @@ var _ = require('lodash'),
     },
 
     /**
-     * Connection Header, added based on agentOptions.keepAlive
-     *
-     * @private
-     * @const
-     * @type {Object}
-     */
-    CONNECTION_HEADER = {
-        key: 'Connection',
-        keepAlive: 'keep-alive',
-        close: 'close'
-    },
-
-    /**
      * Creates a sdk compatible cookie from a tough-cookie compatible cookie.
      *
      * @param cookie
@@ -242,10 +229,10 @@ _.assign(Requester.prototype, /** @lends Requester.prototype */ {
              */
             addMissingRequestHeaders = function (headers) {
                 var header,
-                    keepAlive,
                     lowerCasedKey;
 
                 _.forOwn(headers, function (value, key) {
+                    // @todo handle disabled headers
                     header = request.headers.one(key);
                     lowerCasedKey = _.lowerCase(key);
 
@@ -284,18 +271,6 @@ _.assign(Requester.prototype, /** @lends Requester.prototype */ {
                         system: true
                     });
                 });
-
-                keepAlive = _.get(requestOptions, 'agentOptions.keepAlive');
-
-                // @note Connection header is added by Node based on the agent's
-                // keepAlive option. Don't add if custom is defined already.
-                if (!request.headers.has(CONNECTION_HEADER.key)) {
-                    request.headers.add({
-                        key: CONNECTION_HEADER.key,
-                        value: keepAlive ? CONNECTION_HEADER.keepAlive : CONNECTION_HEADER.close,
-                        system: true
-                    });
-                }
             },
 
             /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1737,13 +1737,13 @@
       "integrity": "sha1-qVPKZwB4Zp3eFCzomUAbnW6F07Q="
     },
     "http-signature": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.3.2.tgz",
+      "integrity": "sha512-sjgXeFLIVJ54n1+HWOvazGkIQpaawFGIQ1PYPORaFNWpPHJ28ZuDgWljvMIhAIcOelTtrh9e5wVB3IorxjiZDA==",
       "requires": {
         "assert-plus": "^1.0.0",
         "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
+        "sshpk": "^1.14.1"
       }
     },
     "httpntlm": {
@@ -3186,9 +3186,9 @@
       "dev": true
     },
     "postman-request": {
-      "version": "2.88.1-postman.21",
-      "resolved": "https://registry.npmjs.org/postman-request/-/postman-request-2.88.1-postman.21.tgz",
-      "integrity": "sha512-2BFjvTLw4q0pl1q47F1O/IVA+WTTPOVBO7YAlKWB+bu6rQFswl/k5eNBi5NQgTk09jWX4TsLQWXsagjb0qjGCw==",
+      "version": "2.88.1-postman.22",
+      "resolved": "https://registry.npmjs.org/postman-request/-/postman-request-2.88.1-postman.22.tgz",
+      "integrity": "sha512-JipoPMDF5MKhTW4xg9AQfu7Pv8EMEbuXxJ8DB7rPFdWwc5dCuhGhhjJUz6KByX0B/H2x73/ZEVgOUPlu5bfJ7w==",
       "requires": {
         "@postman/form-data": "~3.1.0",
         "@postman/tunnel-agent": "^0.6.3",
@@ -3200,7 +3200,7 @@
         "extend": "~3.0.2",
         "forever-agent": "~0.6.1",
         "har-validator": "~5.1.3",
-        "http-signature": "~1.2.0",
+        "http-signature": "~1.3.1",
         "is-typedarray": "~1.0.0",
         "isstream": "~0.1.2",
         "json-stringify-safe": "~5.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "postman-runtime",
-  "version": "7.23.0",
+  "version": "7.24.0-beta.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postman-runtime",
-  "version": "7.23.0",
+  "version": "7.24.0-beta.4",
   "description": "Underlying library of executing Postman Collections (used by Newman)",
   "main": "index.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "node-oauth1": "1.2.4",
     "performance-now": "2.1.0",
     "postman-collection": "3.6.0",
-    "postman-request": "2.88.1-postman.21",
+    "postman-request": "2.88.1-postman.22",
     "postman-sandbox": "3.5.3",
     "postman-url-encoder": "2.1.0",
     "resolve-from": "5.0.0",


### PR DESCRIPTION
`dryRun` method is used to live preview request headers, query params, etc.