### PR TITLE
Added a new requester config to add custom system headers

### DIFF
--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -1,3 +1,6 @@
+master:
+  new features:
+    - GH-1128 Added new requester option to add user defined system headers
 7.26.10:
   date: 2021-01-03
   chores:

--- a/README.md
+++ b/README.md
@@ -122,6 +122,9 @@ runner.run(collection, {
         // Implicitly add `Postman-Token` system header in request (only supported on Node, ignored in the browser)
         implicitTraceHeader: true,
 
+        // Add system headers to all requests which cannot be overridden or disabled
+        systemHeaders: { 'User-Agent': 'PostmanRuntime' }
+
         // Extend well known "root" CAs with the extra certificates in file. The file should consist of one or more trusted certificates in PEM format. (only supported on Node, ignored in the browser)
         extendedRootCA: 'path/to/extra/CA/certs.pem',
 

--- a/lib/requester/core.js
+++ b/lib/requester/core.js
@@ -130,6 +130,7 @@ var dns = require('dns'),
     /**
      * Add static system headers if they are not disable using `disabledSystemHeaders`
      * protocol profile behavior.
+     * Add the system headers provided as requester configuration.
      *
      * @note Don't traverse the user provided `disabledSystemHeaders` object
      * to ensure runtime allowed headers and also for security reasons.
@@ -138,8 +139,9 @@ var dns = require('dns'),
      * @param {Request} request
      * @param {Object} options
      * @param {Object} disabledHeaders
+     * @param {Object} systemHeaders
      */
-    addSystemHeaders = function (request, options, disabledHeaders) {
+    addSystemHeaders = function (request, options, disabledHeaders, systemHeaders) {
         var key,
             headers = request.headers;
 
@@ -164,6 +166,17 @@ var dns = require('dns'),
                     system: true
                 });
         });
+
+        for (key in systemHeaders) {
+            if (systemHeaders.hasOwnProperty(key)) {
+                // upsert instead of add to replace user-defined headers also
+                headers.upsert({
+                    key: key,
+                    value: systemHeaders[key],
+                    system: true
+                });
+            }
+        }
     },
 
     /**
@@ -370,6 +383,8 @@ module.exports = {
             useWhatWGUrlParser = defaultOpts.useWhatWGUrlParser,
             disableUrlEncoding = protocolProfileBehavior.disableUrlEncoding,
             disabledSystemHeaders = protocolProfileBehavior.disabledSystemHeaders || {},
+            // the system headers provided in requester configuration
+            systemHeaders = defaultOpts.systemHeaders || {},
             url = useWhatWGUrlParser ? urlEncoder.toNodeUrl(request.url, disableUrlEncoding) :
                 urlEncoder.toLegacyNodeUrl(request.url.toString(true)),
             isSSL = _.startsWith(url.protocol, HTTPS),
@@ -462,7 +477,8 @@ module.exports = {
         !defaultOpts.implicitTraceHeader && (disabledSystemHeaders['postman-token'] = true);
 
         // Add additional system headers to the request instance
-        addSystemHeaders(request, options, disabledSystemHeaders);
+        addSystemHeaders(request, options, disabledSystemHeaders, systemHeaders);
+
 
         // Don't add `Host` header if disabled using disabledSystemHeaders
         // @note This can't be part of `blacklistHeaders` option as `setHost` is

--- a/lib/requester/requester-pool.js
+++ b/lib/requester/requester-pool.js
@@ -31,6 +31,7 @@ RequesterPool = function (options, callback) {
         maxRedirects: _.get(options, 'requester.maxRedirects'),
         implicitCacheControl: _.get(options, 'requester.implicitCacheControl', true),
         implicitTraceHeader: _.get(options, 'requester.implicitTraceHeader', true),
+        systemHeaders: _.get(options, 'requester.systemHeaders', {}),
         removeRefererHeaderOnRedirect: _.get(options, 'requester.removeRefererHeaderOnRedirect'),
         ignoreProxyEnvironmentVariables: _.get(options, 'ignoreProxyEnvironmentVariables'),
         network: _.get(options, 'network', {})

--- a/test/integration/requester-spec/systemHeaders.test.js
+++ b/test/integration/requester-spec/systemHeaders.test.js
@@ -1,0 +1,230 @@
+var expect = require('chai').expect;
+
+describe('Requester Spec: systemHeaders', function () {
+    var testrun;
+
+    describe('sanity', function () {
+        before(function (done) {
+            this.run({
+                requester: {
+                    systemHeaders: {'foo': 'Bar'}
+                },
+                collection: {
+                    item: [{
+                        request: {
+                            url: 'https://postman-echo.com/get',
+                            method: 'GET'
+                        }
+                    }]
+                }
+            }, function (err, results) {
+                testrun = results;
+                done(err);
+            });
+        });
+
+        it('should complete the run', function () {
+            expect(testrun).to.be.ok;
+            expect(testrun).to.nested.include({
+                'done.calledOnce': true,
+                'start.calledOnce': true,
+                'request.calledOnce': true
+            });
+            expect(testrun.done.getCall(0).calledWith(null)).to.be.true;
+        });
+
+        it('should add the system headers', function () {
+            var request = testrun.request.getCall(0).args[3],
+                headers = request.headers.filter((header) => {
+                    return header.key === 'foo';
+                }),
+                response = testrun.request.getCall(0).args[2],
+                body = response.json();
+
+            expect(headers.length).to.equal(1);
+            expect(headers[0].value).to.equal('Bar');
+            expect(headers[0].system).to.equal(true);
+
+            expect(body.headers).to.have.property('foo', 'Bar');
+        });
+    });
+
+    describe('with user defined headers', function () {
+        before(function (done) {
+            this.run({
+                requester: {
+                    systemHeaders: {'foo': 'Bar'}
+                },
+                collection: {
+                    item: [{
+                        request: {
+                            url: 'https://postman-echo.com/get',
+                            method: 'GET',
+                            header: [{
+                                key: 'foo',
+                                value: 'something/else'
+                            }]
+                        }
+                    }]
+                }
+            }, function (err, results) {
+                testrun = results;
+                done(err);
+            });
+        });
+
+        it('should complete the run', function () {
+            expect(testrun).to.be.ok;
+            expect(testrun).to.nested.include({
+                'done.calledOnce': true,
+                'start.calledOnce': true,
+                'request.calledOnce': true
+            });
+            expect(testrun.done.getCall(0).calledWith(null)).to.be.true;
+        });
+
+        it('should add the system headers instead of user defined headers', function () {
+            var request = testrun.request.getCall(0).args[3],
+                headers = request.headers.filter((header) => {
+                    return header.key === 'foo';
+                }),
+                response = testrun.request.getCall(0).args[2],
+                body = response.json();
+
+            expect(headers.length).to.equal(1);
+            expect(headers[0].value).to.equal('Bar');
+            expect(headers[0].system).to.equal(true);
+
+            expect(body.headers).to.have.property('foo', 'Bar');
+        });
+    });
+
+    describe('with disabledSystemHeaders', function () {
+        before(function (done) {
+            this.run({
+                requester: {
+                    systemHeaders: {'foo': 'Bar'}
+                },
+                collection: {
+                    item: [{
+                        request: {
+                            url: 'https://postman-echo.com/get',
+                            method: 'GET'
+                        },
+                        protocolProfileBehavior: {
+                            disabledSystemHeaders: {
+                                'foo': true
+                            }
+                        }
+                    }]
+                }
+            }, function (err, results) {
+                testrun = results;
+                done(err);
+            });
+        });
+
+        it('should complete the run', function () {
+            expect(testrun).to.be.ok;
+            expect(testrun).to.nested.include({
+                'done.calledOnce': true,
+                'start.calledOnce': true,
+                'request.calledOnce': true
+            });
+            expect(testrun.done.getCall(0).calledWith(null)).to.be.true;
+        });
+
+        it('should add the system headers', function () {
+            var request = testrun.request.getCall(0).args[3],
+                headers = request.headers.filter((header) => {
+                    return header.key === 'foo';
+                }),
+                response = testrun.request.getCall(0).args[2],
+                body = response.json();
+
+            expect(headers.length).to.equal(1);
+            expect(headers[0].value).to.equal('Bar');
+            expect(headers[0].system).to.equal(true);
+
+            expect(body.headers).to.have.property('foo', 'Bar');
+        });
+    });
+
+    describe('with pm.sendRequest', function () {
+        before(function (done) {
+            this.run({
+                requester: {
+                    systemHeaders: {'foo': 'Bar'}
+                },
+                collection: {
+                    item: [{
+                        request: 'https://www.postman-echo.com/get',
+                        event: [{
+                            listen: 'test',
+                            script: {
+                                type: 'text/javascript',
+                                exec: `
+                                pm.sendRequest('https://postman-echo.com/GET', function (err, res) {
+                                    pm.test("Status code is 200", function () {
+                                        pm.expect(res).to.have.status(200);
+                                    });
+                                    pm.test("Has system headers", function () {
+                                        pm.expect(pm.request.headers.get('foo')).to.eql('Bar');
+                                    });
+                                });
+                                `
+                            }
+                        }]
+                    }]
+                }
+            }, function (err, results) {
+                testrun = results;
+                done(err);
+            });
+        });
+
+        it('should complete the run', function () {
+            expect(testrun).to.be.ok;
+            expect(testrun).to.nested.include({
+                'done.calledOnce': true,
+                'start.calledOnce': true,
+                'request.calledTwice': true
+            });
+        });
+
+        it('should add the system headers to request sent by script', function () {
+            var request = testrun.request.getCall(1).args[3],
+                headers = request.headers.filter((header) => {
+                    return header.key === 'foo';
+                }),
+                response = testrun.request.getCall(1).args[2],
+                body = response.json();
+
+            expect(headers.length).to.equal(1);
+            expect(headers[0].value).to.equal('Bar');
+            expect(headers[0].system).to.equal(true);
+
+            expect(body.headers).to.have.property('foo', 'Bar');
+        });
+
+        it('should successfully run the test script to check system headers', function () {
+            expect(testrun).to.nested.include({
+                'script.calledOnce': true,
+                'test.calledOnce': true,
+                'assertion.calledTwice': true
+            });
+            expect(testrun.script.getCall(0).calledWith(null)).to.be.true;
+            expect(testrun.test.getCall(0).calledWith(null)).to.be.true;
+
+            expect(testrun.assertion.getCall(0).args[1][0]).to.include({
+                name: 'Status code is 200',
+                passed: true
+            });
+
+            expect(testrun.assertion.getCall(1).args[1][0]).to.include({
+                name: 'Has system headers',
+                passed: true
+            });
+        });
+    });
+});


### PR DESCRIPTION
new config: `systemHeaders` (part of `requester`)
These headers cannot be disabled or overridden and are added with `system` flag set to true.

Code changes:
Added a new function `addCustomSystemHeaders` which is called from `getRequestOptions()`. This function adds all the headers to `request.headers` object and updates any header if it is already present.