### PR TITLE
Fix the issue of sandbox context not getting garbage collected

### DIFF
--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -1,3 +1,9 @@
+unreleased:
+    fixed bugs:
+        - >-
+          GH-1373 Fixed a bug where execution.result and execution.skipRequest listeners
+          were not getting garbage collected
+
 7.36.2:
   date: 2024-01-19
   chores:

--- a/lib/runner/extensions/event.command.js
+++ b/lib/runner/extensions/event.command.js
@@ -20,6 +20,7 @@ var _ = require('lodash'),
     EXECUTION_ERROR_EVENT_BASE = 'execution.error.',
     EXECUTION_COOKIES_EVENT_BASE = 'execution.cookies.',
     EXECUTION_SKIP_REQUEST_EVENT_BASE = 'execution.skipRequest.',
+    EXECUTION_RESULT_EVENT_BASE = 'execution.result.',
 
     COOKIES_EVENT_STORE_ACTION = 'store',
     COOKIE_STORE_PUT_METHOD = 'putCookie',
@@ -179,7 +180,7 @@ module.exports = {
 
                     if (cursor && cursor.execution && isExecutionSkipped(cursor.execution)) { return; }
 
-                    handler.apply(context, arguments);
+                    handler.apply(run, arguments);
                 });
             };
 
@@ -480,6 +481,8 @@ module.exports = {
                     this.host.removeAllListeners(EXECUTION_RESPONSE_EVENT_BASE + executionId);
                     this.host.removeAllListeners(EXECUTION_COOKIES_EVENT_BASE + executionId);
                     this.host.removeAllListeners(EXECUTION_ERROR_EVENT_BASE + executionId);
+                    this.host.removeAllListeners(EXECUTION_SKIP_REQUEST_EVENT_BASE + executionId);
+                    this.host.removeAllListeners(EXECUTION_RESULT_EVENT_BASE + executionId);
 
                     // Handle async errors as well.
                     // If there was an error running the script itself, that takes precedence


### PR DESCRIPTION
The memory leak surfaced as a result of changes introduced in the following pull request: https://github.com/postmanlabs/postman-runtime/pull/1354/files. Two specific issues led to the memory leak:
1. We were not removing the Skip request event handler.
2. The override of `context.on` resulted in the inability of the garbage collector to handle all handlers attached through `context.on`.