### PR TITLE
Fixed body hash calculation in Digest auth

### DIFF
--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -1,6 +1,9 @@
 master:
   fixed bugs:
     - GH-1050 Handle invalid private key errors in OAuth1 RSA signatures
+    - >-
+      GH-1052 Fixed a bug where digest auth was not generating correct
+      Authorization header when `qop` field was set to `auth-int`
 
 7.26.0:
   date: 2020-06-05

--- a/lib/authorizer/digest.js
+++ b/lib/authorizer/digest.js
@@ -1,6 +1,8 @@
 var _ = require('lodash'),
     crypto = require('crypto'),
     urlEncoder = require('postman-url-encoder'),
+    RequestBody = require('postman-collection').RequestBody,
+    bodyBuilder = require('../requester/core-body-builder'),
 
     EMPTY = '',
     ONE = '00000001',
@@ -54,13 +56,46 @@ var _ = require('lodash'),
     qopRegex = /qop="([^"]*)"/,
     opaqueRegex = /opaque="([^"]*)"/,
     _extractField,
-    SHA512_256;
+    SHA512_256,
+    nodeCrypto;
 
 // Current Electron version(7.2.3) in Postman app uses OpenSSL 1.1.0
 // which don't support `SHA-512-256`. Use external `js-sha512` module
 // to handle this case.
 if (!_.includes(crypto.getHashes(), 'sha512-256')) {
     SHA512_256 = require('js-sha512').sha512_256;
+    nodeCrypto = crypto;
+
+    // create a wrapper class with similar interface to Node's crypto and use jsSHA
+    // to support SHA512-256 algorithm
+    crypto = function () {
+        this._hash = SHA512_256.create();
+    };
+
+    _.assign(crypto.prototype, {
+        update: function (data) {
+            this._hash.update(data);
+
+            return this;
+        },
+
+        digest: function () {
+            // we only need 'hex' digest for this auth
+            return this._hash.hex();
+        }
+    });
+
+    _.assign(crypto, {
+        createHash: function (hashAlgo) {
+            // return hash from js-sha for SHA512-256
+            if (hashAlgo === 'sha512-256') {
+                return new crypto();
+            }
+
+            // return Node's hash otherwise
+            return nodeCrypto.createHash(hashAlgo);
+        }
+    });
 }
 
 /**
@@ -117,11 +152,77 @@ function _getDigestAuthHeader (headers) {
  * @returns {String} hex encoded hash of given data
  */
 function getHash (data, algorithm) {
-    if (algorithm === 'sha512-256' && SHA512_256) {
-        return SHA512_256(data || EMPTY);
+    return crypto.createHash(algorithm).update(data || EMPTY).digest('hex');
+}
+
+/**
+ * Calculates body hash with given algorithm and digestEncoding.
+ *
+ * @param {RequestBody} body Request body
+ * @param {String} algorithm Hash algorithm to use
+ * @param {String} digestEncoding Encoding of the hash
+ * @param {Function} callback Callback function that will be called with body hash
+ */
+function computeBodyHash (body, algorithm, digestEncoding, callback) {
+    if (!(algorithm && digestEncoding)) { return callback(); }
+
+    var hash = crypto.createHash(algorithm),
+        originalReadStream,
+        rawBody,
+        graphqlBody,
+        urlencodedBody;
+
+    // if body is not available, return hash of empty string
+    if (!body || body.isEmpty()) {
+        return callback(hash.digest(digestEncoding));
     }
 
-    return crypto.createHash(algorithm).update(data || EMPTY).digest('hex');
+    if (body.mode === RequestBody.MODES.raw) {
+        rawBody = bodyBuilder.raw(body.raw).body;
+        hash.update(rawBody);
+
+        return callback(hash.digest(digestEncoding));
+    }
+
+    if (body.mode === RequestBody.MODES.urlencoded) {
+        urlencodedBody = bodyBuilder.urlencoded(body.urlencoded).form;
+        urlencodedBody = urlEncoder.encodeQueryString(urlencodedBody);
+        hash.update(urlencodedBody);
+
+        return callback(hash.digest(digestEncoding));
+    }
+
+    if (body.mode === RequestBody.MODES.file) {
+        originalReadStream = _.get(body, 'file.content');
+
+        if (!originalReadStream) {
+            return callback();
+        }
+
+        return originalReadStream.cloneReadStream(function (err, clonedStream) {
+            if (err) { return callback(); }
+
+            clonedStream.on('data', function (chunk) {
+                hash.update(chunk);
+            });
+
+            clonedStream.on('end', function () {
+                callback(hash.digest(digestEncoding));
+            });
+        });
+    }
+
+    if (body.mode === RequestBody.MODES.graphql) {
+        graphqlBody = bodyBuilder.graphql(body.graphql).body;
+        hash.update(graphqlBody);
+
+        return callback(hash.digest(digestEncoding));
+    }
+
+    // @todo: Figure out a way to calculate hash for formdata body type.
+
+    // ensure that callback is called if body.mode doesn't match with any of the above modes
+    return callback();
 }
 
 /**
@@ -256,6 +357,7 @@ module.exports = {
      */
     computeHeader: function (params) {
         var algorithm = params.algorithm,
+            hashAlgo = params.hashAlgo,
             username = params.username,
             realm = params.realm,
             password = params.password,
@@ -274,30 +376,8 @@ module.exports = {
             hashA1,
             hashA2,
 
-            hashAlgo,
             reqDigest,
             headerParams;
-
-        switch (algorithm) {
-            case ALGO.SHA_256:
-            case ALGO.SHA_256_SESS:
-                hashAlgo = 'sha256';
-                break;
-            case ALGO.MD5:
-            case ALGO.MD5_SESS:
-            case EMPTY:
-            case undefined:
-            case null:
-                algorithm = algorithm || ALGO.MD5;
-                hashAlgo = 'md5';
-                break;
-            case ALGO.SHA_512_256:
-            case ALGO.SHA_512_256_SESS:
-                hashAlgo = 'sha512-256';
-                break;
-            default:
-                throw new Error(`Unsupported digest algorithm: ${algorithm}`);
-        }
 
         if (_.endsWith(algorithm, SESS)) {
             A0 = getHash(username + COLON + realm + COLON + password, hashAlgo);
@@ -308,7 +388,7 @@ module.exports = {
         }
 
         if (qop === AUTH_INT) {
-            A2 = method + COLON + uri + COLON + getHash(params.body, hashAlgo);
+            A2 = method + COLON + uri + COLON + params.bodyhash;
         }
         else {
             A2 = method + COLON + uri;
@@ -354,9 +434,10 @@ module.exports = {
      * @param {AuthHandlerInterface~authSignHookCallback} done
      */
     sign: function (auth, request, done) {
-        var header,
+        var self = this,
             params = auth.get(AUTH_PARAMETERS),
-            url = urlEncoder.toNodeUrl(request.url);
+            url = urlEncoder.toNodeUrl(request.url),
+            header;
 
         if (!params.username || !params.realm) {
             return done(); // Nothing to do if required parameters are not present.
@@ -366,12 +447,45 @@ module.exports = {
 
         params.method = request.method;
         params.uri = url.path;
-        params.body = request.body && request.body.toString();
 
-        try {
-            header = this.computeHeader(params);
+        switch (params.algorithm) {
+            case ALGO.SHA_256:
+            case ALGO.SHA_256_SESS:
+                params.hashAlgo = 'sha256';
+                break;
+            case ALGO.MD5:
+            case ALGO.MD5_SESS:
+            case EMPTY:
+            case undefined:
+            case null:
+                params.algorithm = params.algorithm || ALGO.MD5;
+                params.hashAlgo = 'md5';
+                break;
+            case ALGO.SHA_512_256:
+            case ALGO.SHA_512_256_SESS:
+                params.hashAlgo = 'sha512-256';
+                break;
+            default:
+                return done(new Error(`Unsupported digest algorithm: ${params.algorithm}`));
         }
-        catch (e) { return done(e); }
+
+        // calculate body hash for qop='auth-int'
+        if (params.qop === AUTH_INT) {
+            return computeBodyHash(request.body, params.hashAlgo, 'hex', function (bodyhash) {
+                params.bodyhash = bodyhash;
+                header = self.computeHeader(params);
+
+                request.addHeader({
+                    key: AUTHORIZATION,
+                    value: header,
+                    system: true
+                });
+
+                return done();
+            });
+        }
+
+        header = self.computeHeader(params);
 
         request.addHeader({
             key: AUTHORIZATION,

--- a/test/unit/auth-handlers.test.js
+++ b/test/unit/auth-handlers.test.js
@@ -690,6 +690,110 @@ describe('Auth Handler:', function () {
             expect(authHeader.system).to.be.true;
         });
 
+        it('should add correct Auth header for request with raw body and (qop="auth-int")', function () {
+            var clonedReqObj = _.merge({}, rawRequests.digest, {
+                    auth: {
+                        digest: {
+                            algorithm: 'SHA-512-256',
+                            qop: 'auth-int'
+                        }
+                    },
+                    body: {
+                        mode: 'raw',
+                        raw: 'Hello Postman!!!'
+                    }
+                }),
+                request = new Request(clonedReqObj),
+                auth = request.auth,
+                authInterface = createAuthInterface(auth),
+                handler = AuthLoader.getHandler(auth.type),
+                headers,
+                authHeader,
+
+                // eslint-disable-next-line max-len
+                expectedHeader = 'Authorization: Digest username="postman", realm="Users", nonce="bcgEc5RPU1ANglyT2I0ShU0oxqPB5jXp", uri="/digest-auth", algorithm="SHA-512-256", qop=auth-int, nc=00000001, cnonce="0a4f113b", response="08af7d82b032a502331788f1e56e16337910c11a887b99c60abf86e9c26fab2a", opaque="5ccc069c403ebaf9f0171e9517f40e"';
+
+            handler.sign(authInterface, request, _.noop);
+            headers = request.headers.all();
+            authHeader = headers[0];
+
+            expect(headers).to.have.lengthOf(1);
+            expect(authHeader.toString()).to.eql(expectedHeader);
+            expect(authHeader.system).to.be.true;
+        });
+
+        it('should add correct Auth header for request with urlencoded body and (qop="auth-int")', function () {
+            var clonedReqObj = _.merge({}, rawRequests.digest, {
+                    auth: {
+                        digest: {
+                            algorithm: 'SHA-512-256',
+                            qop: 'auth-int'
+                        }
+                    },
+                    body: {
+                        mode: 'urlencoded',
+                        urlencoded: [
+                            {key: 'foo', value: 'bar'},
+                            {key: 'postman', value: '邮差'},
+                            {key: 'alpha', value: 'beta', disabled: true}
+                        ]
+                    }
+                }),
+                request = new Request(clonedReqObj),
+                auth = request.auth,
+                authInterface = createAuthInterface(auth),
+                handler = AuthLoader.getHandler(auth.type),
+                headers,
+                authHeader,
+
+                // eslint-disable-next-line max-len
+                expectedHeader = 'Authorization: Digest username="postman", realm="Users", nonce="bcgEc5RPU1ANglyT2I0ShU0oxqPB5jXp", uri="/digest-auth", algorithm="SHA-512-256", qop=auth-int, nc=00000001, cnonce="0a4f113b", response="cbfd61ad1bc2a4c9bb3d058e2b9b9d231e11501261c2115a8f23f787d296d6f4", opaque="5ccc069c403ebaf9f0171e9517f40e"';
+
+            handler.sign(authInterface, request, _.noop);
+            headers = request.headers.all();
+            authHeader = headers[0];
+
+            expect(headers).to.have.lengthOf(1);
+            expect(authHeader.toString()).to.eql(expectedHeader);
+            expect(authHeader.system).to.be.true;
+        });
+
+        it('should add correct Auth header for request with GraphQL body and (qop="auth-int")', function () {
+            var clonedReqObj = _.merge({}, rawRequests.digest, {
+                    auth: {
+                        digest: {
+                            algorithm: 'SHA-512-256',
+                            qop: 'auth-int'
+                        }
+                    },
+                    body: {
+                        mode: 'graphql',
+                        graphql: {
+                            query: 'query Test { hello }',
+                            operationName: 'Test',
+                            variables: '{"foo":"bar"}'
+                        }
+                    }
+                }),
+                request = new Request(clonedReqObj),
+                auth = request.auth,
+                authInterface = createAuthInterface(auth),
+                handler = AuthLoader.getHandler(auth.type),
+                headers,
+                authHeader,
+
+                // eslint-disable-next-line max-len
+                expectedHeader = 'Authorization: Digest username="postman", realm="Users", nonce="bcgEc5RPU1ANglyT2I0ShU0oxqPB5jXp", uri="/digest-auth", algorithm="SHA-512-256", qop=auth-int, nc=00000001, cnonce="0a4f113b", response="88f80bf9c08dd1250ae6fa848f48147aaebc0d56b7f41f04ccd8de4f217d0256", opaque="5ccc069c403ebaf9f0171e9517f40e"';
+
+            handler.sign(authInterface, request, _.noop);
+            headers = request.headers.all();
+            authHeader = headers[0];
+
+            expect(headers).to.have.lengthOf(1);
+            expect(authHeader.toString()).to.eql(expectedHeader);
+            expect(authHeader.system).to.be.true;
+        });
+
         it('should add the Auth header with query params in case of request with the same', function () {
             var request = new Request(rawRequests.digestWithQueryParams),
                 auth = request.auth,


### PR DESCRIPTION
Fixed a bug where digest auth was not generating correct Authorization header when `qop` field was set to `auth-int`. It was due to improper body hash calculation.