### PR TITLE
Fixed OAuth1 signature calculation for request with disabled urlencoded params

### DIFF
--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -1,3 +1,9 @@
+master:
+  fixed bugs:
+    - >-
+      GH-994 Fixed a bug where OAuth1 was calculating wrong signature for
+      request with urlencoded body having disabled params
+
 7.24.0:
   date: 2020-03-15
   new features:

--- a/lib/authorizer/oauth1.js
+++ b/lib/authorizer/oauth1.js
@@ -236,6 +236,7 @@ module.exports = {
                 'disableHeaderEncoding'
             ]),
             url = urlEncoder.toNodeUrl(request.url),
+            urlencodedBody = request.body,
             signatureParams,
             header;
 
@@ -243,10 +244,16 @@ module.exports = {
             return done(); // Nothing to do if required parameters are not present.
         }
 
+        // before this: urlencodedBody = request.body
+        // after this: urlencodedBody = request.body.urlencoded or undefined
+        urlencodedBody = (urlencodedBody &&
+            urlencodedBody.mode === RequestBody.MODES.urlencoded
+        ) ? urlencodedBody.urlencoded : undefined;
+
         // Remove existing headers and params (if any)
         request.removeHeader('Authorization');
         request.removeQueryParams(_.values(OAUTH1_PARAMS));
-        request.body && request.body.urlencoded && request.body.urlencoded.remove(function (param) {
+        urlencodedBody && urlencodedBody.remove(function (param) {
             return _.includes(_.values(OAUTH1_PARAMS), param.key);
         });
 
@@ -270,26 +277,16 @@ module.exports = {
         signatureParams = this.computeHeader({
             url: getOAuth1BaseUrl(url),
             method: request.method,
-            queryParams: request.url.query && request.url.query.count() ? request.url.query.map(function (qParam) {
-                return {
-                    key: qParam.key,
-                    value: qParam.value
-                };
-            }) : [],
+            queryParams: request.url.query.filter(function (param) {
+                return !param.disabled;
+            }),
 
-            // todo: WTF! figure out a better way
             // Body params only need to be included if they are URL encoded.
             // http://oauth.net/core/1.0a/#anchor13
-            bodyParams: (request.body &&
-                request.body.mode === RequestBody.MODES.urlencoded &&
-                request.body.urlencoded &&
-                request.body.urlencoded.count &&
-                request.body.urlencoded.count()) ? request.body.urlencoded.map(function (formParam) {
-                    return {
-                        key: formParam.key,
-                        value: formParam.value
-                    };
-                }) : [],
+            bodyParams: urlencodedBody ? urlencodedBody.filter(function (param) {
+                return !param.disabled;
+            }) : [],
+
             helperParams: params
         });
 
@@ -309,10 +306,9 @@ module.exports = {
                 system: true
             });
         }
-        else if ((/PUT|POST/).test(request.method) &&
-                (request.body && request.body.mode === RequestBody.MODES.urlencoded)) {
+        else if ((/PUT|POST/).test(request.method) && urlencodedBody) {
             _.forEach(signatureParams, function (param) {
-                request.body.urlencoded.add(param);
+                urlencodedBody.add(param);
             });
         }
         else {

--- a/test/integration/auth-methods/oauth1.test.js
+++ b/test/integration/auth-methods/oauth1.test.js
@@ -78,6 +78,181 @@ describe('oauth 1', function () {
         });
     });
 
+    describe('with urlencoded body having disabled params', function () {
+        before(function (done) {
+            // perform the collection run
+            this.run({
+                collection: {
+                    item: {
+                        request: {
+                            auth: {
+                                type: 'oauth1',
+                                oauth1: {
+                                    consumerKey: 'RKCGzna7bv9YD57c',
+                                    consumerSecret: 'D+EdQ-gs$-%@2Nu7',
+                                    signatureMethod: 'HMAC-SHA1',
+                                    version: '1.0',
+                                    addParamsToHeader: true,
+                                    addEmptyParamsToSign: false
+                                }
+                            },
+                            url: 'https://postman-echo.com/oauth1',
+                            method: 'GET',
+                            body: {
+                                mode: 'urlencoded',
+                                urlencoded: [
+                                    {key: 'param_1', value: 'value_1'},
+                                    {key: 'param_2', value: 'value_2', disabled: true}
+                                ]
+                            }
+                        }
+                    },
+                    protocolProfileBehavior: {
+                        disableBodyPruning: true
+                    }
+                }
+            }, function (err, results) {
+                testrun = results;
+                done(err);
+            });
+        });
+
+        it('should have completed the run', function () {
+            expect(testrun).to.be.ok;
+            expect(testrun).to.nested.include({
+                'done.calledOnce': true,
+                'start.calledOnce': true
+            });
+            expect(testrun.done.getCall(0).args[0]).to.be.null;
+        });
+
+        it('should have passed OAuth 1 authorization', function () {
+            expect(testrun.request.calledOnce).to.be.ok;
+
+            var response = testrun.request.getCall(0).args[2];
+
+            expect(response).to.have.property('code', 200);
+        });
+    });
+
+    describe('with disabled URL params', function () {
+        before(function (done) {
+            // perform the collection run
+            this.run({
+                collection: {
+                    item: {
+                        request: {
+                            auth: {
+                                type: 'oauth1',
+                                oauth1: {
+                                    consumerKey: 'RKCGzna7bv9YD57c',
+                                    consumerSecret: 'D+EdQ-gs$-%@2Nu7',
+                                    signatureMethod: 'HMAC-SHA1',
+                                    version: '1.0',
+                                    addParamsToHeader: true,
+                                    addEmptyParamsToSign: false
+                                }
+                            },
+                            url: {
+                                host: ['postman-echo', 'com'],
+                                path: ['oauth1'],
+                                protocol: 'https',
+                                query: [
+                                    {key: 'param_1', value: 'value_1'},
+                                    {key: 'param_2', value: 'value_2', disabled: true}
+                                ],
+                                variable: []
+                            },
+                            method: 'GET'
+                        }
+                    }
+                }
+            }, function (err, results) {
+                testrun = results;
+                done(err);
+            });
+        });
+
+        it('should have completed the run', function () {
+            expect(testrun).to.be.ok;
+            expect(testrun).to.nested.include({
+                'done.calledOnce': true,
+                'start.calledOnce': true
+            });
+            expect(testrun.done.getCall(0).args[0]).to.be.null;
+        });
+
+        it('should have passed OAuth 1 authorization', function () {
+            expect(testrun.request.calledOnce).to.be.ok;
+
+            var response = testrun.request.getCall(0).args[2];
+
+            expect(response).to.have.property('code', 200);
+        });
+    });
+
+    describe('empty urlencoded body and addParamsToHeader: false', function () {
+        before(function (done) {
+            // perform the collection run
+            this.run({
+                collection: {
+                    item: {
+                        request: {
+                            auth: {
+                                type: 'oauth1',
+                                oauth1: {
+                                    consumerKey: 'RKCGzna7bv9YD57c',
+                                    consumerSecret: 'D+EdQ-gs$-%@2Nu7',
+                                    signatureMethod: 'HMAC-SHA1',
+                                    version: '1.0',
+                                    addParamsToHeader: false,
+                                    addEmptyParamsToSign: false
+                                }
+                            },
+                            url: {
+                                host: ['postman-echo', 'com'],
+                                path: ['post'],
+                                protocol: 'https'
+                            },
+                            method: 'POST',
+                            body: {
+                                mode: 'urlencoded',
+                                urlencoded: [] // empty body
+                            }
+                        }
+                    }
+                }
+            }, function (err, results) {
+                testrun = results;
+                done(err);
+            });
+        });
+
+        it('should have completed the run', function () {
+            expect(testrun).to.be.ok;
+            expect(testrun).to.nested.include({
+                'done.calledOnce': true,
+                'start.calledOnce': true
+            });
+            expect(testrun.done.getCall(0).args[0]).to.be.null;
+        });
+
+        it('should send auth params in request body', function () {
+            expect(testrun.request.calledOnce).to.be.ok;
+
+            var response = testrun.request.getCall(0).args[2].json();
+
+            expect(response.form).to.include.keys([
+                'oauth_consumer_key',
+                'oauth_signature_method',
+                'oauth_timestamp',
+                'oauth_nonce',
+                'oauth_version',
+                'oauth_signature'
+            ]);
+        });
+    });
+
     describe('disableHeaderEncoding: true', function () {
         before(function (done) {
             // perform the collection run

--- a/test/unit/auth-handlers.test.js
+++ b/test/unit/auth-handlers.test.js
@@ -587,6 +587,43 @@ describe('Auth Handler:', function () {
                     addEmptyParamsToSign: true
                 });
         });
+
+        it('should generate correct signature for request with disabled query params', function () {
+            var rawReq = _(rawRequests.oauth1).omit(['auth.oauth1.nonce', 'auth.oauth1.timestamp']).merge({
+                    url: {
+                        host: ['postman-echo', 'com'],
+                        path: ['auth', 'oauth1'],
+                        protocol: 'https',
+                        query: [
+                            {key: 'param_1', value: 'value_1'},
+                            {key: 'param_2', value: 'value_2', disabled: true}
+                        ]
+                    },
+                    auth: {
+                        oauth1: {
+                            consumerKey: 'RKCGzna7bv9YD57c',
+                            consumerSecret: 'D+EdQ-gs$-%@2Nu7',
+                            token: 'foo',
+                            tokenSecret: 'bar',
+                            signatureMethod: 'HMAC-SHA1',
+                            timestamp: 1461319769,
+                            nonce: 'ik3oT5',
+                            version: '1.0',
+                            realm: '',
+                            addParamsToHeader: false,
+                            addEmptyParamsToSign: false
+                        }
+                    }
+                }).value(),
+                request = new Request(rawReq),
+                auth = request.auth,
+                authInterface = createAuthInterface(auth),
+                handler = AuthLoader.getHandler(auth.type);
+
+            handler.sign(authInterface, request, function () {
+                expect(request.url.query.get('oauth_signature')).to.eql('e8WDYQsG8SYPoWnxU4CYbqHT1HU=');
+            });
+        });
     });
 
     describe('oauth2', function () {


### PR DESCRIPTION
- exclude disabled url params and disabled url-encoded body params while calculating OAuth1 signature

Issue: https://github.com/postmanlabs/postman-app-support/issues/7522