### PR TITLE
Fetch cookies on `Requester~dryRun` using the encoded URL object

### DIFF
--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -27,6 +27,8 @@ master:
     - >-
       GH-1041 Added support to include AWS auth data in query params using
       `addAuthDataToQuery` option
+  fixed bugs:
+    - GH-1045 Fetch cookies on `Requester~dryRun` using the encoded URL object
   chores:
     - Updated dependencies
 

--- a/lib/requester/dry-run.js
+++ b/lib/requester/dry-run.js
@@ -6,6 +6,7 @@
 const _ = require('lodash'),
     async = require('async'),
     mime = require('mime-types'),
+    urlEncoder = require('postman-url-encoder'),
     Request = require('postman-collection').Request,
     authorizeRequest = require('../authorizer').authorizeRequest,
     authHandlers = require('../authorizer').AuthLoader.handlers,
@@ -203,7 +204,8 @@ function setCookie (request, cookieJar, callback) {
         return callback(null, request);
     }
 
-    cookieJar.getCookieString(request.url.toString(true), function (err, cookies) {
+    // @note don't pass request.url instance to force re-parsing of the URL
+    cookieJar.getCookieString(urlEncoder.toNodeUrl(request.url.toString()), function (err, cookies) {
         if (err) {
             return callback(null, request);
         }


### PR DESCRIPTION
Fixes a [bug](https://github.com/postmanlabs/postman-app-support/issues/8348) where cookies are not previewed when URL is resolved from a variable.