### PR TITLE
Handle invalid private key errors in OAuth1 RSA signatures

### DIFF
--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -1,3 +1,7 @@
+master:
+  fixed bugs:
+    - GH-1050 Handle invalid private key errors in OAuth1 RSA signatures
+
 7.26.0:
   date: 2020-06-05
   new features:

--- a/lib/authorizer/oauth1.js
+++ b/lib/authorizer/oauth1.js
@@ -252,8 +252,9 @@ module.exports = {
      *
      * @param {Request} request - request to add oauth1 parameters
      * @param {Object} params - oauth data to generate signature
+     * @param {Function} done - callback function
      */
-    addAuthDataToRequest: function (request, params) {
+    addAuthDataToRequest: function (request, params, done) {
         var url = urlEncoder.toNodeUrl(request.url),
             signatureParams,
             urlencodedBody,
@@ -314,7 +315,14 @@ module.exports = {
             })
         };
 
-        signature = oAuth1.SignatureMethod.sign(message, accessor);
+        try {
+            signature = oAuth1.SignatureMethod.sign(message, accessor);
+        }
+        catch (err) {
+            // handle invalid private key errors for RSA signatures
+            return done(err);
+        }
+
         signatureParams.push({system: true, key: OAUTH1_PARAMS.oauthSignature, value: signature});
 
         // Add signature params to the request. The OAuth specification says
@@ -343,6 +351,8 @@ module.exports = {
         else {
             request.addQueryParams(signatureParams);
         }
+
+        done();
     },
 
     /**
@@ -420,16 +430,13 @@ module.exports = {
         // Don't include body hash as defined in specification
         // @see: https://tools.ietf.org/id/draft-eaton-oauth-bodyhash-00.html#when_to_include
         if (urlencodedBody || !(params.includeBodyHash && hashAlgo)) {
-            self.addAuthDataToRequest(request, params);
-
-            return done();
+            return self.addAuthDataToRequest(request, params, done);
         }
 
         computeBodyHash(request.body, hashAlgo, 'base64', function (bodyHash) {
             params.bodyHash = bodyHash;
-            self.addAuthDataToRequest(request, params);
 
-            return done();
+            return self.addAuthDataToRequest(request, params, done);
         });
     }
 };

--- a/test/unit/auth-handlers.test.js
+++ b/test/unit/auth-handlers.test.js
@@ -900,6 +900,24 @@ describe('Auth Handler:', function () {
             expect(request.headers.all()).to.be.an('array').that.is.empty;
         });
 
+        it('should pass invalid privateKey error in callback for RSA signature', function () {
+            var request = new Request(_(rawRequests.oauth1).omit(['header', 'auth.oauth1.consumerSecret']).merge({
+                    auth: {
+                        oauth1: {
+                            signatureMethod: 'RSA-SHA1',
+                            privateKey: 'invalid key'
+                        }
+                    }
+                }).value()),
+                auth = request.auth,
+                authInterface = createAuthInterface(auth),
+                handler = AuthLoader.getHandler(auth.type);
+
+            handler.sign(authInterface, request, function (err) {
+                expect(err).to.be.ok;
+            });
+        });
+
         it('should apply sensible defaults where applicable', function () {
             var rawReq = _(rawRequests.oauth1).omit(['auth.oauth1.nonce', 'auth.oauth1.timestamp']).merge({
                     url: {


### PR DESCRIPTION
OAuth1 throws error when selected algorithm is RSA and the given private key is invalid. This was causing problem in `dryRun()` method which is properly handled now.