### PR TITLE
feature to run selective requests added

### DIFF
--- a/lib/runner/index.js
+++ b/lib/runner/index.js
@@ -110,6 +110,21 @@ _.assign(Runner.prototype, {
                 runOptions.iterationCount = options.data.length;
             }
 
+            // removing unwanted requests from runnableItems
+            if (options.requestList) {
+                let request,
+                    newRunnableItems = [];
+
+                _.forEach(options.requestList, function (requestName) {
+                    // eslint-disable-next-line lodash/matches-prop-shorthand
+                    request = _.find(runnableItems, function (i) { return i.name === requestName; });
+                    if (request) {
+                        newRunnableItems.push(request);
+                    }
+                });
+                runnableItems = newRunnableItems;
+            }
+
             return callback(null, (new Run({
                 items: runnableItems,
                 data: options.data,


### PR DESCRIPTION
Solved issue [#2339](https://github.com/postmanlabs/newman/issues/2339) of newman repo.(To solve this issue it was required to make some changes in this repo.)
Before users were not able to run selective requests from a collection/collections.
Now, (After merging) users will be able to run selective requests from a collection/collections.

Screenshots:
**Newman Library**
Before:
Code:
```
const newman = require('newman');

newman.run({
    collection: require('./test1.json'),
    reporters: 'cli',
    iterationCount: 1,
}, function (err) {
    if (err) {
        throw err;
    }
    console.log('collection run complete!');
});

```
Output:
![newmanLibraryBefore](https://user-images.githubusercontent.com/35838512/83323781-9eadf100-a27e-11ea-881f-b2ba61e531b0.png)

After:
Code:
```
const newman = require('newman');

newman.run({
    collection: require('./test1.json'),
    reporters: 'cli',
    iterationCount: 1,
    requestList: ['get1','Reqres1']
}, function (err) {
    if (err) {
        throw err;
    }
    console.log('collection run complete!');
});
```
Output:
![newmanLibraryAfter](https://user-images.githubusercontent.com/35838512/83323800-b9806580-a27e-11ea-9780-cddbf9098da8.png)

**Newman Cli**
Before:
![newmanCliBefore](https://user-images.githubusercontent.com/35838512/83323819-dcab1500-a27e-11ea-9749-23da7b837e8a.png)
After:
![newmanCliAfter](https://user-images.githubusercontent.com/35838512/83323822-dfa60580-a27e-11ea-944c-82ee01711425.png)

@codenirvana @shamasis please review it.