### PR TITLE
Added support for using custom Authorization header prefix in OAuth 2.0

### DIFF
--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -1,3 +1,9 @@
+master:
+  new features:
+    - >-
+      GH-1018 Added support for using custom Authorization header prefix via 
+      `headerPrefix` property in OAuth 2.0
+
 7.25.0:
   date: 2020-05-15
   new features:

--- a/lib/authorizer/oauth2.js
+++ b/lib/authorizer/oauth2.js
@@ -1,15 +1,12 @@
 var _ = require('lodash'),
 
-    E = '',
-    SPACE = ' ',
     HEADER = 'header',
     QUERY_PARAMS = 'queryParams',
     BEARER = 'bearer',
     MAC = 'mac',
     AUTHORIZATION = 'Authorization',
     ACCESS_TOKEN = 'access_token',
-    AUTHORIZATION_PREFIX = 'Bearer',
-    NO_PREFIX = 'NO_PREFIX',
+    AUTHORIZATION_PREFIX = 'Bearer ',
     OAUTH2_PARAMETERS = [
         'accessToken',
         'addTokenTo',
@@ -94,7 +91,8 @@ module.exports = {
         // Defaults
         params.addTokenTo = params.addTokenTo || HEADER; // Add token to header by default
         params.tokenType = params.tokenType || BEARER; // Use `Bearer` token type by default
-        params.headerPrefix = _.trim(params.headerPrefix || AUTHORIZATION_PREFIX);
+        params.headerPrefix = _.isNil(params.headerPrefix) ?
+            AUTHORIZATION_PREFIX : String(params.headerPrefix);
 
         // Some servers send 'Bearer' while others send 'bearer'
         tokenType = _.toLower(params.tokenType);
@@ -120,13 +118,6 @@ module.exports = {
             });
         }
         else if (params.addTokenTo === HEADER) {
-            if (params.headerPrefix === NO_PREFIX) {
-                params.headerPrefix = E;
-            }
-            else {
-                params.headerPrefix += SPACE;
-            }
-
             request.addHeader({
                 key: AUTHORIZATION,
                 value: params.headerPrefix + params.accessToken,

--- a/lib/authorizer/oauth2.js
+++ b/lib/authorizer/oauth2.js
@@ -1,16 +1,20 @@
 var _ = require('lodash'),
 
+    E = '',
+    SPACE = ' ',
     HEADER = 'header',
     QUERY_PARAMS = 'queryParams',
     BEARER = 'bearer',
     MAC = 'mac',
     AUTHORIZATION = 'Authorization',
     ACCESS_TOKEN = 'access_token',
-    AUTHORIZATION_PREFIX = 'Bearer ',
+    AUTHORIZATION_PREFIX = 'Bearer',
+    NO_PREFIX = 'NO_PREFIX',
     OAUTH2_PARAMETERS = [
         'accessToken',
         'addTokenTo',
-        'tokenType'
+        'tokenType',
+        'headerPrefix'
     ];
 
 /**
@@ -90,6 +94,7 @@ module.exports = {
         // Defaults
         params.addTokenTo = params.addTokenTo || HEADER; // Add token to header by default
         params.tokenType = params.tokenType || BEARER; // Use `Bearer` token type by default
+        params.headerPrefix = _.trim(params.headerPrefix || AUTHORIZATION_PREFIX);
 
         // Some servers send 'Bearer' while others send 'bearer'
         tokenType = _.toLower(params.tokenType);
@@ -115,9 +120,16 @@ module.exports = {
             });
         }
         else if (params.addTokenTo === HEADER) {
+            if (params.headerPrefix === NO_PREFIX) {
+                params.headerPrefix = E;
+            }
+            else {
+                params.headerPrefix += SPACE;
+            }
+
             request.addHeader({
                 key: AUTHORIZATION,
-                value: AUTHORIZATION_PREFIX + params.accessToken,
+                value: params.headerPrefix + params.accessToken,
                 system: true
             });
         }

--- a/test/unit/auth-handlers.test.js
+++ b/test/unit/auth-handlers.test.js
@@ -801,7 +801,7 @@ describe('Auth Handler:', function () {
                 handler;
 
             clonedRequestObj = _.cloneDeep(requestObj);
-            clonedRequestObj.auth.oauth2.headerPrefix = 'Postman';
+            clonedRequestObj.auth.oauth2.headerPrefix = 'Postman ';
 
             request = new Request(clonedRequestObj);
             auth = request.auth;
@@ -818,7 +818,7 @@ describe('Auth Handler:', function () {
             });
         });
 
-        it('should not add header prefix when headerPrefix = "NO_PREFIX"', function () {
+        it('should add empty header prefix when headerPrefix = ""', function () {
             var clonedRequestObj,
                 request,
                 auth,
@@ -826,7 +826,7 @@ describe('Auth Handler:', function () {
                 handler;
 
             clonedRequestObj = _.cloneDeep(requestObj);
-            clonedRequestObj.auth.oauth2.headerPrefix = 'NO_PREFIX';
+            clonedRequestObj.auth.oauth2.headerPrefix = '';
 
             request = new Request(clonedRequestObj);
             auth = request.auth;
@@ -839,6 +839,31 @@ describe('Auth Handler:', function () {
             expect(request.headers.toJSON()[0]).to.eql({
                 key: 'Authorization',
                 value: requestObj.auth.oauth2.accessToken,
+                system: true
+            });
+        });
+
+        it('should add default header prefix when headerPrefix = undefined', function () {
+            var clonedRequestObj,
+                request,
+                auth,
+                authInterface,
+                handler;
+
+            clonedRequestObj = _.cloneDeep(requestObj);
+            clonedRequestObj.auth.oauth2.headerPrefix = undefined;
+
+            request = new Request(clonedRequestObj);
+            auth = request.auth;
+            authInterface = createAuthInterface(auth);
+            handler = AuthLoader.getHandler(auth.type);
+
+            handler.sign(authInterface, request, _.noop);
+
+            expect(request.headers.all()).to.be.an('array').that.has.lengthOf(1);
+            expect(request.headers.toJSON()[0]).to.eql({
+                key: 'Authorization',
+                value: 'Bearer ' + requestObj.auth.oauth2.accessToken,
                 system: true
             });
         });

--- a/test/unit/auth-handlers.test.js
+++ b/test/unit/auth-handlers.test.js
@@ -793,6 +793,56 @@ describe('Auth Handler:', function () {
             });
         });
 
+        it('should use custom header prefix when provided', function () {
+            var clonedRequestObj,
+                request,
+                auth,
+                authInterface,
+                handler;
+
+            clonedRequestObj = _.cloneDeep(requestObj);
+            clonedRequestObj.auth.oauth2.headerPrefix = 'Postman';
+
+            request = new Request(clonedRequestObj);
+            auth = request.auth;
+            authInterface = createAuthInterface(auth);
+            handler = AuthLoader.getHandler(auth.type);
+
+            handler.sign(authInterface, request, _.noop);
+
+            expect(request.headers.all()).to.be.an('array').that.has.lengthOf(1);
+            expect(request.headers.toJSON()[0]).to.eql({
+                key: 'Authorization',
+                value: 'Postman ' + requestObj.auth.oauth2.accessToken,
+                system: true
+            });
+        });
+
+        it('should not add header prefix when headerPrefix = "NO_PREFIX"', function () {
+            var clonedRequestObj,
+                request,
+                auth,
+                authInterface,
+                handler;
+
+            clonedRequestObj = _.cloneDeep(requestObj);
+            clonedRequestObj.auth.oauth2.headerPrefix = 'NO_PREFIX';
+
+            request = new Request(clonedRequestObj);
+            auth = request.auth;
+            authInterface = createAuthInterface(auth);
+            handler = AuthLoader.getHandler(auth.type);
+
+            handler.sign(authInterface, request, _.noop);
+
+            expect(request.headers.all()).to.be.an('array').that.has.lengthOf(1);
+            expect(request.headers.toJSON()[0]).to.eql({
+                key: 'Authorization',
+                value: requestObj.auth.oauth2.accessToken,
+                system: true
+            });
+        });
+
         it('should return when token type is MAC', function () {
             var clonedRequestObj,
                 request,


### PR DESCRIPTION
In OAuth 2.0,
- `headerPrefix` field will allow overriding Authorization header prefix
- If not provided (null or undefined), prefix `Bearer ` will be used by default

Issues:
- https://github.com/postmanlabs/postman-app-support/issues/4727
- https://github.com/postmanlabs/postman-app-support/issues/6616