### PR TITLE
Updated history object to include headers

### DIFF
--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -1,7 +1,7 @@
 master:
   new features:
     - >-
-      GH-1143 Updated request headers to match actual headers on redirects
+      GH-1143 Updated history object to include headers
 
 7.27.0:
   date: 2021-03-24

--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -1,6 +1,7 @@
 master:
   new features:
-    - GH-1143 Stopped adding extra headers to first request in redirects
+    - >-
+      GH-1143 Updated request headers to match actual headers on redirects
 
 7.27.0:
   date: 2021-03-24

--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -1,3 +1,7 @@
+master:
+  new features:
+    - GH-1143 Stopped adding extra headers to first request in redirects
+
 7.27.0:
   date: 2021-03-24
   new features:

--- a/docs/history.md
+++ b/docs/history.md
@@ -114,14 +114,14 @@ The history object has the following top-level properties:
     - **request** `<Object>` The information of the request sent.
         - *method* `<String>` Request method. For example, `GET`, `POST`.
         - *href* `<String>` Request URL.
-        - *headers* `<Object>` Request headers.
+        - *headers* `<Array>` Array of request headers in form [ {key: 'agent', value: 'postman'} ].
         - *proxy* `<Object>` Request Proxy details if enabled.
             - *href* `<String>` Proxy URL.
         - *httpVersion* `<String>` Request HTTP Version. For example, `1.1`
     - **response** `<Object>` The response of the request.
       - *statusCode* `<Number>` Response status code.
       - *httpVersion* `<String>` Response HTTP Version.
-      - *headers* `<Object>` Response headers.
+      - *headers* `<Array>` Array of request headers in form [ {key: 'agent', value: 'postman'} ].
     - **session** `<Object>` Session used by this request connection (referred in `sessions`).
       - *id* `<String>` Unique session ID (UUID).
       - *reused* `<Boolean>` Is session reused (persistent connection connection).

--- a/docs/history.md
+++ b/docs/history.md
@@ -121,7 +121,7 @@ The history object has the following top-level properties:
     - **response** `<Object>` The response of the request.
       - *statusCode* `<Number>` Response status code.
       - *httpVersion* `<String>` Response HTTP Version.
-      - *headers* `<Array>` Array of request headers in form [ {key: 'agent', value: 'postman'} ].
+      - *headers* `<Array>` Array of response headers in form [ {key: 'agent', value: 'postman'} ].
     - **session** `<Object>` Session used by this request connection (referred in `sessions`).
       - *id* `<String>` Unique session ID (UUID).
       - *reused* `<Boolean>` Is session reused (persistent connection connection).

--- a/lib/requester/browser/request.js
+++ b/lib/requester/browser/request.js
@@ -399,14 +399,42 @@ function run_xhr(XHR, originalRequest, options) {
 
         // Construct postman-request compatible debug object
         !xhr.request && (xhr.request = {});
+        var requestHeaders = originalRequest.headers.reduce((acc, header)=>{
+                acc.push({key: header.key, value: header.value});
+                return acc;
+            }, [])
+
+        // return the response headers into [{key: headername, value: headervalue}] form
+        function getResponseHeaders (xhr) {
+            var headerString = xhr.getAllResponseHeaders(),
+                arr = headerString.split('\r\n'),
+                acc = []
+
+            // last element is empty string therefore ignoring it
+            for (var i = 0; i < arr.length - 1; i++) {
+              // header name cannot have a ':' but header value allows it
+              // therefore we split on the index of the first ':'
+              var splitIndex = arr[i].indexOf(':')
+
+              acc.push({
+                key: arr[i].slice(0, splitIndex),
+                value: arr[i].slice(splitIndex + 2)
+              })
+            }
+
+            return acc
+        }
+
         xhr.request._debug = xhr._debugData || [{
             request: {
                 method: options.method,
                 href: options.uri,
+                headers: requestHeaders,
                 httpVersion: '1.1'
             },
             response: {
                 statusCode: xhr.statusCode,
+                headers: getResponseHeaders(xhr),
                 httpVersion: '1.1'
             }
         }];

--- a/lib/requester/browser/request.js
+++ b/lib/requester/browser/request.js
@@ -399,47 +399,17 @@ function run_xhr(XHR, originalRequest, options) {
 
         // Construct postman-request compatible debug object
         !xhr.request && (xhr.request = {});
-        var requestHeaders = originalRequest.headers.reduce((acc, header)=>{
-                acc.push({key: header.key, value: header.value})
-                return acc
-            }, [])
-
-        // return the response headers into [{key: headername, value: headervalue}] form
-        function getResponseHeaders (xhr) {
-
-            // to support multiple agents
-            if (!(typeof xhr.getAllResponseHeaders === 'function')){
-                return []
-            }
-            var headerString = xhr.getAllResponseHeaders(),
-                arr = headerString.split('\r\n'),
-                acc = []
-
-            // last element is empty string therefore ignoring it
-            for (var i = 0; i < arr.length - 1; i++) {
-              // header name cannot have a ':' but header value allows it
-              // therefore we split on the index of the first ':'
-              var splitIndex = arr[i].indexOf(':')
-
-              acc.push({
-                key: arr[i].slice(0, splitIndex),
-                value: arr[i].slice(splitIndex + 2)
-              })
-            }
-
-            return acc
-        }
 
         xhr.request._debug = xhr._debugData || [{
             request: {
                 method: options.method,
                 href: options.uri,
-                headers: requestHeaders,
+                headers: originalRequest.headers.toJSON(),
                 httpVersion: '1.1'
             },
             response: {
                 statusCode: xhr.statusCode,
-                headers: getResponseHeaders(xhr),
+                headers: parseHeadersString(xhr.getAllResponseHeaders()),
                 httpVersion: '1.1'
             }
         }];

--- a/lib/requester/browser/request.js
+++ b/lib/requester/browser/request.js
@@ -400,12 +400,17 @@ function run_xhr(XHR, originalRequest, options) {
         // Construct postman-request compatible debug object
         !xhr.request && (xhr.request = {});
         var requestHeaders = originalRequest.headers.reduce((acc, header)=>{
-                acc.push({key: header.key, value: header.value});
-                return acc;
+                acc.push({key: header.key, value: header.value})
+                return acc
             }, [])
 
         // return the response headers into [{key: headername, value: headervalue}] form
         function getResponseHeaders (xhr) {
+
+            // to support multiple agents
+            if (!(typeof xhr.getAllResponseHeaders === 'function')){
+                return []
+            }
             var headerString = xhr.getAllResponseHeaders(),
                 arr = headerString.split('\r\n'),
                 acc = []

--- a/lib/requester/requester.js
+++ b/lib/requester/requester.js
@@ -229,15 +229,18 @@ _.assign(Requester.prototype, /** @lends Requester.prototype */ {
              */
             addMissingRequestHeaders = function (headers) {
                 _.forEach(headers, function (header) {
-                    // update headers which gets overwritten by the requester
-                    if (OVERWRITTEN_HEADERS[header.key.toLowerCase()]) {
-                        let lowerCasedKey = header.key.toLowerCase();
+                    var lowerCasedKey = header.key.toLowerCase();
 
+                    // update headers which gets overwritten by the requester
+                    if (OVERWRITTEN_HEADERS[lowerCasedKey]) {
                         // in case of duplicate headers, remove all the duplicates
                         // just keep the last item in the list.
                         if (Array.isArray(_.get(request.headers, ['reference', lowerCasedKey]))) {
+                            // eslint-disable-next-line one-var
+                            var lastHeader = request.headers.one(header.key);
+
                             request.headers.remove(function (h) {
-                                return _.lowerCase(h.key) === lowerCasedKey && h !== header;
+                                return _.lowerCase(h.key) === lowerCasedKey && h !== lastHeader;
                             });
                         }
 

--- a/lib/requester/requester.js
+++ b/lib/requester/requester.js
@@ -233,15 +233,8 @@ _.assign(Requester.prototype, /** @lends Requester.prototype */ {
 
                     // update headers which gets overwritten by the requester
                     if (OVERWRITTEN_HEADERS[lowerCasedKey]) {
-                        // in case of duplicate headers, remove all the duplicates
-                        // just keep the last item in the list.
                         if (Array.isArray(_.get(request.headers, ['reference', lowerCasedKey]))) {
-                            // eslint-disable-next-line one-var
-                            var lastHeader = request.headers.one(header.key);
-
-                            request.headers.remove(function (h) {
-                                return _.lowerCase(h.key) === lowerCasedKey && h !== lastHeader;
-                            });
+                            request.headers.remove('Cookie');
                         }
 
                         request.headers.upsert({

--- a/lib/requester/requester.js
+++ b/lib/requester/requester.js
@@ -228,7 +228,7 @@ _.assign(Requester.prototype, /** @lends Requester.prototype */ {
              * @param {Object[]} headers
              */
             addMissingRequestHeaders = function (headers) {
-                _.forEach(headers, (header) => {
+                _.forEach(headers, function (header) {
                     // update headers which gets overwritten by the requester
                     if (OVERWRITTEN_HEADERS[header.key.toLowerCase()]) {
                         let lowerCasedKey = header.key.toLowerCase();
@@ -343,11 +343,12 @@ _.assign(Requester.prototype, /** @lends Requester.prototype */ {
                     header: responseHeaders
                 });
 
-                // add missing request headers so that they get bubbled up into the UI
-                addMissingRequestHeaders(_.get(response, 'request._debug[0].request.headers'));
-
                 // prepare history from request debug data
                 history = getExecutionHistory(_.get(response, 'request._debug'));
+
+                // add missing request headers so that they get bubbled up into the UI
+
+                addMissingRequestHeaders(_.get(history, 'execution.data[0].request.headers'));
 
                 // Pull out cookies from the cookie jar, and make them chrome compatible.
                 if (cookieJar && _.isFunction(cookieJar.getCookies)) {

--- a/lib/requester/requester.js
+++ b/lib/requester/requester.js
@@ -24,6 +24,7 @@ var _ = require('lodash'),
      */
     OVERWRITTEN_HEADERS = {
         cookie: true, // cookies get appended with `;`
+        'content-length': true
     },
 
     /**
@@ -230,6 +231,16 @@ _.assign(Requester.prototype, /** @lends Requester.prototype */ {
                 _.forEach(headers, (header) => {
                     // update cookie header which gets overwritten by the requester
                     if (OVERWRITTEN_HEADERS[header.key.toLowerCase()]) {
+                        let lowerCasedKey = header.key.toLowerCase();
+
+                        // in case of duplicate headers, remove all the duplicates
+                        // just keep the last item in the list.
+                        if (Array.isArray(_.get(request.headers, ['reference', lowerCasedKey]))) {
+                            request.headers.remove(function (h) {
+                                return _.lowerCase(h.key) === lowerCasedKey && h !== header;
+                            });
+                        }
+
                         request.headers.upsert({
                             key: header.key,
                             value: header.value,

--- a/lib/requester/requester.js
+++ b/lib/requester/requester.js
@@ -347,7 +347,6 @@ _.assign(Requester.prototype, /** @lends Requester.prototype */ {
                 history = getExecutionHistory(_.get(response, 'request._debug'));
 
                 // add missing request headers so that they get bubbled up into the UI
-
                 addMissingRequestHeaders(_.get(history, 'execution.data[0].request.headers'));
 
                 // Pull out cookies from the cookie jar, and make them chrome compatible.

--- a/lib/requester/requester.js
+++ b/lib/requester/requester.js
@@ -229,7 +229,7 @@ _.assign(Requester.prototype, /** @lends Requester.prototype */ {
              */
             addMissingRequestHeaders = function (headers) {
                 _.forEach(headers, (header) => {
-                    // update cookie header which gets overwritten by the requester
+                    // update headers which gets overwritten by the requester
                     if (OVERWRITTEN_HEADERS[header.key.toLowerCase()]) {
                         let lowerCasedKey = header.key.toLowerCase();
 

--- a/lib/requester/requester.js
+++ b/lib/requester/requester.js
@@ -24,7 +24,6 @@ var _ = require('lodash'),
      */
     OVERWRITTEN_HEADERS = {
         cookie: true, // cookies get appended with `;`
-        referer: true // referer gets updated on redirects
     },
 
     /**
@@ -228,48 +227,15 @@ _.assign(Requester.prototype, /** @lends Requester.prototype */ {
              * @param {Object[]} headers
              */
             addMissingRequestHeaders = function (headers) {
-                var header,
-                    lowerCasedKey;
-
-                _.forOwn(headers, function (value, key) {
-                    // @todo handle disabled headers
-                    header = request.headers.one(key);
-                    lowerCasedKey = _.lowerCase(key);
-
-                    // neither request nor runtime overwrites user-defined headers
-                    // so instead of upsert, just add missing headers to the list
-                    // with system: true flag.
-                    if (!header || header.disabled) {
-                        request.headers.add({
-                            key: key,
-                            value: value,
+                _.forEach(headers, (header) => {
+                    // update cookie header which gets overwritten by the requester
+                    if (OVERWRITTEN_HEADERS[header.key.toLowerCase()]) {
+                        request.headers.upsert({
+                            key: header.key,
+                            value: header.value,
                             system: true
                         });
-
-                        return;
                     }
-
-                    // bail out if
-                    // 1. header is not one of overwritten headers
-                    // 2. overwritten header value is not updated
-                    if (!(OVERWRITTEN_HEADERS[lowerCasedKey] && value !== header.value)) {
-                        return;
-                    }
-
-                    // in case of duplicate headers, remove all the duplicates
-                    // just keep the last item in the list.
-                    if (Array.isArray(_.get(request.headers, ['reference', lowerCasedKey]))) {
-                        request.headers.remove(function (h) {
-                            return _.lowerCase(h.key) === lowerCasedKey && h !== header;
-                        });
-                    }
-
-                    // update headers which gets overwritten by the requester
-                    header.update({
-                        key: key,
-                        value: value,
-                        system: true
-                    });
                 });
             },
 
@@ -367,11 +333,7 @@ _.assign(Requester.prototype, /** @lends Requester.prototype */ {
                 });
 
                 // add missing request headers so that they get bubbled up into the UI
-                // add the headers only if no redirect was followed,
-                // else response object contains headers of last request
-                if (_.get(response, 'request._redirect.redirectsFollowed') === 0) {
-                    addMissingRequestHeaders(responseJSON.request && responseJSON.request.headers);
-                }
+                addMissingRequestHeaders(_.get(response, 'request._debug[0].request.headers'));
 
                 // prepare history from request debug data
                 history = getExecutionHistory(_.get(response, 'request._debug'));

--- a/lib/requester/requester.js
+++ b/lib/requester/requester.js
@@ -367,7 +367,11 @@ _.assign(Requester.prototype, /** @lends Requester.prototype */ {
                 });
 
                 // add missing request headers so that they get bubbled up into the UI
-                addMissingRequestHeaders(responseJSON.request && responseJSON.request.headers);
+                // add the headers only if no redirect was followed,
+                // else response object contains headers of last request
+                if (_.get(response, 'request._redirect.redirectsFollowed') === 0) {
+                    addMissingRequestHeaders(responseJSON.request && responseJSON.request.headers);
+                }
 
                 // prepare history from request debug data
                 history = getExecutionHistory(_.get(response, 'request._debug'));

--- a/lib/requester/requester.js
+++ b/lib/requester/requester.js
@@ -234,7 +234,7 @@ _.assign(Requester.prototype, /** @lends Requester.prototype */ {
                     // update headers which gets overwritten by the requester
                     if (OVERWRITTEN_HEADERS[lowerCasedKey]) {
                         if (Array.isArray(_.get(request.headers, ['reference', lowerCasedKey]))) {
-                            request.headers.remove('Cookie');
+                            request.headers.remove(header.key);
                         }
 
                         request.headers.upsert({

--- a/package-lock.json
+++ b/package-lock.json
@@ -6026,9 +6026,9 @@
       "dev": true
     },
     "postman-request": {
-      "version": "2.88.1-postman.29",
-      "resolved": "https://registry.npmjs.org/postman-request/-/postman-request-2.88.1-postman.29.tgz",
-      "integrity": "sha512-QuL3+AvGlmPLb1Qf0t/rM8M4U8LCYbADZBijUNToLl6l37i65KH8wY1gTLWLxlw2I6ugxUfX2Zyyk5/J5HFZIg==",
+      "version": "2.88.1-postman.30",
+      "resolved": "https://registry.npmjs.org/postman-request/-/postman-request-2.88.1-postman.30.tgz",
+      "integrity": "sha512-zsGvs8OgNeno1Q44zTgGP2IL7kCqUy4DAtl8/ms0AQpqkIoysrxzR/Zg4kM1Kz8/duBvwxt8NN717wB7SMNm6w==",
       "requires": {
         "@postman/form-data": "~3.1.1",
         "@postman/tunnel-agent": "^0.6.3",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "node-oauth1": "1.3.0",
     "performance-now": "2.1.0",
     "postman-collection": "3.6.10",
-    "postman-request": "2.88.1-postman.29",
+    "postman-request": "2.88.1-postman.30",
     "postman-sandbox": "4.0.2",
     "postman-url-encoder": "3.0.1",
     "resolve-from": "5.0.0",

--- a/test/integration/request-flow/headers.test.js
+++ b/test/integration/request-flow/headers.test.js
@@ -4,7 +4,7 @@ var sinon = require('sinon'),
     Header = require('postman-collection').Header,
     cookieJar = require('postman-request').jar();
 
-(typeof window === 'undefined' ? describe.only : describe.skip)('request headers', function () {
+(typeof window === 'undefined' ? describe : describe.skip)('request headers', function () {
     var testrun,
         HEADERS_URL,
         COOKIES_URL;

--- a/test/integration/request-flow/headers.test.js
+++ b/test/integration/request-flow/headers.test.js
@@ -1,5 +1,6 @@
 var sinon = require('sinon'),
     expect = require('chai').expect,
+    fs = require('fs'),
     Header = require('postman-collection').Header,
     cookieJar = require('postman-request').jar();
 
@@ -20,6 +21,7 @@ var sinon = require('sinon'),
             requester: {
                 cookieJar: cookieJar
             },
+            fileResolver: fs,
             collection: {
                 item: [{
                     name: 'Duplicate headers',
@@ -100,6 +102,20 @@ var sinon = require('sinon'),
                             key: 'Cookie',
                             value: 'c2=v2'
                         }]
+                    }
+                }, {
+                    name: 'content-length',
+                    request: {
+                        url: 'https://postman-echo.com/post',
+                        method: 'POST',
+                        body: {
+                            mode: 'formdata',
+                            formdata: [{
+                                key: 'file',
+                                src: 'test/fixtures/upload-file.json',
+                                type: 'file'
+                            }]
+                        }
                     }
                 }]
             }
@@ -222,7 +238,6 @@ var sinon = require('sinon'),
             response = testrun.response.getCall(4).args[2],
             requestHeaders = JSON.parse(response.stream);
 
-
         // make sure there's only 1 cookie header
         expect(requestHeaders.filter(function (h) { return h.key.toLowerCase() === 'cookie'; }))
             .to.have.lengthOf(1);
@@ -233,6 +248,21 @@ var sinon = require('sinon'),
         // make sure duplicates (multiple cookie headers) are removed
         expect(request.headers.reference.cookie).to.deep.eql(
             new Header({key: 'Cookie', value: 'c1=v1; c2=v2; c3=v3; c4=v4', system: true})
+        );
+    });
+
+    it('should handle content-length header correctly', function () {
+        sinon.assert.calledWith(testrun.request.getCall(5), null);
+        sinon.assert.calledWith(testrun.response.getCall(5), null);
+
+        var request = testrun.response.getCall(5).args[3],
+            response = testrun.response.getCall(5).args[2],
+            requestHeaders = JSON.parse(response.stream).headers;
+
+        expect(requestHeaders).to.have.property('content-length', '253');
+
+        expect(request.headers.members[request.headers.count() - 1]).to.deep.equal(
+            new Header({key: 'Content-Length', 'system': true, value: '253'})
         );
     });
 });

--- a/test/integration/request-flow/headers.test.js
+++ b/test/integration/request-flow/headers.test.js
@@ -4,7 +4,7 @@ var sinon = require('sinon'),
     Header = require('postman-collection').Header,
     cookieJar = require('postman-request').jar();
 
-(typeof window === 'undefined' ? describe : describe.skip)('request headers', function () {
+(typeof window === 'undefined' ? describe.only : describe.skip)('request headers', function () {
     var testrun,
         HEADERS_URL,
         COOKIES_URL;
@@ -131,8 +131,8 @@ var sinon = require('sinon'),
         sinon.assert.calledOnce(testrun.done);
         sinon.assert.calledWith(testrun.done.getCall(0), null);
 
-        sinon.assert.callCount(testrun.request, 5);
-        sinon.assert.callCount(testrun.response, 5);
+        sinon.assert.callCount(testrun.request, 6);
+        sinon.assert.callCount(testrun.response, 6);
     });
 
     it('should handle duplicate headers correctly', function () {

--- a/test/integration/request-flow/pm-send-request-cookies.test.js
+++ b/test/integration/request-flow/pm-send-request-cookies.test.js
@@ -1,7 +1,7 @@
 var _ = require('lodash'),
     expect = require('chai').expect;
 
-(typeof window === 'undefined' ? describe.only : describe.skip)('cookie sandbox request interaction', function () {
+(typeof window === 'undefined' ? describe : describe.skip)('cookie sandbox request interaction', function () {
     var cookieUrl = 'https://postman-echo.com/cookies';
 
     describe('intra-sandbox', function () {
@@ -189,18 +189,11 @@ var _ = require('lodash'),
                 });
 
                 it('should clear the cookies outside the sandbox as well', function () {
-                    var reqOne = testrun.io.firstCall.args[4],
-                        reqTwo = testrun.request.firstCall.args[3],
-                        resOne = testrun.io.firstCall.args[3];
+                    var resOne = testrun.io.firstCall.args[3];
 
                     // Both reqOne and reqTwo represent the call from pre-request script.
                     // It will not have cookie header, because no cookie is being sent
                     // The redirect call from it will have the cookie header, with sails.sid cookie only
-
-                    // eslint-disable-next-line max-len
-                    // expect(reqOne).to.have.nested.property('headers.reference.cookie.value').that.not.include('foo=bar');
-                    // eslint-disable-next-line max-len
-                    // expect(reqTwo).to.have.nested.property('headers.reference.cookie.value').that.not.include('foo=bar');
 
                     expect(resOne.json()).to.eql({cookies: {}});
                     expect(testrun.request.secondCall.args[2].json()).to.eql({cookies: {foo: 'bar'}});
@@ -491,15 +484,14 @@ var _ = require('lodash'),
                 });
 
                 it('should expose cookies outside the sandbox as well', function () {
-                    var reqOne = testrun.request.firstCall.args[3],
-                        resOne = testrun.request.firstCall.args[2],
+                    var resOne = testrun.request.firstCall.args[2],
                         reqTwo = testrun.io.secondCall.args[4],
                         resTwo = testrun.io.secondCall.args[3];
 
                     // redirect will have this, first request request wont have
-                    // expect(reqOne).to.have.nested.property('headers.reference.cookie.value').that.include('foo=bar;');
 
                     // possible solution:
+                    // eslint-disable-next-line one-var
                     var historyOne = testrun.response.firstCall.lastArg,
                         headers = historyOne.execution.data[1].request.headers;
 

--- a/test/integration/request-flow/pm-send-request-cookies.test.js
+++ b/test/integration/request-flow/pm-send-request-cookies.test.js
@@ -190,7 +190,7 @@ var _ = require('lodash'),
 
                 it('should clear the cookies outside the sandbox as well', function () {
                     var resOne = testrun.io.firstCall.args[3],
-                        historyOne = testrun.response.firstCall.lastArg,
+                        historyOne = testrun.request.firstCall.lastArg,
                         headers = historyOne.execution.data[1].request.headers;
 
                     // cookies are set after the first response in redirect

--- a/test/integration/requester-spec/history.test.js
+++ b/test/integration/requester-spec/history.test.js
@@ -192,7 +192,7 @@ var expect = require('chai').expect,
                 collection: {
                     item: [{
                         request: {
-                            url: 'https://cutt.ly/axOnfoK',
+                            url: global.servers.followRedirects + '/2/302',
                             method: 'GET',
                             header: [{
                                 key: 'foo',
@@ -223,10 +223,6 @@ var expect = require('chai').expect,
 
             var history = testrun.request.getCall(0).lastArg,
                 executionData;
-
-            // console.log(history.execution.data[0].request.headers);
-            // console.log(history.execution.data[1].request.headers);
-            // console.log(history.execution.data[2].request.headers);
 
             // `history` should be present
             expect(history).to.be.an('object').to.have.property('execution');

--- a/test/integration/requester-spec/history.test.js
+++ b/test/integration/requester-spec/history.test.js
@@ -192,7 +192,7 @@ var expect = require('chai').expect,
                 collection: {
                     item: [{
                         request: {
-                            url: global.servers.followRedirects + '/2/302',
+                            url: 'https://cutt.ly/axOnfoK',
                             method: 'GET',
                             header: [{
                                 key: 'foo',
@@ -223,6 +223,10 @@ var expect = require('chai').expect,
 
             var history = testrun.request.getCall(0).lastArg,
                 executionData;
+
+            // console.log(history.execution.data[0].request.headers);
+            // console.log(history.execution.data[1].request.headers);
+            // console.log(history.execution.data[2].request.headers);
 
             // `history` should be present
             expect(history).to.be.an('object').to.have.property('execution');

--- a/test/integration/requester-spec/redirect.test.js
+++ b/test/integration/requester-spec/redirect.test.js
@@ -169,7 +169,7 @@ var sinon = require('sinon'),
             expect(history).to.be.an('array').that.have.lengthOf(2);
 
             expect(history[1].request).to.be.an('object').that.has.property('headers');
-            expect(history[1].request.headers).to.have.property('referer', URL);
+            expect(history[1].request.headers).to.deep.include({key: 'referer', value: URL});
         });
     });
 

--- a/test/integration/requester-spec/redirect.test.js
+++ b/test/integration/requester-spec/redirect.test.js
@@ -109,7 +109,8 @@ var sinon = require('sinon'),
             URL = global.servers.followRedirects + '/1/302';
             this.run({
                 requester: {
-                    removeRefererHeaderOnRedirect: false
+                    removeRefererHeaderOnRedirect: false,
+                    verbose: true
                 },
                 collection: {
                     item: [{
@@ -142,7 +143,7 @@ var sinon = require('sinon'),
             sinon.assert.calledWith(testrun.response.getCall(0), null);
         });
 
-        it('should have referer header on redirects', function () {
+        it('should not have referer header in the first request on redirects', function () {
             var request = testrun.response.getCall(0).args[3],
                 response = testrun.response.getCall(0).args[2],
                 hits;
@@ -158,10 +159,17 @@ var sinon = require('sinon'),
             expect(hits[1]).to.have.property('headers');
             expect(hits[1].headers).to.have.property('referer', URL);
 
-            // this also checks that referer header is updated in the request
             expect(request.headers.reference).to.have.property('referer');
-            expect(request.headers).to.have.nested.property('reference.referer.value', URL);
-            expect(request.headers).to.have.nested.property('reference.referer.system', true);
+            expect(request.headers).to.have.nested.property('reference.referer.value', 'POSTMAN');
+        });
+
+        it('should have referer header in the subsequent requests on redirects', function () {
+            var history = testrun.request.getCall(0).lastArg.execution.data;
+
+            expect(history).to.be.an('array').that.have.lengthOf(2);
+
+            expect(history[1].request).to.be.an('object').that.has.property('headers');
+            expect(history[1].request.headers).to.have.property('referer', URL);
         });
     });
 

--- a/test/integration/requester-spec/redirect.test.js
+++ b/test/integration/requester-spec/redirect.test.js
@@ -143,13 +143,17 @@ var sinon = require('sinon'),
             sinon.assert.calledWith(testrun.response.getCall(0), null);
         });
 
-        it('should not have referer header in the first request on redirects', function () {
-            var request = testrun.response.getCall(0).args[3],
-                response = testrun.response.getCall(0).args[2],
+        it('should have referer header in subsequent requests on redirects', function () {
+            var response = testrun.response.getCall(0).args[2],
+                history = testrun.request.getCall(0).lastArg.execution.data,
                 hits;
 
             expect(response).to.have.property('code', 200);
             expect(response).to.have.property('stream');
+
+            expect(history).to.be.an('array').that.have.lengthOf(2);
+            expect(history[1].request).to.be.an('object').that.has.property('headers');
+            expect(history[1].request.headers).to.deep.include({key: 'referer', value: URL});
 
             hits = response.json();
 
@@ -158,18 +162,13 @@ var sinon = require('sinon'),
             expect(hits[1]).to.have.property('method', 'GET');
             expect(hits[1]).to.have.property('headers');
             expect(hits[1].headers).to.have.property('referer', URL);
+        });
+
+        it('should preserve referer header set in the initial request', function () {
+            var request = testrun.response.getCall(0).args[3];
 
             expect(request.headers.reference).to.have.property('referer');
             expect(request.headers).to.have.nested.property('reference.referer.value', 'POSTMAN');
-        });
-
-        it('should have referer header in the subsequent requests on redirects', function () {
-            var history = testrun.request.getCall(0).lastArg.execution.data;
-
-            expect(history).to.be.an('array').that.have.lengthOf(2);
-
-            expect(history[1].request).to.be.an('object').that.has.property('headers');
-            expect(history[1].request.headers).to.deep.include({key: 'referer', value: URL});
         });
     });
 

--- a/test/integration/sanity/cookie-handling.test.js
+++ b/test/integration/sanity/cookie-handling.test.js
@@ -42,8 +42,6 @@ var expect = require('chai').expect;
         expect(testrun.test.getCall(0).args[0]).to.be.null;
         expect(_.find(testrun.test.getCall(0).args[2][0].result.cookies, {name: 'foo'})).to.have
             .property('value', 'bar');
-        expect(_.get(testrun.test.getCall(0).args[2], '0.result.request.headers.reference.cookie.value')).to
-            .match(/foo=bar;/);
 
         expect(testrun.test.getCall(1).args[0]).to.be.null;
         expect(_.find(testrun.test.getCall(1).args[2][0].result.cookies, {name: 'foo'})).to.have

--- a/test/integration/sanity/file-uploads.test.js
+++ b/test/integration/sanity/file-uploads.test.js
@@ -75,10 +75,10 @@ var fs = require('fs'),
 
         sinon.assert.calledWith(testrun.request.getCall(0), null);
         expect(_.find(testrun.request.getCall(0).args[3].headers.members, {key: 'Content-Length'}))
-            .to.have.property('value', 253);
+            .to.have.property('value', '253');
 
         sinon.assert.calledWith(testrun.request.getCall(1), null);
         expect(_.find(testrun.request.getCall(1).args[3].headers.members, {key: 'Content-Length'}))
-            .to.have.property('value', 33);
+            .to.have.property('value', '33');
     });
 });


### PR DESCRIPTION
Add request and response headers to history object. 
Update the `addMissingRequestHeaders()` function to add headers from history.
Fixed a bug where in case of redirects, the request object in callbacks, had headers which were not present in the first request. 