### PR TITLE
Include request body of multipart/form-data requests into AWS4 signature

### DIFF
--- a/lib/authorizer/aws4.js
+++ b/lib/authorizer/aws4.js
@@ -71,9 +71,16 @@ var _ = require('lodash'),
             return callback(hash.digest(digestEncoding));
         }
 
-        // @todo: formdata body type requires adding new data to form instead of setting headers for AWS auth.
+        // @todo: formdata body type for S3 requires adding new data to form instead of setting headers for AWS auth.
         //        Figure out how to do that. See below link:
         //        AWS auth with formdata: https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-post-example.html
+        //        For now, sign requests as other POST requests for use with API gateway and Lambda functions.
+        if (body.mode === RequestBody.MODES.formdata) {
+            formdataBody = bodyBuilder.formdata(body.formdata).body;
+            hash.update(formdataBody);
+
+            return callback(hash.digest(digestEncoding));
+        }
 
         // ensure that callback is called if body.mode doesn't match with any of the above modes
         return callback();


### PR DESCRIPTION
Context: I'm using Postman to test API endpoints that are located on API Gateway (and backed by Lambda functions) with request authentication by AWS signature. And everything works great except one request that uses `multipart/form-data` to upload file along with some metadata in single request.

Exploring source code I noticed that request body hashing is skipped for form data requests in the assumption that it is only used to do uploads directly to S3. But in my case, I want to post form data to API gateway with authentication. Maybe it is better to implement signature in the same way as for raw body type to cover at least this use case?

Should fix https://github.com/postmanlabs/postman-app-support/issues/8180

However, I'm not sure whether this pull request really fixes my problem as I don't know how to run Postman with my own runtime. Any links or guidance on how to do it is highly appreciated!