### PR TITLE
Update httpntlm

### DIFF
--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -1,3 +1,7 @@
+unreleased:
+  chores:
+    - Updated httpntlm dependencies for NTLMv2 support
+
 7.29.2:
   date: 2022-06-06
   chores:

--- a/package-lock.json
+++ b/package-lock.json
@@ -3492,18 +3492,18 @@
       }
     },
     "httpntlm": {
-      "version": "1.7.7",
-      "resolved": "https://registry.npmjs.org/httpntlm/-/httpntlm-1.7.7.tgz",
-      "integrity": "sha512-Pv2Rvrz8H0qv1Dne5mAdZ9JegG1uc6Vu5lwLflIY6s8RKHdZQbW39L4dYswSgqMDT0pkJILUTKjeyU0VPNRZjA==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/httpntlm/-/httpntlm-1.8.1.tgz",
+      "integrity": "sha512-T3FfzKYAcvb1wNy91aW7jmdJUKl+/F3Uys2Vf1ZavFESVwDjqPMvJKQHz2pRHflhSTogflBsmvhU7dEZcBc4Nw==",
       "requires": {
         "httpreq": ">=0.4.22",
         "underscore": "~1.12.1"
       }
     },
     "httpreq": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/httpreq/-/httpreq-0.4.24.tgz",
-      "integrity": "sha1-QzX/2CzZaWaKOUZckprGHWOTYn8="
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/httpreq/-/httpreq-0.5.2.tgz",
+      "integrity": "sha512-2Jm+x9WkExDOeFRrdBCBSpLPT5SokTcRHkunV3pjKmX/cx6av8zQ0WtHUMDrYb6O4hBFzNU6sxJEypvRUVYKnw=="
     },
     "https-browserify": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "async": "3.2.3",
     "aws4": "1.11.0",
     "handlebars": "4.7.7",
-    "httpntlm": "1.7.7",
+    "httpntlm": "1.8.1",
     "js-sha512": "0.8.0",
     "lodash": "4.17.21",
     "mime-types": "2.1.35",


### PR DESCRIPTION
Updates httpntlm to 1.8.1 for NTLMv2 support. (Contains https://github.com/SamDecrock/node-http-ntlm/pull/101)

Fixes https://github.com/postmanlabs/postman-app-support/issues/8038