### PR TITLE
Fix OAuth1.0a Incorrect Signature for URL Encoded Params

### DIFF
--- a/lib/authorizer/oauth1.js
+++ b/lib/authorizer/oauth1.js
@@ -247,6 +247,29 @@ module.exports = {
     },
 
     /**
+     * Updates the encoding for query parameters in request to RFC-3986.
+     * decodeFrom here decodes breaks the query string down and does
+     * percent decoding on parameters too.
+     *
+     * @param {Request} request - request to update query parameters
+     * @param {Object} url - Node.js like url object
+     */
+    updateQueryParamEncoding: function (request, url) {
+        queryParams = url.query && oAuth1.decodeForm(url.query);
+
+        queryParams && _.forEach(queryParams, function (param) {
+            encodedKey = param[0] && oAuth1.percentEncode(param[0]);
+            encodedValue = param[1] && oAuth1.percentEncode(param[1]);
+
+            if (encodedKey){
+                // remove parameter from request and add the newly encoded parameter
+                request.removeQueryParams(param[0]);
+                request.addQueryParams([{key: encodedKey, value: encodedValue}])
+            }
+        });
+    },
+
+    /**
      * Generates and adds oAuth1 data to the request. This function modifies the
      * request passed in the argument.
      *
@@ -278,6 +301,10 @@ module.exports = {
             {system: true, key: OAUTH1_PARAMS.oauthNonce, value: params.nonce},
             {system: true, key: OAUTH1_PARAMS.oauthVersion, value: params.version}
         ];
+
+        // Update the encoding for query parameters to RFC-3986 in accordance
+        // with the OAUth specification
+        this.updateQueryParamEncoding(request, url);
 
         // bodyHash, callback and verifier parameters are part of extensions of the original OAuth1 spec.
         // So we only include those in signature if they are non-empty, ignoring the addEmptyParamsToSign setting.

--- a/lib/authorizer/oauth1.js
+++ b/lib/authorizer/oauth1.js
@@ -53,41 +53,30 @@ function getOAuth1BaseUrl (url) {
 }
 
 /**
- * Query parameters are encoded with WHATWG encoding in the request.
- * OAuth1.0 requires the query params to be encoded with the RFC-3986
- * standard. This function decodes the query parameters and encodes
- * them to the required RFC-3986 standard.
+ * Query parameters are encoded with WHATWG encoding in the request. OAuth1.0
+ * requires the query params to be encoded with the RFC-3986 standard. This
+ * function decodes the query parameters and encodes them to the required RFC-3986
+ * standard. For details: https://oauth.net/core/1.0a/#encoding_parameters
  *
  * @param {Request} request - request to update query parameters
  * @param {Object} url - Node.js like url object
  */
 function updateQueryParamEncoding (request, url) {
-    const queryParams = url.query && oAuth1.decodeForm(url.query);
+    // early bailout if no query is set.
+    if (!url.query) {
+        return;
+    }
+
+    const queryParams = oAuth1.decodeForm(url.query);
 
     // clear all query parameters
     request.url.query.clear();
 
     queryParams && _.forEach(queryParams, function (param) {
-        var encodedKey = param[0] && oAuth1.percentEncode(param[0]),
-            encodedValue = param[1] && oAuth1.percentEncode(param[1]);
-
-        request.addQueryParams([{key: encodedKey, value: encodedValue}]);
-    });
-}
-
-/**
- * Encodes the OAuth1 signature parameters according to RFC-3986 standards
- * and adds them to the request query parameters
- *
- * @param {Request} request - request to update query parameters
- * @param {Array} signatureParams - Array of oAuth1 signature params
- */
-function addSignatureParamsToRequest (request, signatureParams) {
-    signatureParams && _.forEach(signatureParams, function (param) {
-        var encodedKey = param.key && oAuth1.percentEncode(param.key),
-            encodedValue = param.value && oAuth1.percentEncode(param.value);
-
-        request.addQueryParams([{system: true, key: encodedKey, value: encodedValue}]);
+        request.url.query.add({
+            key: param[0] && oAuth1.percentEncode(param[0]),
+            value: param[1] && oAuth1.percentEncode(param[1])
+        });
     });
 }
 
@@ -366,8 +355,8 @@ module.exports = {
             return done(err);
         }
 
-        // Update the encoding for query parameters to RFC-3986 in accordance
-        // with the OAUth specification
+        // Update the encoding for query parameters to RFC-3986 in accordance with the
+        // OAuth1.0a specification: https://oauth.net/core/1.0a/#encoding_parameters
         updateQueryParamEncoding(request, url);
 
         signatureParams.push({system: true, key: OAUTH1_PARAMS.oauthSignature, value: signature});
@@ -396,7 +385,13 @@ module.exports = {
             });
         }
         else {
-            addSignatureParamsToRequest(request, signatureParams);
+            _.forEach(signatureParams, function (param) {
+                request.url.query.add({
+                    key: param.key && oAuth1.percentEncode(param.key),
+                    value: param.value && oAuth1.percentEncode(param.value),
+                    system: true
+                });
+            });
         }
 
         done();

--- a/lib/authorizer/oauth1.js
+++ b/lib/authorizer/oauth1.js
@@ -72,7 +72,7 @@ function updateQueryParamEncoding (request, url) {
     // clear all query parameters
     request.url.query.clear();
 
-    queryParams && _.forEach(queryParams, function (param) {
+    _.forEach(queryParams, function (param) {
         request.url.query.add({
             key: param[0] && oAuth1.percentEncode(param[0]),
             value: param[1] && oAuth1.percentEncode(param[1])

--- a/lib/authorizer/oauth1.js
+++ b/lib/authorizer/oauth1.js
@@ -53,6 +53,29 @@ function getOAuth1BaseUrl (url) {
 }
 
 /**
+ * Query parameters are encoded with WHATWG encoding in the request.
+ * OAuth1.0 requires the query params to be encoded with the RFC-3986
+ * standard. This function decodes the query parameters and encodes
+ * them to the required RFC-3986 standard.
+ *
+ * @param {Request} request - request to update query parameters
+ * @param {Object} url - Node.js like url object
+ */
+function updateQueryParamEncoding (request, url) {
+    const queryParams = url.query && oAuth1.decodeForm(url.query);
+
+    // clear all query parameters
+    request.url.query.clear();
+
+    queryParams && _.forEach(queryParams, function (param) {
+        var encodedKey = param[0] && oAuth1.percentEncode(param[0]),
+            encodedValue = param[1] && oAuth1.percentEncode(param[1]);
+
+        request.addQueryParams([{key: encodedKey, value: encodedValue}]);
+    });
+}
+
+/**
  * Calculates body hash with given algorithm and digestEncoding.
  *
  * @param {RequestBody} body Request body
@@ -247,29 +270,6 @@ module.exports = {
     },
 
     /**
-     * Updates the encoding for query parameters in request to RFC-3986.
-     * decodeFrom here decodes breaks the query string down and does
-     * percent decoding on parameters too.
-     *
-     * @param {Request} request - request to update query parameters
-     * @param {Object} url - Node.js like url object
-     */
-    updateQueryParamEncoding: function (request, url) {
-        const queryParams = url.query && oAuth1.decodeForm(url.query);
-
-        queryParams && _.forEach(queryParams, function (param) {
-            var encodedKey = param[0] && oAuth1.percentEncode(param[0]),
-                encodedValue = param[1] && oAuth1.percentEncode(param[1]);
-
-            if (encodedKey) {
-                // remove parameter from request and add the newly encoded parameter
-                request.removeQueryParams(param[0]);
-                request.addQueryParams([{key: encodedKey, value: encodedValue}]);
-            }
-        });
-    },
-
-    /**
      * Generates and adds oAuth1 data to the request. This function modifies the
      * request passed in the argument.
      *
@@ -300,10 +300,6 @@ module.exports = {
             {system: true, key: OAUTH1_PARAMS.oauthNonce, value: params.nonce},
             {system: true, key: OAUTH1_PARAMS.oauthVersion, value: params.version}
         ];
-
-        // Update the encoding for query parameters to RFC-3986 in accordance
-        // with the OAUth specification
-        this.updateQueryParamEncoding(request, url);
 
         // bodyHash, callback and verifier parameters are part of extensions of the original OAuth1 spec.
         // So we only include those in signature if they are non-empty, ignoring the addEmptyParamsToSign setting.
@@ -353,6 +349,10 @@ module.exports = {
             // handle invalid private key errors for RSA signatures
             return done(err);
         }
+
+        // Update the encoding for query parameters to RFC-3986 in accordance
+        // with the OAUth specification
+        updateQueryParamEncoding(request, url);
 
         signatureParams.push({system: true, key: OAUTH1_PARAMS.oauthSignature, value: signature});
 

--- a/lib/authorizer/oauth1.js
+++ b/lib/authorizer/oauth1.js
@@ -255,16 +255,16 @@ module.exports = {
      * @param {Object} url - Node.js like url object
      */
     updateQueryParamEncoding: function (request, url) {
-        queryParams = url.query && oAuth1.decodeForm(url.query);
+        const queryParams = url.query && oAuth1.decodeForm(url.query);
 
         queryParams && _.forEach(queryParams, function (param) {
-            encodedKey = param[0] && oAuth1.percentEncode(param[0]);
-            encodedValue = param[1] && oAuth1.percentEncode(param[1]);
+            var encodedKey = param[0] && oAuth1.percentEncode(param[0]),
+                encodedValue = param[1] && oAuth1.percentEncode(param[1]);
 
-            if (encodedKey){
+            if (encodedKey) {
                 // remove parameter from request and add the newly encoded parameter
                 request.removeQueryParams(param[0]);
-                request.addQueryParams([{key: encodedKey, value: encodedValue}])
+                request.addQueryParams([{key: encodedKey, value: encodedValue}]);
             }
         });
     },
@@ -281,7 +281,6 @@ module.exports = {
         var url = urlEncoder.toNodeUrl(request.url),
             signatureParams,
             urlencodedBody,
-            queryParams,
             bodyParams,
             allParams,
             signature,
@@ -325,11 +324,6 @@ module.exports = {
         // filter empty signature parameters
         signatureParams = _.filter(signatureParams, function (param) {
             return params.addEmptyParamsToSign || param.value;
-        });
-
-        // filter disabled query parameters
-        queryParams = request.url.query.filter(function (param) {
-            return !param.disabled;
         });
 
         urlencodedBody = request.body &&

--- a/lib/authorizer/oauth1.js
+++ b/lib/authorizer/oauth1.js
@@ -76,6 +76,22 @@ function updateQueryParamEncoding (request, url) {
 }
 
 /**
+ * Encodes the OAuth1 signature parameters according to RFC-3986 standards
+ * and adds them to the request query parameters
+ *
+ * @param {Request} request - request to update query parameters
+ * @param {Array} signatureParams - Array of oAuth1 signature params
+ */
+function addSignatureParamsToRequest (request, signatureParams) {
+    signatureParams && _.forEach(signatureParams, function (param) {
+        var encodedKey = param.key && oAuth1.percentEncode(param.key),
+            encodedValue = param.value && oAuth1.percentEncode(param.value);
+
+        request.addQueryParams([{system: true, key: encodedKey, value: encodedValue}]);
+    });
+}
+
+/**
  * Calculates body hash with given algorithm and digestEncoding.
  *
  * @param {RequestBody} body Request body
@@ -380,7 +396,7 @@ module.exports = {
             });
         }
         else {
-            request.addQueryParams(signatureParams);
+            addSignatureParamsToRequest(request, signatureParams);
         }
 
         done();

--- a/lib/authorizer/oauth1.js
+++ b/lib/authorizer/oauth1.js
@@ -42,7 +42,7 @@ function getOAuth1BaseUrl (url) {
         host = ((port === HTTP_PORT ||
             port === HTTPS_PORT ||
             port === undefined) && url.hostname) || url.host,
-        path = url.pathname,
+        path = url.path,
 
         // trim to convert 'http:' from Node's URL object to 'http'
         protocol = _.trimEnd(url.protocol || PROTOCOL_HTTP, PROTOCOL_SEPARATOR);
@@ -315,7 +315,7 @@ module.exports = {
             return !param.disabled;
         }) : [];
 
-        allParams = [].concat(signatureParams, queryParams, bodyParams);
+        allParams = [].concat(signatureParams, bodyParams);
 
         message = {
             action: getOAuth1BaseUrl(url),

--- a/test/integration/auth-methods/oauth1.test.js
+++ b/test/integration/auth-methods/oauth1.test.js
@@ -534,6 +534,14 @@ describe('oauth 1', function () {
             });
         });
 
+        it('should have completed the run', function () {
+            expect(testrun).to.be.ok;
+            expect(testrun.done.calledOnce).to.be.ok;
+            testrun.done.getCall(0).args[0] && console.error(testrun.done.getCall(0).args[0].stack);
+            expect(testrun.done.getCall(0).args[0]).to.be.null;
+            expect(testrun.start.calledOnce).to.be.ok;
+        });
+
         it('should have passed OAuth 1 authorization', function () {
             expect(testrun.request.calledOnce).to.be.ok;
 
@@ -591,6 +599,14 @@ describe('oauth 1', function () {
             });
         });
 
+        it('should have completed the run', function () {
+            expect(testrun).to.be.ok;
+            expect(testrun.done.calledOnce).to.be.ok;
+            testrun.done.getCall(0).args[0] && console.error(testrun.done.getCall(0).args[0].stack);
+            expect(testrun.done.getCall(0).args[0]).to.be.null;
+            expect(testrun.start.calledOnce).to.be.ok;
+        });
+
         it('should have passed OAuth 1 authorization', function () {
             expect(testrun.request.calledOnce).to.be.ok;
 
@@ -637,6 +653,14 @@ describe('oauth 1', function () {
                 testrun = results;
                 done(err);
             });
+        });
+
+        it('should have completed the run', function () {
+            expect(testrun).to.be.ok;
+            expect(testrun.done.calledOnce).to.be.ok;
+            testrun.done.getCall(0).args[0] && console.error(testrun.done.getCall(0).args[0].stack);
+            expect(testrun.done.getCall(0).args[0]).to.be.null;
+            expect(testrun.start.calledOnce).to.be.ok;
         });
 
         it('should have passed OAuth 1 authorization', function () {

--- a/test/integration/auth-methods/oauth1.test.js
+++ b/test/integration/auth-methods/oauth1.test.js
@@ -550,4 +550,101 @@ describe('oauth 1', function () {
             expect(request.url.query.get('param_3')).to.eql('value_1%2Cvalue_2%2Cvalue_3');
         });
     });
+
+    // Authorization is failing when query parameters have duplicate keys
+    // e.g. {key: 'param_1', value: 'value_1'}, {key: 'param_1', value: 'value_2'},
+    describe.skip('with duplicate query params', function () {
+        before(function (done) {
+            // perform the collection run
+            this.run({
+                collection: {
+                    item: {
+                        request: {
+                            auth: {
+                                type: 'oauth1',
+                                oauth1: {
+                                    consumerKey: 'RKCGzna7bv9YD57c',
+                                    consumerSecret: 'D+EdQ-gs$-%@2Nu7',
+                                    signatureMethod: 'HMAC-SHA1',
+                                    version: '1.0',
+                                    addParamsToHeader: false,
+                                    addEmptyParamsToSign: false
+                                }
+                            },
+                            url: {
+                                host: ['postman-echo', 'com'],
+                                path: ['oauth1'],
+                                protocol: 'https',
+                                query: [
+                                    {key: 'param_1', value: 'value_1'},
+                                    {key: 'param_1', value: 'value_2'}
+                                ],
+                                variable: []
+                            },
+                            method: 'GET'
+                        }
+                    }
+                }
+            }, function (err, results) {
+                testrun = results;
+                done(err);
+            });
+        });
+
+        it('should have passed OAuth 1 authorization', function () {
+            expect(testrun.request.calledOnce).to.be.ok;
+
+            var response = testrun.request.getCall(0).args[2];
+
+            expect(response).to.have.property('code', 200);
+        });
+    });
+
+    // Authorization is failing when query parameters have an empty key
+    // e.g. {key: '', value: 'value_1'}, request: www.xyz.com/a?=value_1
+    describe.skip('with query params having empty keys', function () {
+        before(function (done) {
+            // perform the collection run
+            this.run({
+                collection: {
+                    item: {
+                        request: {
+                            auth: {
+                                type: 'oauth1',
+                                oauth1: {
+                                    consumerKey: 'RKCGzna7bv9YD57c',
+                                    consumerSecret: 'D+EdQ-gs$-%@2Nu7',
+                                    signatureMethod: 'HMAC-SHA1',
+                                    version: '1.0',
+                                    addParamsToHeader: false,
+                                    addEmptyParamsToSign: false
+                                }
+                            },
+                            url: {
+                                host: ['postman-echo', 'com'],
+                                path: ['oauth1'],
+                                protocol: 'https',
+                                query: [
+                                    {key: '', value: 'value_1'}
+                                ],
+                                variable: []
+                            },
+                            method: 'GET'
+                        }
+                    }
+                }
+            }, function (err, results) {
+                testrun = results;
+                done(err);
+            });
+        });
+
+        it('should have passed OAuth 1 authorization', function () {
+            expect(testrun.request.calledOnce).to.be.ok;
+
+            var response = testrun.request.getCall(0).args[2];
+
+            expect(response).to.have.property('code', 200);
+        });
+    });
 });

--- a/test/integration/auth-methods/oauth1.test.js
+++ b/test/integration/auth-methods/oauth1.test.js
@@ -21,7 +21,7 @@ describe('oauth 1', function () {
                                     token: '',
                                     tokenSecret: '',
                                     signatureMethod: 'HMAC-SHA1',
-                                    timeStamp: 1461319769,
+                                    timestamp: 1461319769,
                                     nonce: 'ik3oT5',
                                     version: '1.0',
                                     realm: '',

--- a/test/unit/auth-handlers.test.js
+++ b/test/unit/auth-handlers.test.js
@@ -1210,7 +1210,7 @@ describe('Auth Handler:', function () {
 
             handler.sign(authInterface, request, _.noop);
 
-            expect(request.url.query.get('oauth_body_hash')).to.eql('2jmj7l5rSw0yVb/vlWAYkK/YBwk=');
+            expect(request.url.query.get('oauth_body_hash')).to.eql('2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D');
         });
 
         it('should include correct body hash for raw body', function () {
@@ -1233,7 +1233,7 @@ describe('Auth Handler:', function () {
 
             handler.sign(authInterface, request, _.noop);
 
-            expect(request.url.query.get('oauth_body_hash')).to.eql('pqfIFYs01VSVSkySGxRPgtddtoM=');
+            expect(request.url.query.get('oauth_body_hash')).to.eql('pqfIFYs01VSVSkySGxRPgtddtoM%3D');
         });
 
         it('should include correct body hash for GraphQL body', function () {
@@ -1260,7 +1260,7 @@ describe('Auth Handler:', function () {
 
             handler.sign(authInterface, request, _.noop);
 
-            expect(request.url.query.get('oauth_body_hash')).to.eql('2jwsdzjZEuFdm6ubMtk0HZi34+U=');
+            expect(request.url.query.get('oauth_body_hash')).to.eql('2jwsdzjZEuFdm6ubMtk0HZi34%2BU%3D');
         });
 
         it('should include all non-empty oauth1 params in request', function () {
@@ -1298,9 +1298,9 @@ describe('Auth Handler:', function () {
                     oauth_timestamp: '1461319769',
                     oauth_nonce: 'ik3oT5',
                     oauth_version: '1.0',
-                    oauth_callback: 'http://postman.com',
+                    oauth_callback: 'http%3A%2F%2Fpostman.com',
                     oauth_verifier: 'bar',
-                    oauth_signature: 'WHnpdWcwWzBM3bHcRQNshHVh2Og='
+                    oauth_signature: 'WHnpdWcwWzBM3bHcRQNshHVh2Og%3D'
                 });
             });
         });
@@ -1333,7 +1333,7 @@ describe('Auth Handler:', function () {
                 handler = AuthLoader.getHandler(auth.type);
 
             handler.sign(authInterface, request, function () {
-                expect(request.url.query.get('oauth_signature')).to.eql('w8WS1SXfe/dtJu/4tH5DaD7qZgM=');
+                expect(request.url.query.get('oauth_signature')).to.eql('w8WS1SXfe%2FdtJu%2F4tH5DaD7qZgM%3D');
             });
         });
 
@@ -1365,7 +1365,7 @@ describe('Auth Handler:', function () {
                 handler = AuthLoader.getHandler(auth.type);
 
             handler.sign(authInterface, request, function () {
-                expect(request.url.query.get('oauth_signature')).to.eql('WO1RMBRLIM5Anfxxt8P7Kbt82b4=');
+                expect(request.url.query.get('oauth_signature')).to.eql('WO1RMBRLIM5Anfxxt8P7Kbt82b4%3D');
             });
         });
 
@@ -1373,7 +1373,7 @@ describe('Auth Handler:', function () {
             // eslint-disable-next-line max-len
             var privateKey = '-----BEGIN RSA PRIVATE KEY-----\nMIICWwIBAAKBgFKLvzM9zbm3I0+HWcHlBSqpfRY/bKs6NDLclERrzfnReFV4utjkhjaEQPPT6tHVHKrZkcxmIgwe3XrkJkUjcuingXIF+Fc3KpY61qJ4HSM50qIuHdi+C5YfuXwNrh6OOeZAhhqgSw2e2XqPfATbkYYwpIFpdVdcH/Pb2ynpd6VXAgMBAAECgYAbQE+LFyhH25Iou0KCpJ0kDHhjU+UIUlrRP8kjHYQOqXzUmtr0p903OkpHNPsc8wJX1SQxGra60aXE4HVR9fYFQNliAnSmA/ztGR4ddnirK1Gzog4y2OOkicTdSqJ/1XXtTEDSRkA0Z2DIqcWgudeSDzVjUpreYwQ/rCEZbi50AQJBAJcf9wi5bU8tdZUCg3/8MNDwHhr4If4V/9kmhsgNp+M/9tHwCbD05hCbiGS7g58DPF+6V2K30qQYq7yvBP8Te4ECQQCL1GhX/YwkD6rexi0E1bjz+RqhNLTR9kexkTfSYmL6zHeeIFSH8ROioGOJMU51lUtMNkkrKEeki5SZpkfaQOzXAkAvBnJPU6vQ7HtfH8YdiDMEgQNNLxMcxmmzf4qHK8CnNRsvnnrVho8kcdFSTwsY6t/Zhdl1TXANQeQGtYtfeAeBAkEAhUB351JSWJMtrHqCsFbTmHxNKk7F+kiObeMLpUvpM0PiwifhJmNQ6Oubr0Pzlw4c4ZXiCGSsUVxK0lmpo423pQJATYDoxVhZrKA3xDAifWoyxbyxf/WXtUGDaAOuZc/naVN5TKiqaEO6G+k3NpmOXNKsYU/Zd9e6P/TnfU74TyDDDA==\n-----END RSA PRIVATE KEY-----',
                 // eslint-disable-next-line max-len
-                signature = 'Bi/ocoeczWLcYlMpYtW9HdFh41YMEFXSWpdzFZkJKJ8T7rBsuYoC/VDeCUx52DLiHMlkrnfVwmNfnvwyUusEPIOq61Ytb0w3Oq3V2G5jE58+SYMmgKEZQuP6znqfadWq+u8z3nv1oiN4xacJpIRtFh4M1iDz8q+pLvxl3of+toE=',
+                signature = 'Bi%2FocoeczWLcYlMpYtW9HdFh41YMEFXSWpdzFZkJKJ8T7rBsuYoC%2FVDeCUx52DLiHMlkrnfVwmNfnvwyUusEPIOq61Ytb0w3Oq3V2G5jE58%2BSYMmgKEZQuP6znqfadWq%2Bu8z3nv1oiN4xacJpIRtFh4M1iDz8q%2BpLvxl3of%2BtoE%3D',
                 rawReq = _.merge({}, rawRequests.oauth1, {
                     auth: {
                         oauth1: {
@@ -1435,7 +1435,7 @@ describe('Auth Handler:', function () {
                 handler = AuthLoader.getHandler(auth.type);
 
             handler.sign(authInterface, request, function () {
-                expect(request.url.query.get('oauth_signature')).to.eql('e8WDYQsG8SYPoWnxU4CYbqHT1HU=');
+                expect(request.url.query.get('oauth_signature')).to.eql('e8WDYQsG8SYPoWnxU4CYbqHT1HU%3D');
             });
         });
     });


### PR DESCRIPTION
TASK: Fix the Incorrect Signature Generation for URLs with Encoded Query Parameters
Implementation: Updated the message being sent to `node-oauth1` for signature generation. Added query parameters to action of this message by adding path instead of pathname in `getOAuth1BaseURL`. Removed queryParams from allParams which is passed to `node-oauth1` for signature generation.

Added a function to re-encode the query parameters to RFC-3986 and update these in the request being sent. This function uses formDecode and percentEncode from `node-oauth1`. `formDecode` breaks the query string down and decodes it with `decodePercent`, so that we can encode it again with `percentEncode` to the RFC-3986 standards and update the request. It correspondingly removes parameters from the request and adds the newly encoded parameters.