### PR TITLE
Fixed CookieList in request and response callback on redirects

### DIFF
--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -1,3 +1,9 @@
+unreleased:
+  fixed bugs:
+    - >-
+      GH-1161 Fixed a bug where cookies set in the request and response callback
+      don't account for redirects
+
 7.28.1:
   date: 2021-06-16
   fixed bugs:

--- a/lib/requester/requester.js
+++ b/lib/requester/requester.js
@@ -315,6 +315,9 @@ _.assign(Requester.prototype, /** @lends Requester.prototype */ {
              */
             onStart = function (response) {
                 var responseStartEventName = RESPONSE_START_EVENT_BASE + id,
+                    executionData,
+                    initialRequest,
+                    finalRequest,
                     sdkResponse,
                     history,
                     done = function () {
@@ -342,12 +345,22 @@ _.assign(Requester.prototype, /** @lends Requester.prototype */ {
                 // prepare history from request debug data
                 history = getExecutionHistory(_.get(response, 'request._debug'));
 
-                // add missing request headers so that they get bubbled up into the UI
-                addMissingRequestHeaders(_.get(history, 'execution.data[0].request.headers'));
+                // get the initial and final (on redirect) request from history
+                executionData = _.get(history, 'execution.data') || [];
+                initialRequest = _.get(executionData, '[0].request') || {};
+                finalRequest = executionData.length > 1 ?
+                    // get final redirect
+                    _.get(executionData, [executionData.length - 1, 'request']) :
+                    // no redirects
+                    initialRequest;
 
-                // Pull out cookies from the cookie jar, and make them chrome compatible.
+                // add missing request headers so that they get bubbled up into the UI
+                addMissingRequestHeaders(initialRequest.headers);
+
+                // pull out cookies from the cookie jar, and make them chrome compatible.
                 if (cookieJar && _.isFunction(cookieJar.getCookies)) {
-                    cookieJar.getCookies(requestOptions.url, function (err, cookiesFromJar) {
+                    // get cookies set for the final request URL
+                    cookieJar.getCookies(finalRequest.href, function (err, cookiesFromJar) {
                         if (err) {
                             return done();
                         }

--- a/test/fixtures/servers/http.js
+++ b/test/fixtures/servers/http.js
@@ -48,4 +48,11 @@ httpServer.on('/custom-reason', function (req, res) {
     res.end();
 });
 
+httpServer.on('/redirect-to', function (req, res) {
+    res.writeHead(301, {
+        location: decodeURI(req.url.substr(req.url.indexOf('?url=') + 5))
+    });
+    res.end();
+});
+
 module.exports = httpServer;

--- a/test/integration/sanity/cookie-handling.test.js
+++ b/test/integration/sanity/cookie-handling.test.js
@@ -25,29 +25,21 @@ var expect = require('chai').expect;
                         }
                     }],
                     request: 'https://postman-echo.com/cookies/get'
+                }, {
+                    event: [{
+                        listen: 'test',
+                        script: {
+                            type: 'text/javascript',
+                            exec: ['tests["working"] = postman.getResponseCookie("foo").value === "bar"']
+                        }
+                    }],
+                    request: global.servers.http + '/redirect-to?url=' + encodeURI('https://postman-echo.com/cookies')
                 }]
             }
         }, function (err, results) {
             testrun = results;
             done(err);
         });
-    });
-
-    it('should have run the test script successfully', function () {
-        expect(testrun).to.be.ok;
-        expect(testrun).to.nested.include({
-            'test.calledTwice': true
-        });
-
-        expect(testrun.test.getCall(0).args[0]).to.be.null;
-        expect(_.find(testrun.test.getCall(0).args[2][0].result.cookies, {name: 'foo'})).to.have
-            .property('value', 'bar');
-
-        expect(testrun.test.getCall(1).args[0]).to.be.null;
-        expect(_.find(testrun.test.getCall(1).args[2][0].result.cookies, {name: 'foo'})).to.have
-            .property('value', 'bar');
-        expect(_.get(testrun.test.getCall(1).args[2], '0.result.request.headers.reference.cookie.value')).to
-            .match(/foo=bar;/);
     });
 
     it('should have completed the run', function () {
@@ -57,5 +49,41 @@ var expect = require('chai').expect;
             'done.calledOnce': true,
             'start.calledOnce': true
         });
+    });
+
+    it('should have run the test script successfully', function () {
+        expect(testrun).to.nested.include({
+            'test.calledThrice': true
+        });
+
+        const t1 = testrun.test.getCall(0).args,
+            t2 = testrun.test.getCall(1).args,
+            t3 = testrun.test.getCall(2).args;
+
+        expect(t1[0]).to.be.null;
+        expect(_.find(t1[2][0].result.cookies, {name: 'foo'})).to.have.property('value', 'bar');
+
+        expect(t2[0]).to.be.null;
+        expect(_.find(t2[2][0].result.cookies, {name: 'foo'})).to.have.property('value', 'bar');
+        expect(_.get(t2[2], '0.result.request.headers.reference.cookie.value')).to.match(/foo=bar;/);
+
+        // redirect request
+        expect(t3[0]).to.be.null;
+        expect(_.find(t3[2][0].result.cookies, {name: 'foo'})).to.have.property('value', 'bar');
+        expect(_.get(t3[2], '0.result.request.headers.reference.cookie')).to.be.undefined;
+    });
+
+    it('should have CookieList in the response callback', function () {
+        expect(testrun).to.nested.include({
+            'response.calledThrice': true
+        });
+
+        const c1 = testrun.response.getCall(1).args[5],
+            c2 = testrun.response.getCall(1).args[5],
+            c3 = testrun.response.getCall(2).args[5];
+
+        expect(c1.get('foo')).to.equal('bar');
+        expect(c2.get('foo')).to.equal('bar');
+        expect(c3.get('foo')).to.equal('bar'); // redirect
     });
 });


### PR DESCRIPTION
`CookieList` was populated with initial request's cookies instead of the final request sent in a redirect chain.