### PR TITLE
Treat query params and body params as case sensitive in `dryRun()`

### DIFF
--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -29,6 +29,9 @@ master:
       `addAuthDataToQuery` option
   fixed bugs:
     - GH-1045 Fetch cookies on `Requester~dryRun` using the encoded URL object
+    - >-
+      GH-1046 Treat query params and urlencoded body params as case-sensitive
+      in `Requester~dryRun`
   chores:
     - Updated dependencies
 

--- a/lib/requester/dry-run.js
+++ b/lib/requester/dry-run.js
@@ -128,12 +128,19 @@ function setAuthorization (request, callback) {
         }
 
         manifest.updates.forEach(function (update) {
-            propertyKey = update.property.toLowerCase();
+            propertyKey = update.property;
 
             switch (update.type) {
-                case 'header': propertyList = headers; break;
-                case 'url.param': propertyList = queryParams; break;
-                case 'body.urlencoded': propertyList = bodyParams; break;
+                case 'header':
+                    propertyKey = propertyKey.toLowerCase();
+                    propertyList = headers;
+                    break;
+                case 'url.param':
+                    propertyList = queryParams;
+                    break;
+                case 'body.urlencoded':
+                    propertyList = bodyParams;
+                    break;
                 default: return;
             }
 


### PR DESCRIPTION
Only headers should be treated as case insensitive not the query params and urlencoded body params. This was causing problems for added query params by AWS auth helper because added params contain uppercase letters and SDK treats params as case-sensitive.

Discovered this as a part of https://github.com/postmanlabs/postman-runtime/pull/1041