### PR TITLE
When iterating a data file, loop back to the beginning...

### DIFF
--- a/lib/runner/extensions/waterfall.command.js
+++ b/lib/runner/extensions/waterfall.command.js
@@ -51,13 +51,8 @@ extractSNR = function (executions, previous) {
  * @return {Any} - The data for the iteration
  */
 getIterationData = function (data, iteration) {
-    // if iteration has a corresponding data element use that
-    if (iteration < data.length) {
-        return data[iteration];
-    }
-
-    // otherwise use the last data element
-    return data[data.length - 1];
+    // if iteration has a corresponding data element use that, otherwise, start from the beginning again.
+    return data[iteration % data.length];
 };
 
 /**


### PR DESCRIPTION
 rather than repeat the last element. For example, take the following data file:

```
[
    {"inputData":"foo"},
    {"inputData":"bar"}
]
```

If I were to run a collection with the following GET API: https://postman-echo.com/get?foo1={{inputData}} using the runner, several things happen:

1. When uploading the data file, it sets the iteration count to the length of the data array, in this case, 2. 
2. If the collection is run like that, it will run once with foo and once with bar.
3. After setting the data file, the iteration count can be changed. This can be useful for data seeding into an environment. For example, it can be set to 5.

the current behavior is to run once with foo and 4 times with bar. For data seeding, this is not ideal. this enhancement causes the iteration count, if greater than the number of rows in the data, to return to the first index of the data file and continue to invoke the APIs in the collection.

![image](https://user-images.githubusercontent.com/61213359/175451278-06a7079d-317c-4b08-b713-784afff15df9.png)
