### PR TITLE
Added support for SHA256 algorithm in Digest auth

### DIFF
--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -17,6 +17,7 @@ master:
       [OAuth 1.0a spec](https://oauth.net/core/1.0a)
         1. oauth_callback
         2. oauth_verifier
+    - GH-1039 Added support for SHA-256 and SHA-256-sess algorithms in Digest auth
   chores:
     - Updated dependencies
 

--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -17,7 +17,12 @@ master:
       [OAuth 1.0a spec](https://oauth.net/core/1.0a)
         1. oauth_callback
         2. oauth_verifier
-    - GH-1039 Added support for SHA-256 and SHA-256-sess algorithms in Digest auth
+    - |
+      GH-1039 Added support for following algorithms in Digest auth
+        1. SHA-256
+        2. SHA-256-sess
+        3. SHA-512-256
+        4. SHA-512-256-sess
   chores:
     - Updated dependencies
 

--- a/lib/authorizer/digest.js
+++ b/lib/authorizer/digest.js
@@ -1,5 +1,5 @@
 var _ = require('lodash'),
-    crypto = require('crypto-js'),
+    crypto = require('crypto'),
     urlEncoder = require('postman-url-encoder'),
 
     EMPTY = '',
@@ -11,6 +11,7 @@ var _ = require('lodash'),
     AUTH = 'auth',
     COLON = ':',
     QUOTE = '"',
+    SESS = '-sess',
     AUTH_INT = 'auth-int',
     AUTHORIZATION = 'Authorization',
     MD5_SESS = 'MD5-sess',
@@ -26,6 +27,14 @@ var _ = require('lodash'),
     OPAQUE_EQUALS_QUOTE = 'opaque="',
     QOP_EQUALS = 'qop=',
     NC_EQUALS = 'nc=',
+    ALGO = {
+        MD5: 'MD5',
+        MD5_SESS: 'MD5-sess',
+        SHA_256: 'SHA-256',
+        SHA_256_SESS: 'SHA-256-sess',
+        SHA_512_256: 'SHA-512-256',
+        SHA_512_256_SESS: 'SHA-512-256-sess'
+    },
     AUTH_PARAMETERS = [
         'algorithm',
         'username',
@@ -92,6 +101,17 @@ function _getDigestAuthHeader (headers) {
     });
 }
 
+/**
+ * Returns a function to calculate hash of data with given algorithm
+ *
+ * @param {String} algorithm hash algorithm
+ * @returns {Function} functiont that takes data as argument and returns its hash
+ */
+function getHashFunction (algorithm) {
+    return function (data) {
+        return crypto.createHash(algorithm).update(data || EMPTY).digest('hex');
+    };
+}
 
 /**
  * All the auth definition parameters excluding username and password should be stored and resued.
@@ -243,11 +263,33 @@ module.exports = {
             hashA1,
             hashA2,
 
+            hash,
             reqDigest,
             headerParams;
 
-        if (algorithm === MD5_SESS) {
-            A0 = crypto.MD5(username + COLON + realm + COLON + password).toString();
+        switch (algorithm) {
+            case ALGO.SHA_256:
+            case ALGO.SHA_256_SESS:
+                hash = getHashFunction('sha256');
+                break;
+            case ALGO.MD5:
+            case ALGO.MD5_SESS:
+            case undefined:
+            case null:
+                algorithm = algorithm || ALGO.MD5;
+                hash = getHashFunction('md5');
+                break;
+            case ALGO.SHA_512_256:
+            case ALGO.SHA_512_256_SESS:
+            default:
+                // Current Electron version(7.2.3) in Postman app uses OpenSSL 1.1.0
+                // which don't support `SHA-512-256`.
+                // @todo: change this when Electron is upgraded to a version which supports `SHA-512-256`.
+                throw new Error(`Unsupported digest algorithm: ${algorithm}`);
+        }
+
+        if (_.endsWith(algorithm, SESS)) {
+            A0 = hash(username + COLON + realm + COLON + password);
             A1 = A0 + COLON + nonce + COLON + clientNonce;
         }
         else {
@@ -255,19 +297,19 @@ module.exports = {
         }
 
         if (qop === AUTH_INT) {
-            A2 = method + COLON + uri + COLON + crypto.MD5(params.body);
+            A2 = method + COLON + uri + COLON + hash(params.body);
         }
         else {
             A2 = method + COLON + uri;
         }
-        hashA1 = crypto.MD5(A1).toString();
-        hashA2 = crypto.MD5(A2).toString();
+        hashA1 = hash(A1);
+        hashA2 = hash(A2);
 
         if (qop === AUTH || qop === AUTH_INT) {
-            reqDigest = crypto.MD5([hashA1, nonce, nonceCount, clientNonce, qop, hashA2].join(COLON)).toString();
+            reqDigest = hash([hashA1, nonce, nonceCount, clientNonce, qop, hashA2].join(COLON));
         }
         else {
-            reqDigest = crypto.MD5([hashA1, nonce, hashA2].join(COLON)).toString();
+            reqDigest = hash([hashA1, nonce, hashA2].join(COLON));
         }
 
         headerParams = [USERNAME_EQUALS_QUOTE + username + QUOTE,

--- a/lib/authorizer/digest.js
+++ b/lib/authorizer/digest.js
@@ -273,6 +273,7 @@ module.exports = {
                 break;
             case ALGO.MD5:
             case ALGO.MD5_SESS:
+            case EMPTY:
             case undefined:
             case null:
                 algorithm = algorithm || ALGO.MD5;

--- a/lib/authorizer/digest.js
+++ b/lib/authorizer/digest.js
@@ -1,6 +1,5 @@
 var _ = require('lodash'),
     crypto = require('crypto'),
-    jsSHA = require('js-sha512'),
     urlEncoder = require('postman-url-encoder'),
 
     EMPTY = '',
@@ -54,7 +53,15 @@ var _ = require('lodash'),
     realmRegex = /realm="([^"]*)"/,
     qopRegex = /qop="([^"]*)"/,
     opaqueRegex = /opaque="([^"]*)"/,
-    _extractField;
+    _extractField,
+    SHA512_256;
+
+// Current Electron version(7.2.3) in Postman app uses OpenSSL 1.1.0
+// which don't support `SHA-512-256`. Use external `js-sha512` module
+// to handle this case.
+if (!_.includes(crypto.getHashes(), 'sha512-256')) {
+    SHA512_256 = require('js-sha512').sha512_256;
+}
 
 /**
  * Generates a random string of given length
@@ -110,20 +117,11 @@ function _getDigestAuthHeader (headers) {
  * @returns {String} hex encoded hash of given data
  */
 function getHash (data, algorithm) {
-    try {
-        return crypto.createHash(algorithm).update(data || EMPTY).digest('hex');
+    if (algorithm === 'sha512-256' && SHA512_256) {
+        return SHA512_256(data || EMPTY);
     }
-    catch (e) {
-        // Current Electron version(7.2.3) in Postman app uses OpenSSL 1.1.0
-        // which don't support `SHA-512-256`. Use external `js-sha512` module
-        // to handle this case.
-        if (e.message === 'Digest method not supported' && algorithm === 'sha512-256') {
-            return jsSHA.sha512_256(data);
-        }
 
-        // throw other errors as it is
-        throw e;
-    }
+    return crypto.createHash(algorithm).update(data || EMPTY).digest('hex');
 }
 
 /**

--- a/lib/authorizer/digest.js
+++ b/lib/authorizer/digest.js
@@ -102,15 +102,14 @@ function _getDigestAuthHeader (headers) {
 }
 
 /**
- * Returns a function to calculate hash of data with given algorithm
+ * Returns hex encoded hash of given data using given algorithm.
  *
+ * @param {String} data string to calculate hash
  * @param {String} algorithm hash algorithm
- * @returns {Function} functiont that takes data as argument and returns its hash
+ * @returns {String} hex encoded hash of given data
  */
-function getHashFunction (algorithm) {
-    return function (data) {
-        return crypto.createHash(algorithm).update(data || EMPTY).digest('hex');
-    };
+function getHash (data, algorithm) {
+    return crypto.createHash(algorithm).update(data || EMPTY).digest('hex');
 }
 
 /**
@@ -263,21 +262,21 @@ module.exports = {
             hashA1,
             hashA2,
 
-            hash,
+            hashAlgo,
             reqDigest,
             headerParams;
 
         switch (algorithm) {
             case ALGO.SHA_256:
             case ALGO.SHA_256_SESS:
-                hash = getHashFunction('sha256');
+                hashAlgo = 'sha256';
                 break;
             case ALGO.MD5:
             case ALGO.MD5_SESS:
             case undefined:
             case null:
                 algorithm = algorithm || ALGO.MD5;
-                hash = getHashFunction('md5');
+                hashAlgo = 'md5';
                 break;
             case ALGO.SHA_512_256:
             case ALGO.SHA_512_256_SESS:
@@ -289,7 +288,7 @@ module.exports = {
         }
 
         if (_.endsWith(algorithm, SESS)) {
-            A0 = hash(username + COLON + realm + COLON + password);
+            A0 = getHash(username + COLON + realm + COLON + password, hashAlgo);
             A1 = A0 + COLON + nonce + COLON + clientNonce;
         }
         else {
@@ -297,19 +296,19 @@ module.exports = {
         }
 
         if (qop === AUTH_INT) {
-            A2 = method + COLON + uri + COLON + hash(params.body);
+            A2 = method + COLON + uri + COLON + getHash(params.body, hashAlgo);
         }
         else {
             A2 = method + COLON + uri;
         }
-        hashA1 = hash(A1);
-        hashA2 = hash(A2);
+        hashA1 = getHash(A1, hashAlgo);
+        hashA2 = getHash(A2, hashAlgo);
 
         if (qop === AUTH || qop === AUTH_INT) {
-            reqDigest = hash([hashA1, nonce, nonceCount, clientNonce, qop, hashA2].join(COLON));
+            reqDigest = getHash([hashA1, nonce, nonceCount, clientNonce, qop, hashA2].join(COLON), hashAlgo);
         }
         else {
-            reqDigest = hash([hashA1, nonce, hashA2].join(COLON));
+            reqDigest = getHash([hashA1, nonce, hashA2].join(COLON), hashAlgo);
         }
 
         headerParams = [USERNAME_EQUALS_QUOTE + username + QUOTE,

--- a/lib/authorizer/digest.js
+++ b/lib/authorizer/digest.js
@@ -1,5 +1,6 @@
 var _ = require('lodash'),
     crypto = require('crypto'),
+    jsSHA = require('js-sha512'),
     urlEncoder = require('postman-url-encoder'),
 
     EMPTY = '',
@@ -109,7 +110,20 @@ function _getDigestAuthHeader (headers) {
  * @returns {String} hex encoded hash of given data
  */
 function getHash (data, algorithm) {
-    return crypto.createHash(algorithm).update(data || EMPTY).digest('hex');
+    try {
+        return crypto.createHash(algorithm).update(data || EMPTY).digest('hex');
+    }
+    catch (e) {
+        // Current Electron version(7.2.3) in Postman app uses OpenSSL 1.1.0
+        // which don't support `SHA-512-256`. Use external `js-sha512` module
+        // to handle this case.
+        if (e.message === 'Digest method not supported' && algorithm === 'sha512-256') {
+            return jsSHA.sha512_256(data);
+        }
+
+        // throw other errors as it is
+        throw e;
+    }
 }
 
 /**
@@ -281,10 +295,9 @@ module.exports = {
                 break;
             case ALGO.SHA_512_256:
             case ALGO.SHA_512_256_SESS:
+                hashAlgo = 'sha512-256';
+                break;
             default:
-                // Current Electron version(7.2.3) in Postman app uses OpenSSL 1.1.0
-                // which don't support `SHA-512-256`.
-                // @todo: change this when Electron is upgraded to a version which supports `SHA-512-256`.
                 throw new Error(`Unsupported digest algorithm: ${algorithm}`);
         }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -943,11 +943,6 @@
         "which": "^1.2.9"
       }
     },
-    "crypto-js": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-3.3.0.tgz",
-      "integrity": "sha512-DIT51nX0dCfKltpRiXV+/TVZq+Qq2NgF4644+K7Ttnla7zEzqc+kjJyiB96BHNyUTBxyjzRcZYpUdZa+QAqi6Q=="
-    },
     "dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2310,6 +2310,11 @@
       "integrity": "sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg==",
       "dev": true
     },
+    "js-sha512": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/js-sha512/-/js-sha512-0.8.0.tgz",
+      "integrity": "sha512-PWsmefG6Jkodqt+ePTvBZCSMFgN7Clckjd0O7su3I0+BW2QWUTJNzjktHsztGLhncP2h8mcF9V9Y2Ha59pAViQ=="
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "http-reasons": "0.1.0",
     "httpntlm": "1.7.6",
     "inherits": "2.0.4",
+    "js-sha512": "0.8.0",
     "lodash": "4.17.15",
     "node-oauth1": "1.3.0",
     "performance-now": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
   "dependencies": {
     "async": "2.6.3",
     "aws4": "1.9.1",
-    "crypto-js": "3.3.0",
     "eventemitter3": "4.0.4",
     "handlebars": "4.7.6",
     "http-reasons": "0.1.0",

--- a/test/unit/auth-handlers.test.js
+++ b/test/unit/auth-handlers.test.js
@@ -524,6 +524,174 @@ describe('Auth Handler:', function () {
             expect(authHeader.system).to.be.true;
         });
 
+        // @todo: Unskip following 6 tests when support for SHA-512-256 algorithm is added
+
+        it.skip('should add the Auth header for (algorithm="SHA-512-256", qop=""', function () {
+            var clonedReqObj = _.merge({}, rawRequests.digest, {
+                    auth: {
+                        digest: {
+                            algorithm: 'SHA-512-256'
+                        }
+                    }
+                }),
+                request = new Request(clonedReqObj),
+                auth = request.auth,
+                authInterface = createAuthInterface(auth),
+                handler = AuthLoader.getHandler(auth.type),
+                headers,
+                authHeader,
+
+                // eslint-disable-next-line max-len
+                expectedHeader = 'Authorization: Digest username="postman", realm="Users", nonce="bcgEc5RPU1ANglyT2I0ShU0oxqPB5jXp", uri="/digest-auth", algorithm="SHA-512-256", response="1676ceef7b880281567d30ca03f2517131fbc4a0c0a16d577cc4ad477b6b8c52", opaque="5ccc069c403ebaf9f0171e9517f40e"';
+
+            handler.sign(authInterface, request, _.noop);
+            headers = request.headers.all();
+            authHeader = headers[0];
+
+            expect(headers).to.have.lengthOf(1);
+            expect(authHeader.toString()).to.eql(expectedHeader);
+            expect(authHeader.system).to.be.true;
+        });
+
+        it.skip('should add the Auth header for (algorithm="SHA-512-256", qop="auth")', function () {
+            var clonedReqObj = _.merge({}, rawRequests.digest, {
+                    auth: {
+                        digest: {
+                            algorithm: 'SHA-512-256',
+                            qop: 'auth'
+                        }
+                    }
+                }),
+                request = new Request(clonedReqObj),
+                auth = request.auth,
+                authInterface = createAuthInterface(auth),
+                handler = AuthLoader.getHandler(auth.type),
+                headers,
+                authHeader,
+
+                // eslint-disable-next-line max-len
+                expectedHeader = 'Authorization: Digest username="postman", realm="Users", nonce="bcgEc5RPU1ANglyT2I0ShU0oxqPB5jXp", uri="/digest-auth", algorithm="SHA-512-256", qop=auth, nc=00000001, cnonce="0a4f113b", response="fb53cf8c6922b758cf05477afd5cd896ad0213f16588ed15089da72a2900cb19", opaque="5ccc069c403ebaf9f0171e9517f40e"';
+
+            handler.sign(authInterface, request, _.noop);
+            headers = request.headers.all();
+            authHeader = headers[0];
+
+            expect(headers).to.have.lengthOf(1);
+            expect(authHeader.toString()).to.eql(expectedHeader);
+            expect(authHeader.system).to.be.true;
+        });
+
+        it.skip('should add the Auth header for (algorithm="SHA-512-256", qop="auth-int")', function () {
+            var clonedReqObj = _.merge({}, rawRequests.digest, {
+                    auth: {
+                        digest: {
+                            algorithm: 'SHA-512-256',
+                            qop: 'auth-int'
+                        }
+                    }
+                }),
+                request = new Request(clonedReqObj),
+                auth = request.auth,
+                authInterface = createAuthInterface(auth),
+                handler = AuthLoader.getHandler(auth.type),
+                headers,
+                authHeader,
+
+                // eslint-disable-next-line max-len
+                expectedHeader = 'Authorization: Digest username="postman", realm="Users", nonce="bcgEc5RPU1ANglyT2I0ShU0oxqPB5jXp", uri="/digest-auth", algorithm="SHA-512-256", qop=auth-int, nc=00000001, cnonce="0a4f113b", response="f928c7ae0b0d4e4fe870e2fe66ccb85362e08b7c9ac33dcc527915019dec7aa2", opaque="5ccc069c403ebaf9f0171e9517f40e"';
+
+            handler.sign(authInterface, request, _.noop);
+            headers = request.headers.all();
+            authHeader = headers[0];
+
+            expect(headers).to.have.lengthOf(1);
+            expect(authHeader.toString()).to.eql(expectedHeader);
+            expect(authHeader.system).to.be.true;
+        });
+
+        it.skip('should add the Auth header for (algorithm="SHA-512-256-sess", qop="")', function () {
+            var clonedReqObj = _.merge({}, rawRequests.digest, {
+                    auth: {
+                        digest: {
+                            algorithm: 'SHA-512-256-sess'
+                        }
+                    }
+                }),
+                request = new Request(clonedReqObj),
+                auth = request.auth,
+                authInterface = createAuthInterface(auth),
+                handler = AuthLoader.getHandler(auth.type),
+                headers,
+                authHeader,
+
+                // eslint-disable-next-line max-len
+                expectedHeader = 'Authorization: Digest username="postman", realm="Users", nonce="bcgEc5RPU1ANglyT2I0ShU0oxqPB5jXp", uri="/digest-auth", algorithm="SHA-512-256-sess", response="501c722984db1ecab705757c060e359debac8c9ee98bea00fc70c111977fcaba", opaque="5ccc069c403ebaf9f0171e9517f40e"';
+
+            handler.sign(authInterface, request, _.noop);
+            headers = request.headers.all();
+            authHeader = headers[0];
+
+            expect(headers).to.have.lengthOf(1);
+            expect(authHeader.toString()).to.eql(expectedHeader);
+            expect(authHeader.system).to.be.true;
+        });
+
+        it.skip('should add the Auth header for (algorithm="SHA-512-256-sess", qop="auth")', function () {
+            var clonedReqObj = _.merge({}, rawRequests.digest, {
+                    auth: {
+                        digest: {
+                            algorithm: 'SHA-512-256-sess',
+                            qop: 'auth'
+                        }
+                    }
+                }),
+                request = new Request(clonedReqObj),
+                auth = request.auth,
+                authInterface = createAuthInterface(auth),
+                handler = AuthLoader.getHandler(auth.type),
+                headers,
+                authHeader,
+
+                // eslint-disable-next-line max-len
+                expectedHeader = 'Authorization: Digest username="postman", realm="Users", nonce="bcgEc5RPU1ANglyT2I0ShU0oxqPB5jXp", uri="/digest-auth", algorithm="SHA-512-256-sess", qop=auth, nc=00000001, cnonce="0a4f113b", response="5b0af1e60cff4aaa751326f6e837ea5d32c77324254f6c0c9882ff6cc0947799", opaque="5ccc069c403ebaf9f0171e9517f40e"';
+
+            handler.sign(authInterface, request, _.noop);
+            headers = request.headers.all();
+            authHeader = headers[0];
+
+            expect(headers).to.have.lengthOf(1);
+            expect(authHeader.toString()).to.eql(expectedHeader);
+            expect(authHeader.system).to.be.true;
+        });
+
+        it.skip('should add the Auth header for (algorithm="SHA-512-256-sess", qop="auth-int")', function () {
+            var clonedReqObj = _.merge({}, rawRequests.digest, {
+                    auth: {
+                        digest: {
+                            algorithm: 'SHA-512-256-sess',
+                            qop: 'auth-int'
+                        }
+                    }
+                }),
+                request = new Request(clonedReqObj),
+                auth = request.auth,
+                authInterface = createAuthInterface(auth),
+                handler = AuthLoader.getHandler(auth.type),
+                headers,
+                authHeader,
+
+                // eslint-disable-next-line max-len
+                expectedHeader = 'Authorization: Digest username="postman", realm="Users", nonce="bcgEc5RPU1ANglyT2I0ShU0oxqPB5jXp", uri="/digest-auth", algorithm="SHA-512-256-sess", qop=auth-int, nc=00000001, cnonce="0a4f113b", response="6e12487570a4f493953dd7e378924eee9a61dea0e6f0ee59854cf2c77c223f53", opaque="5ccc069c403ebaf9f0171e9517f40e"';
+
+            handler.sign(authInterface, request, _.noop);
+            headers = request.headers.all();
+            authHeader = headers[0];
+
+            expect(headers).to.have.lengthOf(1);
+            expect(authHeader.toString()).to.eql(expectedHeader);
+            expect(authHeader.system).to.be.true;
+        });
+
         it('should add the Auth header with query params in case of request with the same', function () {
             var request = new Request(rawRequests.digestWithQueryParams),
                 auth = request.auth,

--- a/test/unit/auth-handlers.test.js
+++ b/test/unit/auth-handlers.test.js
@@ -524,9 +524,7 @@ describe('Auth Handler:', function () {
             expect(authHeader.system).to.be.true;
         });
 
-        // @todo: Unskip following 6 tests when support for SHA-512-256 algorithm is added
-
-        it.skip('should add the Auth header for (algorithm="SHA-512-256", qop=""', function () {
+        it('should add the Auth header for (algorithm="SHA-512-256", qop=""', function () {
             var clonedReqObj = _.merge({}, rawRequests.digest, {
                     auth: {
                         digest: {
@@ -553,7 +551,7 @@ describe('Auth Handler:', function () {
             expect(authHeader.system).to.be.true;
         });
 
-        it.skip('should add the Auth header for (algorithm="SHA-512-256", qop="auth")', function () {
+        it('should add the Auth header for (algorithm="SHA-512-256", qop="auth")', function () {
             var clonedReqObj = _.merge({}, rawRequests.digest, {
                     auth: {
                         digest: {
@@ -581,7 +579,7 @@ describe('Auth Handler:', function () {
             expect(authHeader.system).to.be.true;
         });
 
-        it.skip('should add the Auth header for (algorithm="SHA-512-256", qop="auth-int")', function () {
+        it('should add the Auth header for (algorithm="SHA-512-256", qop="auth-int")', function () {
             var clonedReqObj = _.merge({}, rawRequests.digest, {
                     auth: {
                         digest: {
@@ -609,7 +607,7 @@ describe('Auth Handler:', function () {
             expect(authHeader.system).to.be.true;
         });
 
-        it.skip('should add the Auth header for (algorithm="SHA-512-256-sess", qop="")', function () {
+        it('should add the Auth header for (algorithm="SHA-512-256-sess", qop="")', function () {
             var clonedReqObj = _.merge({}, rawRequests.digest, {
                     auth: {
                         digest: {
@@ -636,7 +634,7 @@ describe('Auth Handler:', function () {
             expect(authHeader.system).to.be.true;
         });
 
-        it.skip('should add the Auth header for (algorithm="SHA-512-256-sess", qop="auth")', function () {
+        it('should add the Auth header for (algorithm="SHA-512-256-sess", qop="auth")', function () {
             var clonedReqObj = _.merge({}, rawRequests.digest, {
                     auth: {
                         digest: {
@@ -664,7 +662,7 @@ describe('Auth Handler:', function () {
             expect(authHeader.system).to.be.true;
         });
 
-        it.skip('should add the Auth header for (algorithm="SHA-512-256-sess", qop="auth-int")', function () {
+        it('should add the Auth header for (algorithm="SHA-512-256-sess", qop="auth-int")', function () {
             var clonedReqObj = _.merge({}, rawRequests.digest, {
                     auth: {
                         digest: {

--- a/test/unit/auth-handlers.test.js
+++ b/test/unit/auth-handlers.test.js
@@ -358,6 +358,172 @@ describe('Auth Handler:', function () {
             expect(authHeader.system).to.be.true;
         });
 
+        it('should add the Auth header for (algorithm="SHA-256", qop=""', function () {
+            var clonedReqObj = _.merge({}, rawRequests.digest, {
+                    auth: {
+                        digest: {
+                            algorithm: 'SHA-256'
+                        }
+                    }
+                }),
+                request = new Request(clonedReqObj),
+                auth = request.auth,
+                authInterface = createAuthInterface(auth),
+                handler = AuthLoader.getHandler(auth.type),
+                headers,
+                authHeader,
+
+                // eslint-disable-next-line max-len
+                expectedHeader = 'Authorization: Digest username="postman", realm="Users", nonce="bcgEc5RPU1ANglyT2I0ShU0oxqPB5jXp", uri="/digest-auth", algorithm="SHA-256", response="640a149858bc1b2a90a02453a328bad01c1bad5dad6ba92cf0bf7832fd7dcae2", opaque="5ccc069c403ebaf9f0171e9517f40e"';
+
+            handler.sign(authInterface, request, _.noop);
+            headers = request.headers.all();
+            authHeader = headers[0];
+
+            expect(headers).to.have.lengthOf(1);
+            expect(authHeader.toString()).to.eql(expectedHeader);
+            expect(authHeader.system).to.be.true;
+        });
+
+        it('should add the Auth header for (algorithm="SHA-256", qop="auth")', function () {
+            var clonedReqObj = _.merge({}, rawRequests.digest, {
+                    auth: {
+                        digest: {
+                            algorithm: 'SHA-256',
+                            qop: 'auth'
+                        }
+                    }
+                }),
+                request = new Request(clonedReqObj),
+                auth = request.auth,
+                authInterface = createAuthInterface(auth),
+                handler = AuthLoader.getHandler(auth.type),
+                headers,
+                authHeader,
+
+                // eslint-disable-next-line max-len
+                expectedHeader = 'Authorization: Digest username="postman", realm="Users", nonce="bcgEc5RPU1ANglyT2I0ShU0oxqPB5jXp", uri="/digest-auth", algorithm="SHA-256", qop=auth, nc=00000001, cnonce="0a4f113b", response="6025934347a57283989281f03d9c4e1adbb3ee50af57827c83182d87e0cb7ec0", opaque="5ccc069c403ebaf9f0171e9517f40e"';
+
+            handler.sign(authInterface, request, _.noop);
+            headers = request.headers.all();
+            authHeader = headers[0];
+
+            expect(headers).to.have.lengthOf(1);
+            expect(authHeader.toString()).to.eql(expectedHeader);
+            expect(authHeader.system).to.be.true;
+        });
+
+        it('should add the Auth header for (algorithm="SHA-256", qop="auth-int")', function () {
+            var clonedReqObj = _.merge({}, rawRequests.digest, {
+                    auth: {
+                        digest: {
+                            algorithm: 'SHA-256',
+                            qop: 'auth-int'
+                        }
+                    }
+                }),
+                request = new Request(clonedReqObj),
+                auth = request.auth,
+                authInterface = createAuthInterface(auth),
+                handler = AuthLoader.getHandler(auth.type),
+                headers,
+                authHeader,
+
+                // eslint-disable-next-line max-len
+                expectedHeader = 'Authorization: Digest username="postman", realm="Users", nonce="bcgEc5RPU1ANglyT2I0ShU0oxqPB5jXp", uri="/digest-auth", algorithm="SHA-256", qop=auth-int, nc=00000001, cnonce="0a4f113b", response="06ba0831e0043ddc784784a1915acfd6d58792ab8203edaff5082800f8d294a5", opaque="5ccc069c403ebaf9f0171e9517f40e"';
+
+            handler.sign(authInterface, request, _.noop);
+            headers = request.headers.all();
+            authHeader = headers[0];
+
+            expect(headers).to.have.lengthOf(1);
+            expect(authHeader.toString()).to.eql(expectedHeader);
+            expect(authHeader.system).to.be.true;
+        });
+
+        it('should add the Auth header for (algorithm="SHA-256-sess", qop="")', function () {
+            var clonedReqObj = _.merge({}, rawRequests.digest, {
+                    auth: {
+                        digest: {
+                            algorithm: 'SHA-256-sess'
+                        }
+                    }
+                }),
+                request = new Request(clonedReqObj),
+                auth = request.auth,
+                authInterface = createAuthInterface(auth),
+                handler = AuthLoader.getHandler(auth.type),
+                headers,
+                authHeader,
+
+                // eslint-disable-next-line max-len
+                expectedHeader = 'Authorization: Digest username="postman", realm="Users", nonce="bcgEc5RPU1ANglyT2I0ShU0oxqPB5jXp", uri="/digest-auth", algorithm="SHA-256-sess", response="0b4e18576fd9f4850dda49eab2a581a5f40bb50f6ecaa17ab4340cd416497e13", opaque="5ccc069c403ebaf9f0171e9517f40e"';
+
+            handler.sign(authInterface, request, _.noop);
+            headers = request.headers.all();
+            authHeader = headers[0];
+
+            expect(headers).to.have.lengthOf(1);
+            expect(authHeader.toString()).to.eql(expectedHeader);
+            expect(authHeader.system).to.be.true;
+        });
+
+        it('should add the Auth header for (algorithm="SHA-256-sess", qop="auth")', function () {
+            var clonedReqObj = _.merge({}, rawRequests.digest, {
+                    auth: {
+                        digest: {
+                            algorithm: 'SHA-256-sess',
+                            qop: 'auth'
+                        }
+                    }
+                }),
+                request = new Request(clonedReqObj),
+                auth = request.auth,
+                authInterface = createAuthInterface(auth),
+                handler = AuthLoader.getHandler(auth.type),
+                headers,
+                authHeader,
+
+                // eslint-disable-next-line max-len
+                expectedHeader = 'Authorization: Digest username="postman", realm="Users", nonce="bcgEc5RPU1ANglyT2I0ShU0oxqPB5jXp", uri="/digest-auth", algorithm="SHA-256-sess", qop=auth, nc=00000001, cnonce="0a4f113b", response="9388df8d879c3d988419aafca225ccc4626eb089192e992239b5595a532e243d", opaque="5ccc069c403ebaf9f0171e9517f40e"';
+
+            handler.sign(authInterface, request, _.noop);
+            headers = request.headers.all();
+            authHeader = headers[0];
+
+            expect(headers).to.have.lengthOf(1);
+            expect(authHeader.toString()).to.eql(expectedHeader);
+            expect(authHeader.system).to.be.true;
+        });
+
+        it('should add the Auth header for (algorithm="SHA-256-sess", qop="auth-int")', function () {
+            var clonedReqObj = _.merge({}, rawRequests.digest, {
+                    auth: {
+                        digest: {
+                            algorithm: 'SHA-256-sess',
+                            qop: 'auth-int'
+                        }
+                    }
+                }),
+                request = new Request(clonedReqObj),
+                auth = request.auth,
+                authInterface = createAuthInterface(auth),
+                handler = AuthLoader.getHandler(auth.type),
+                headers,
+                authHeader,
+
+                // eslint-disable-next-line max-len
+                expectedHeader = 'Authorization: Digest username="postman", realm="Users", nonce="bcgEc5RPU1ANglyT2I0ShU0oxqPB5jXp", uri="/digest-auth", algorithm="SHA-256-sess", qop=auth-int, nc=00000001, cnonce="0a4f113b", response="31ecccb1899773a8d2478e6f7042f3174485ce18949731e84c572a1dd48d1539", opaque="5ccc069c403ebaf9f0171e9517f40e"';
+
+            handler.sign(authInterface, request, _.noop);
+            headers = request.headers.all();
+            authHeader = headers[0];
+
+            expect(headers).to.have.lengthOf(1);
+            expect(authHeader.toString()).to.eql(expectedHeader);
+            expect(authHeader.system).to.be.true;
+        });
+
         it('should add the Auth header with query params in case of request with the same', function () {
             var request = new Request(rawRequests.digestWithQueryParams),
                 auth = request.auth,
@@ -373,6 +539,42 @@ describe('Auth Handler:', function () {
                 'algorithm="MD5", response="24dfb8851ee27e4b00252a13b1fd8ec3", opaque="5ccc069c403ebaf9f0171e9517f40e"';
 
             expect(authHeader.toString()).to.eql(expectedHeader);
+        });
+
+        it('should give error for unsupported algorithm', function () {
+            var request = new Request(_.merge({}, rawRequests.digest, {
+                    auth: {
+                        digest: {
+                            algorithm: 'Unknown algorithm'
+                        }
+                    }
+                })),
+                auth = request.auth,
+                authInterface = createAuthInterface(auth),
+                handler = AuthLoader.getHandler(auth.type);
+
+            handler.sign(authInterface, request, function (err) {
+                expect(err).to.be.ok;
+            });
+        });
+
+        it('should default to MD5 algorithm when not provided', function () {
+            var request = new Request(_.merge({}, rawRequests.digest, {
+                    auth: {
+                        digest: {
+                            algorithm: null
+                        }
+                    }
+                })),
+                auth = request.auth,
+                authInterface = createAuthInterface(auth),
+                handler = AuthLoader.getHandler(auth.type),
+                authHeader;
+
+            handler.sign(authInterface, request, _.noop);
+            authHeader = request.headers.one('Authorization');
+
+            expect(authHeader.toString()).to.include('algorithm="MD5"');
         });
 
         it('should bail out for invalid requests', function () {


### PR DESCRIPTION
- Added support for following algorithms in Digest auth
  1. SHA-256
  2. SHA-256-sess
  3. SHA-512-256
  4. SHA-512-256-sess
- Removed `crypto-js` form dependencies
- Added `js-sha512` dependency for SHA-512-256 algorithm

Issue: https://github.com/postmanlabs/postman-app-support/issues/5265