### PR TITLE
Fix OAuth1.0a Incorrect Signature for URL Encoded Params

### DIFF
--- a/lib/authorizer/oauth1.js
+++ b/lib/authorizer/oauth1.js
@@ -247,6 +247,29 @@ module.exports = {
     },
 
     /**
+     * Updates the encoding for query parameters in request to RFC-3986.
+     * decodeFrom here decodes breaks the query string down and does
+     * percent decoding on parameters too.
+     *
+     * @param {Request} request - request to update query parameters
+     * @param {Object} url - Node.js like url object
+     */
+    updateQueryParamEncoding: function (request, url) {
+        queryParams = url.query && oAuth1.decodeForm(url.query);
+
+        queryParams && _.forEach(queryParams, function (param) {
+            encodedKey = param[0] && oAuth1.percentEncode(param[0]);
+            encodedValue = param[1] && oAuth1.percentEncode(param[1]);
+
+            if (encodedKey){
+                // remove parameter from request and add the newly encoded parameter
+                request.removeQueryParams(param[0]);
+                request.addQueryParams([{key: encodedKey, value: encodedValue}])
+            }
+        });
+    },
+
+    /**
      * Generates and adds oAuth1 data to the request. This function modifies the
      * request passed in the argument.
      *
@@ -278,6 +301,10 @@ module.exports = {
             {system: true, key: OAUTH1_PARAMS.oauthNonce, value: params.nonce},
             {system: true, key: OAUTH1_PARAMS.oauthVersion, value: params.version}
         ];
+
+        // Update the encoding for query parameters to RFC-3986 in accordance
+        // with the OAUth specification
+        this.updateQueryParamEncoding(request, url);
 
         // bodyHash, callback and verifier parameters are part of extensions of the original OAuth1 spec.
         // So we only include those in signature if they are non-empty, ignoring the addEmptyParamsToSign setting.

--- a/lib/authorizer/oauth1.js
+++ b/lib/authorizer/oauth1.js
@@ -255,11 +255,11 @@ module.exports = {
      * @param {Object} url - Node.js like url object
      */
     updateQueryParamEncoding: function (request, url) {
-        queryParams = url.query && oAuth1.decodeForm(url.query);
+        const queryParams = url.query && oAuth1.decodeForm(url.query);
 
         queryParams && _.forEach(queryParams, function (param) {
-            encodedKey = param[0] && oAuth1.percentEncode(param[0]);
-            encodedValue = param[1] && oAuth1.percentEncode(param[1]);
+            var encodedKey = param[0] && oAuth1.percentEncode(param[0]);
+            var encodedValue = param[1] && oAuth1.percentEncode(param[1]);
 
             if (encodedKey){
                 // remove parameter from request and add the newly encoded parameter

--- a/lib/authorizer/oauth1.js
+++ b/lib/authorizer/oauth1.js
@@ -258,8 +258,8 @@ module.exports = {
         const queryParams = url.query && oAuth1.decodeForm(url.query);
 
         queryParams && _.forEach(queryParams, function (param) {
-            var encodedKey = param[0] && oAuth1.percentEncode(param[0]);
-            var encodedValue = param[1] && oAuth1.percentEncode(param[1]);
+            var encodedKey = param[0] && oAuth1.percentEncode(param[0]),
+                 encodedValue = param[1] && oAuth1.percentEncode(param[1]);
 
             if (encodedKey){
                 // remove parameter from request and add the newly encoded parameter
@@ -281,7 +281,6 @@ module.exports = {
         var url = urlEncoder.toNodeUrl(request.url),
             signatureParams,
             urlencodedBody,
-            queryParams,
             bodyParams,
             allParams,
             signature,
@@ -325,11 +324,6 @@ module.exports = {
         // filter empty signature parameters
         signatureParams = _.filter(signatureParams, function (param) {
             return params.addEmptyParamsToSign || param.value;
-        });
-
-        // filter disabled query parameters
-        queryParams = request.url.query.filter(function (param) {
-            return !param.disabled;
         });
 
         urlencodedBody = request.body &&

--- a/lib/authorizer/oauth1.js
+++ b/lib/authorizer/oauth1.js
@@ -42,7 +42,7 @@ function getOAuth1BaseUrl (url) {
         host = ((port === HTTP_PORT ||
             port === HTTPS_PORT ||
             port === undefined) && url.hostname) || url.host,
-        path = url.pathname,
+        path = url.path,
 
         // trim to convert 'http:' from Node's URL object to 'http'
         protocol = _.trimEnd(url.protocol || PROTOCOL_HTTP, PROTOCOL_SEPARATOR);
@@ -315,7 +315,7 @@ module.exports = {
             return !param.disabled;
         }) : [];
 
-        allParams = [].concat(signatureParams, queryParams, bodyParams);
+        allParams = [].concat(signatureParams, bodyParams);
 
         message = {
             action: getOAuth1BaseUrl(url),


### PR DESCRIPTION
**TASK**: Fix the Incorrect Signature Generation for URLs with Encoded Query Parameters
**Implementation**: Updated the message being sent to `node-oauth1` for signature generation. Added query parameters to action of this message by adding `path` instead of `pathname` in getOAuth1BaseURL. Removed queryParams from allParams which is passed to `node-oauth1` for signature generation. 

Added a function to re-encode the query parameters to RFC-3986 and update these in the request being sent. This function uses `formDecode` and `percentEncode` from `node-oauth1`. `formDecode` breaks the query string down and decodes it with `decodePercent`, so that we can encode it again with `percentEncode` to the RFC-3986 standards and update the request. It correspondingly removes parameters from the request and adds the newly encoded parameters.