### PR TITLE
OAuth1 signature fix for empty callback and verifier fields

### DIFF
--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -1,3 +1,9 @@
+master:
+  fixed bugs:
+    - >-
+      GH-1063 Fixed a bug where OAuth1 helper was calculating wrong signature
+      when callback and verifier parameters are left empty
+
 7.26.3:
   date: 2020-07-30
   fixed bugs:

--- a/lib/authorizer/oauth1.js
+++ b/lib/authorizer/oauth1.js
@@ -276,13 +276,23 @@ module.exports = {
             {system: true, key: OAUTH1_PARAMS.oauthSignatureMethod, value: params.signatureMethod},
             {system: true, key: OAUTH1_PARAMS.oauthTimestamp, value: params.timestamp},
             {system: true, key: OAUTH1_PARAMS.oauthNonce, value: params.nonce},
-            {system: true, key: OAUTH1_PARAMS.oauthVersion, value: params.version},
-            {system: true, key: OAUTH1_PARAMS.oauthCallback, value: params.callback},
-            {system: true, key: OAUTH1_PARAMS.oauthVerifier, value: params.verifier}
+            {system: true, key: OAUTH1_PARAMS.oauthVersion, value: params.version}
         ];
 
+        // bodyHash, callback and verifier parameters are part of extensions of the original OAuth1 spec.
+        // So we only include those in signature if they are non-empty, ignoring the addEmptyParamsToSign setting.
+        // Otherwise it causes problem for servers that don't support the respective OAuth1 extensions.
+        // Issue: https://github.com/postmanlabs/postman-app-support/issues/8737
         if (params.bodyHash) {
             signatureParams.push({system: true, key: OAUTH1_PARAMS.oauthBodyHash, value: params.bodyHash});
+        }
+
+        if (params.callback) {
+            signatureParams.push({system: true, key: OAUTH1_PARAMS.oauthCallback, value: params.callback});
+        }
+
+        if (params.verifier) {
+            signatureParams.push({system: true, key: OAUTH1_PARAMS.oauthVerifier, value: params.verifier});
         }
 
         // filter empty signature parameters

--- a/test/unit/auth-handlers.test.js
+++ b/test/unit/auth-handlers.test.js
@@ -1305,6 +1305,70 @@ describe('Auth Handler:', function () {
             });
         });
 
+        // issue: https://github.com/postmanlabs/postman-app-support/issues/8737
+        it('should generate correct signature for empty callback and addEmptyParamsToSign:true', function () {
+            var rawReq = {
+                    url: 'https://postman-echo.com/oauth1',
+                    auth: {
+                        type: 'oauth1',
+                        oauth1: {
+                            consumerKey: 'RKCGzna7bv9YD57c',
+                            consumerSecret: 'D+EdQ-gs$-%@2Nu7',
+                            token: 'foo',
+                            tokenSecret: 'bar',
+                            signatureMethod: 'HMAC-SHA1',
+                            timestamp: '1461319769',
+                            nonce: 'ik3oT5',
+                            version: '1.0',
+                            verifier: 'bar',
+                            callback: '',
+                            addParamsToHeader: false,
+                            addEmptyParamsToSign: true
+                        }
+                    }
+                },
+                request = new Request(rawReq),
+                auth = request.auth,
+                authInterface = createAuthInterface(auth),
+                handler = AuthLoader.getHandler(auth.type);
+
+            handler.sign(authInterface, request, function () {
+                expect(request.url.query.get('oauth_signature')).to.eql('w8WS1SXfe/dtJu/4tH5DaD7qZgM=');
+            });
+        });
+
+        // issue: https://github.com/postmanlabs/postman-app-support/issues/8737
+        it('should generate correct signature for empty verifier and addEmptyParamsToSign:true', function () {
+            var rawReq = {
+                    url: 'https://postman-echo.com/oauth1',
+                    auth: {
+                        type: 'oauth1',
+                        oauth1: {
+                            consumerKey: 'RKCGzna7bv9YD57c',
+                            consumerSecret: 'D+EdQ-gs$-%@2Nu7',
+                            token: 'foo',
+                            tokenSecret: 'bar',
+                            signatureMethod: 'HMAC-SHA1',
+                            timestamp: '1461319769',
+                            nonce: 'ik3oT5',
+                            version: '1.0',
+                            verifier: '',
+                            callback: 'http://postman.com',
+                            addParamsToHeader: false,
+                            addEmptyParamsToSign: true
+                        }
+                    }
+                },
+                request = new Request(rawReq),
+                auth = request.auth,
+                authInterface = createAuthInterface(auth),
+                handler = AuthLoader.getHandler(auth.type);
+
+            handler.sign(authInterface, request, function () {
+                expect(request.url.query.get('oauth_signature')).to.eql('WO1RMBRLIM5Anfxxt8P7Kbt82b4=');
+            });
+        });
+
         it('should generate correct signature for RSA based signature method', function () {
             // eslint-disable-next-line max-len
             var privateKey = '-----BEGIN RSA PRIVATE KEY-----\nMIICWwIBAAKBgFKLvzM9zbm3I0+HWcHlBSqpfRY/bKs6NDLclERrzfnReFV4utjkhjaEQPPT6tHVHKrZkcxmIgwe3XrkJkUjcuingXIF+Fc3KpY61qJ4HSM50qIuHdi+C5YfuXwNrh6OOeZAhhqgSw2e2XqPfATbkYYwpIFpdVdcH/Pb2ynpd6VXAgMBAAECgYAbQE+LFyhH25Iou0KCpJ0kDHhjU+UIUlrRP8kjHYQOqXzUmtr0p903OkpHNPsc8wJX1SQxGra60aXE4HVR9fYFQNliAnSmA/ztGR4ddnirK1Gzog4y2OOkicTdSqJ/1XXtTEDSRkA0Z2DIqcWgudeSDzVjUpreYwQ/rCEZbi50AQJBAJcf9wi5bU8tdZUCg3/8MNDwHhr4If4V/9kmhsgNp+M/9tHwCbD05hCbiGS7g58DPF+6V2K30qQYq7yvBP8Te4ECQQCL1GhX/YwkD6rexi0E1bjz+RqhNLTR9kexkTfSYmL6zHeeIFSH8ROioGOJMU51lUtMNkkrKEeki5SZpkfaQOzXAkAvBnJPU6vQ7HtfH8YdiDMEgQNNLxMcxmmzf4qHK8CnNRsvnnrVho8kcdFSTwsY6t/Zhdl1TXANQeQGtYtfeAeBAkEAhUB351JSWJMtrHqCsFbTmHxNKk7F+kiObeMLpUvpM0PiwifhJmNQ6Oubr0Pzlw4c4ZXiCGSsUVxK0lmpo423pQJATYDoxVhZrKA3xDAifWoyxbyxf/WXtUGDaAOuZc/naVN5TKiqaEO6G+k3NpmOXNKsYU/Zd9e6P/TnfU74TyDDDA==\n-----END RSA PRIVATE KEY-----',


### PR DESCRIPTION
Don't include empty callback and verifier fields in the OAuth1 signature calculation. It creates invalid signature problem for servers that don't support those parameters.

Issue: https://github.com/postmanlabs/postman-app-support/issues/8737