### PR TITLE
Respect Request Encoding Option in Authorizer

### DIFF
--- a/lib/authorizer/auth-interface.js
+++ b/lib/authorizer/auth-interface.js
@@ -7,15 +7,22 @@ var _ = require('lodash'),
  *
  * @constructs AuthInterface
  * @param {RequestAuth} auth
+ * @param {Object} protocolProfileBehavior - Protocol profile behaviors
  * @return {AuthInterface}
  * @throws {Error}
  */
-createAuthInterface = function (auth) {
+createAuthInterface = function (auth, protocolProfileBehavior) {
     if (!(auth && auth.parameters && auth.parameters())) {
         throw new Error('runtime~createAuthInterface: invalid auth');
     }
 
     return /** @lends AuthInterface.prototype **/{
+        /**
+         * @private
+         * @property {protocolProfileBehavior} - Protocol profile behaviors
+         */
+        _protocolProfileBehavior: protocolProfileBehavior || {},
+
         /**
          * @param {String|Array<String>} keys
          * @return {*} Returns a value for a key or an object having all keys & values depending on the input

--- a/lib/authorizer/oauth1.js
+++ b/lib/authorizer/oauth1.js
@@ -280,9 +280,10 @@ module.exports = {
      *
      * @param {Request} request - request to add oauth1 parameters
      * @param {Object} params - oauth data to generate signature
+     * @param protocolProfileBehavior - Protocol profile behaviors
      * @param {Function} done - callback function
      */
-    addAuthDataToRequest: function (request, params, done) {
+    addAuthDataToRequest: function (request, params, protocolProfileBehavior, done) {
         var url = urlEncoder.toNodeUrl(request.url),
             signatureParams,
             urlencodedBody,
@@ -295,7 +296,8 @@ module.exports = {
                 consumerSecret: params.consumerSecret || EMPTY,
                 tokenSecret: params.tokenSecret || EMPTY,
                 privateKey: params.privateKey || EMPTY
-            };
+            },
+            disableUrlEncoding = protocolProfileBehavior && protocolProfileBehavior.disableUrlEncoding;
 
         signatureParams = [
             {system: true, key: OAUTH1_PARAMS.oauthConsumerKey, value: params.consumerKey},
@@ -357,7 +359,10 @@ module.exports = {
 
         // Update the encoding for query parameters to RFC-3986 in accordance with the
         // OAuth1.0a specification: https://oauth.net/core/1.0a/#encoding_parameters
-        updateQueryParamEncoding(request, url);
+        // disableUrlEncoding option should be respected in authorization flow as well
+        if (disableUrlEncoding !== true) {
+            updateQueryParamEncoding(request, url);
+        }
 
         signatureParams.push({system: true, key: OAUTH1_PARAMS.oauthSignature, value: signature});
 
@@ -383,6 +388,10 @@ module.exports = {
             _.forEach(signatureParams, function (param) {
                 urlencodedBody.add(param);
             });
+        }
+        else if (disableUrlEncoding === true) {
+            // disableUrlEncoding option should be respected in authorization flow as well
+            request.addQueryParams(signatureParams);
         }
         else {
             _.forEach(signatureParams, function (param) {
@@ -426,7 +435,8 @@ module.exports = {
             ]),
             urlencodedBody = request.body,
             signatureAlgo,
-            hashAlgo;
+            hashAlgo,
+            protocolProfileBehavior = auth._protocolProfileBehavior;
 
         // extract hash and signature algorithm form signatureMethod
         // signature methods are in this format: '<signatureAlgo>-<hashAlgo>' e.g. RSA-SHA1
@@ -472,13 +482,13 @@ module.exports = {
         // Don't include body hash as defined in specification
         // @see: https://tools.ietf.org/id/draft-eaton-oauth-bodyhash-00.html#when_to_include
         if (urlencodedBody || !(params.includeBodyHash && hashAlgo)) {
-            return self.addAuthDataToRequest(request, params, done);
+            return self.addAuthDataToRequest(request, params, protocolProfileBehavior, done);
         }
 
         computeBodyHash(request.body, hashAlgo, 'base64', function (bodyHash) {
             params.bodyHash = bodyHash;
 
-            return self.addAuthDataToRequest(request, params, done);
+            return self.addAuthDataToRequest(request, params, protocolProfileBehavior, done);
         });
     }
 };

--- a/lib/authorizer/oauth1.js
+++ b/lib/authorizer/oauth1.js
@@ -280,7 +280,7 @@ module.exports = {
      *
      * @param {Request} request - request to add oauth1 parameters
      * @param {Object} params - oauth data to generate signature
-     * @param protocolProfileBehavior - Protocol profile behaviors
+     * @param {Object} protocolProfileBehavior - Protocol profile behaviors
      * @param {Function} done - callback function
      */
     addAuthDataToRequest: function (request, params, protocolProfileBehavior, done) {

--- a/lib/runner/request-helpers-presend.js
+++ b/lib/runner/request-helpers-presend.js
@@ -190,7 +190,7 @@ module.exports = [
             return done();
         }
 
-        authInterface = createAuthInterface(auth);
+        authInterface = createAuthInterface(auth, context.protocolProfileBehavior);
 
         /**
          * We go through the `pre` request send validation for the auth. In this step one of the three things can happen

--- a/test/integration/auth-methods/oauth1.test.js
+++ b/test/integration/auth-methods/oauth1.test.js
@@ -671,4 +671,134 @@ describe('oauth 1', function () {
             expect(response).to.have.property('code', 200);
         });
     });
+
+    describe('with protocolProfileBehavior.disableUrlEncoding: true', function () {
+        before(function (done) {
+            // perform the collection run
+            this.run({
+                collection: {
+                    item: {
+                        request: {
+                            auth: {
+                                type: 'oauth1',
+                                oauth1: {
+                                    consumerKey: 'RKCGzna7bv9YD57c',
+                                    consumerSecret: 'D+EdQ-gs$-%@2Nu7',
+                                    signatureMethod: 'HMAC-SHA1',
+                                    version: '1.0',
+                                    addParamsToHeader: true,
+                                    addEmptyParamsToSign: false
+                                }
+                            },
+                            url: {
+                                host: ['postman-echo', 'com'],
+                                path: ['oauth1'],
+                                protocol: 'https',
+                                query: [
+                                    {key: 'param_1', value: 'value_1,value_2,value_3'},
+                                    {key: 'param_2', value: 'value_4/value_5'}
+                                ],
+                                variable: []
+                            },
+                            method: 'GET'
+                        }
+                    },
+                    protocolProfileBehavior: {
+                        disableUrlEncoding: true
+                    }
+                }
+            }, function (err, results) {
+                testrun = results;
+                done(err);
+            });
+        });
+
+        it('should have completed the run', function () {
+            expect(testrun).to.be.ok;
+            expect(testrun.done.calledOnce).to.be.ok;
+            testrun.done.getCall(0).args[0] && console.error(testrun.done.getCall(0).args[0].stack);
+            expect(testrun.done.getCall(0).args[0]).to.be.null;
+            expect(testrun.start.calledOnce).to.be.ok;
+        });
+
+        it('should have passed OAuth 1 authorization', function () {
+            expect(testrun.request.calledOnce).to.be.ok;
+
+            var response = testrun.request.getCall(0).args[2];
+
+            expect(response).to.have.property('code', 200);
+        });
+
+        it('should not encode query parameters if disableUrlEncoding is true', function () {
+            var request = testrun.request.getCall(0).args[3];
+
+            expect(request.url.query.get('param_1')).to.eql('value_1,value_2,value_3');
+            expect(request.url.query.get('param_2')).to.eql('value_4/value_5');
+        });
+    });
+
+    describe('with protocolProfileBehavior.disableUrlEncoding: false', function () {
+        before(function (done) {
+            // perform the collection run
+            this.run({
+                collection: {
+                    item: {
+                        request: {
+                            auth: {
+                                type: 'oauth1',
+                                oauth1: {
+                                    consumerKey: 'RKCGzna7bv9YD57c',
+                                    consumerSecret: 'D+EdQ-gs$-%@2Nu7',
+                                    signatureMethod: 'HMAC-SHA1',
+                                    version: '1.0',
+                                    addParamsToHeader: true,
+                                    addEmptyParamsToSign: false
+                                }
+                            },
+                            url: {
+                                host: ['postman-echo', 'com'],
+                                path: ['oauth1'],
+                                protocol: 'https',
+                                query: [
+                                    {key: 'param_1', value: 'value_1,value_2,value_3'},
+                                    {key: 'param_2', value: 'value_4/value_5'}
+                                ],
+                                variable: []
+                            },
+                            method: 'GET'
+                        }
+                    },
+                    protocolProfileBehavior: {
+                        disableUrlEncoding: false
+                    }
+                }
+            }, function (err, results) {
+                testrun = results;
+                done(err);
+            });
+        });
+
+        it('should have completed the run', function () {
+            expect(testrun).to.be.ok;
+            expect(testrun.done.calledOnce).to.be.ok;
+            testrun.done.getCall(0).args[0] && console.error(testrun.done.getCall(0).args[0].stack);
+            expect(testrun.done.getCall(0).args[0]).to.be.null;
+            expect(testrun.start.calledOnce).to.be.ok;
+        });
+
+        it('should have passed OAuth 1 authorization', function () {
+            expect(testrun.request.calledOnce).to.be.ok;
+
+            var response = testrun.request.getCall(0).args[2];
+
+            expect(response).to.have.property('code', 200);
+        });
+
+        it('should encode query parameters if disableUrlEncoding is false', function () {
+            var request = testrun.request.getCall(0).args[3];
+
+            expect(request.url.query.get('param_1')).to.eql('value_1%2Cvalue_2%2Cvalue_3');
+            expect(request.url.query.get('param_2')).to.eql('value_4%2Fvalue_5');
+        });
+    });
 });

--- a/test/unit/auth-handlers.test.js
+++ b/test/unit/auth-handlers.test.js
@@ -1506,6 +1506,192 @@ describe('Auth Handler:', function () {
             handler.sign(authInterface, request, _.noop);
             expect(request.url.query.count()).to.eql(2);
         });
+
+        it('should encode query params when the disableUrlEncoding option is false', function () {
+            var _rawReq = {
+                    url: 'https://postman-echo.com/oauth1?foo,+?=bar*+=&testParam/*=testValue$@',
+                    auth: {
+                        type: 'oauth1',
+                        oauth1: {
+                            consumerKey: 'RKCGzna7bv9YD57c',
+                            consumerSecret: 'D+EdQ-gs$-%@2Nu7',
+                            token: 'foo',
+                            tokenSecret: 'bar',
+                            signatureMethod: 'HMAC-SHA1',
+                            callback: 'http://postman.com',
+                            addParamsToHeader: true,
+                            addEmptyParamsToSign: false
+                        }
+                    }
+                },
+                protocolProfileBehavior = {
+                    disableUrlEncoding: false
+                },
+                request = new Request(_rawReq),
+                auth = request.auth,
+                authInterface = createAuthInterface(auth, protocolProfileBehavior),
+                handler = AuthLoader.getHandler(auth.type);
+
+            handler.sign(authInterface, request, _.noop);
+
+            expect(request.url.query.count()).to.eql(2);
+            expect(request.url.query.get('foo%2C%20%3F')).to.eql('bar%2A%20%3D');
+            expect(request.url.query.get('testParam%2F%2A')).to.eql('testValue%24%40');
+        });
+
+        it('should not encode query params when the disableUrlEncoding option is true', function () {
+            var _rawReq = {
+                    url: 'https://postman-echo.com/oauth1?foo,+?=bar*+=&testParam/*=testValue$@',
+                    auth: {
+                        type: 'oauth1',
+                        oauth1: {
+                            consumerKey: 'RKCGzna7bv9YD57c',
+                            consumerSecret: 'D+EdQ-gs$-%@2Nu7',
+                            token: 'foo',
+                            tokenSecret: 'bar',
+                            signatureMethod: 'HMAC-SHA1',
+                            callback: 'http://postman.com',
+                            addParamsToHeader: true,
+                            addEmptyParamsToSign: false
+                        }
+                    }
+                },
+                protocolProfileBehavior = {
+                    disableUrlEncoding: true
+                },
+                request = new Request(_rawReq),
+                auth = request.auth,
+                authInterface = createAuthInterface(auth, protocolProfileBehavior),
+                handler = AuthLoader.getHandler(auth.type);
+
+            handler.sign(authInterface, request, _.noop);
+
+            expect(request.url.query.count()).to.eql(2);
+            expect(request.url.query.get('foo,+?')).to.eql('bar*+=');
+            expect(request.url.query.get('testParam/*')).to.eql('testValue$@');
+        });
+
+        // This test is to make sure that in the absence of a setting, the standard is followed
+        it('should encode query params when protocolProfilebehavior is not passed to authInterface', function () {
+            var _rawReq = {
+                    url: 'https://postman-echo.com/oauth1?foo,+?=bar*+=&testParam/*=testValue$@',
+                    auth: {
+                        type: 'oauth1',
+                        oauth1: {
+                            consumerKey: 'RKCGzna7bv9YD57c',
+                            consumerSecret: 'D+EdQ-gs$-%@2Nu7',
+                            token: 'foo',
+                            tokenSecret: 'bar',
+                            signatureMethod: 'HMAC-SHA1',
+                            callback: 'http://postman.com',
+                            addParamsToHeader: true,
+                            addEmptyParamsToSign: false
+                        }
+                    }
+                },
+                request = new Request(_rawReq),
+                auth = request.auth,
+                authInterface = createAuthInterface(auth),
+                handler = AuthLoader.getHandler(auth.type);
+
+            handler.sign(authInterface, request, _.noop);
+
+            expect(request.url.query.count()).to.eql(2);
+            expect(request.url.query.get('foo%2C%20%3F')).to.eql('bar%2A%20%3D');
+            expect(request.url.query.get('testParam%2F%2A')).to.eql('testValue%24%40');
+        });
+
+        // protocolProfileBehavior is a part of the OAuth1 flow now and is set externally, hence
+        // this check is necessary
+        it('should encode query params when protocolProfilebehavior is undefined', function () {
+            var _rawReq = {
+                    url: 'https://postman-echo.com/oauth1?foo,+?=bar*+=&testParam/*=testValue$@',
+                    auth: {
+                        type: 'oauth1',
+                        oauth1: {
+                            consumerKey: 'RKCGzna7bv9YD57c',
+                            consumerSecret: 'D+EdQ-gs$-%@2Nu7',
+                            token: 'foo',
+                            tokenSecret: 'bar',
+                            signatureMethod: 'HMAC-SHA1',
+                            callback: 'http://postman.com',
+                            addParamsToHeader: true,
+                            addEmptyParamsToSign: false
+                        }
+                    }
+                },
+                protocolProfileBehavior,
+                request = new Request(_rawReq),
+                auth = request.auth,
+                authInterface = createAuthInterface(auth, protocolProfileBehavior),
+                handler = AuthLoader.getHandler(auth.type);
+
+            handler.sign(authInterface, request, _.noop);
+
+            expect(request.url.query.count()).to.eql(2);
+            expect(request.url.query.get('foo%2C%20%3F')).to.eql('bar%2A%20%3D');
+            expect(request.url.query.get('testParam%2F%2A')).to.eql('testValue%24%40');
+        });
+
+        it('should encode signature params in query when the disableUrlEncoding option is false', function () {
+            var _rawReq = {
+                    url: 'https://postman-echo.com/oauth1',
+                    auth: {
+                        type: 'oauth1',
+                        oauth1: {
+                            consumerKey: 'RKCGzna7bv9YD57c',
+                            consumerSecret: 'D+EdQ-gs$-%@2Nu7',
+                            token: 'foo',
+                            tokenSecret: 'bar',
+                            signatureMethod: 'HMAC-SHA1',
+                            callback: 'http://postman.com',
+                            addParamsToHeader: false,
+                            addEmptyParamsToSign: false
+                        }
+                    }
+                },
+                protocolProfileBehavior = {
+                    disableUrlEncoding: false
+                },
+                request = new Request(_rawReq),
+                auth = request.auth,
+                authInterface = createAuthInterface(auth, protocolProfileBehavior),
+                handler = AuthLoader.getHandler(auth.type);
+
+            handler.sign(authInterface, request, _.noop);
+
+            expect(request.url.query.get('oauth_callback')).to.eql('http%3A%2F%2Fpostman.com');
+        });
+
+        it('should not encode signature params in query when the disableUrlEncoding option is true', function () {
+            var _rawReq = {
+                    url: 'https://postman-echo.com/oauth1',
+                    auth: {
+                        type: 'oauth1',
+                        oauth1: {
+                            consumerKey: 'RKCGzna7bv9YD57c',
+                            consumerSecret: 'D+EdQ-gs$-%@2Nu7',
+                            token: 'foo',
+                            tokenSecret: 'bar',
+                            signatureMethod: 'HMAC-SHA1',
+                            callback: 'http://postman.com',
+                            addParamsToHeader: false,
+                            addEmptyParamsToSign: false
+                        }
+                    }
+                },
+                protocolProfileBehavior = {
+                    disableUrlEncoding: true
+                },
+                request = new Request(_rawReq),
+                auth = request.auth,
+                authInterface = createAuthInterface(auth, protocolProfileBehavior),
+                handler = AuthLoader.getHandler(auth.type);
+
+            handler.sign(authInterface, request, _.noop);
+
+            expect(request.url.query.get('oauth_callback')).to.eql('http://postman.com');
+        });
     });
 
     describe('oauth2', function () {


### PR DESCRIPTION
**Task**: Update Authorizer to respect protocolProfileBehavior.disableUrlEncoding option
**Implementation**: Pass the protocolProfileBehaviour in `request-helpers-presend` in `createAuthInterface`. This is assigned to a private property `_protocolProfileBehavior` in `AuthInterface`, which defaults to `{}` when not passed.  Update Auth Handlers where parameter encoding is updated (only in OAuth1) to encode params according to this setting.

Add unit tests for the `sign` method in OAuth1 for this option and integration tests to make sure the setting is repsected.