### PR TITLE
Pass agent option through to postman-request

### DIFF
--- a/lib/requester/core.js
+++ b/lib/requester/core.js
@@ -342,6 +342,7 @@ module.exports = {
      *
      * @param request
      * @param defaultOpts
+     * @param defaultOpts.agent
      * @param defaultOpts.network
      * @param defaultOpts.keepAlive
      * @param defaultOpts.timeout
@@ -527,6 +528,8 @@ module.exports = {
                 network: networkOptions
             }));
         }
+
+        options.agent = defaultOpts.agent;
 
         _.assign(options, bodyParams, {
             agentOptions: {

--- a/lib/requester/requester-pool.js
+++ b/lib/requester/requester-pool.js
@@ -32,7 +32,8 @@ RequesterPool = function (options, callback) {
         implicitTraceHeader: _.get(options, 'requester.implicitTraceHeader', true),
         removeRefererHeaderOnRedirect: _.get(options, 'requester.removeRefererHeaderOnRedirect'),
         ignoreProxyEnvironmentVariables: _.get(options, 'ignoreProxyEnvironmentVariables'),
-        network: _.get(options, 'network', {})
+        network: _.get(options, 'network', {}),
+        agent: _.get(options, 'agent')
     });
 
     // create a cookie jar if one is not provided

--- a/test/unit/requester-core.test.js
+++ b/test/unit/requester-core.test.js
@@ -123,6 +123,20 @@ describe('requester util', function () {
             });
         });
 
+        it('should allow agent option', function () {
+            var request = new sdk.Request({
+                    url: 'https://postman-echo.com',
+                    method: 'GET'
+                }),
+                agent = 'my agent',
+                requestOptions = requesterCore.getRequestOptions(request, {agent});
+
+            expect(requestOptions).to.have.ownProperty('agent');
+            expect(requestOptions).to.include({
+                agent
+            });
+        });
+
         describe('Should accept URL irrespective of the case', function () {
             it('should accept URL in uppercase', function () {
                 var request = new sdk.Request({


### PR DESCRIPTION
This first of two PRs aimed to address the need to run postman tests via socks proxy. It is a long-standing request documented here: postmanlabs/postman-app-support#1321.

The proposed first (minimum viable) step is to allow teams that use newman as a library to pass their own HTTP agent through to postman request. Postman request already supports agent option. This would enable use of libraries like socks-proxy-agent to run tests through socks proxy.

Please let me know if you need additional information.