### PR TITLE
Remove case sensitivity check for scheme and parameters name in Digest Auth

### DIFF
--- a/lib/authorizer/digest.js
+++ b/lib/authorizer/digest.js
@@ -141,7 +141,7 @@ _extractField = function (string, regexp) {
 function _getDigestAuthHeader (headers) {
     return headers.find(function (property) {
         return (property.key.toLowerCase() === WWW_AUTHENTICATE) &&
-        (_.startsWith(property.value.toString().toLowerCase(), DIGEST_PREFIX.toLowerCase()));
+        (_.startsWith(String(property.value).toLowerCase(), DIGEST_PREFIX.toLowerCase()));
     });
 }
 

--- a/lib/authorizer/digest.js
+++ b/lib/authorizer/digest.js
@@ -141,7 +141,7 @@ _extractField = function (string, regexp) {
 function _getDigestAuthHeader (headers) {
     return headers.find(function (property) {
         return (property.key.toLowerCase() === WWW_AUTHENTICATE) &&
-        (_.startsWith(property.value.toLowerCase(), DIGEST_PREFIX.toLowerCase()));
+        (_.startsWith(property.value.toString().toLowerCase(), DIGEST_PREFIX.toLowerCase()));
     });
 }
 

--- a/lib/authorizer/digest.js
+++ b/lib/authorizer/digest.js
@@ -51,10 +51,10 @@ var _ = require('lodash'),
         'uri'
     ],
 
-    nonceRegex = /nonce="([^"]*)"/,
-    realmRegex = /realm="([^"]*)"/,
-    qopRegex = /qop="([^"]*)"/,
-    opaqueRegex = /opaque="([^"]*)"/,
+    nonceRegex = /nonce="([^"]*)"/i,
+    realmRegex = /realm="([^"]*)"/i,
+    qopRegex = /qop="([^"]*)"/i,
+    opaqueRegex = /opaque="([^"]*)"/i,
     _extractField,
     SHA512_256,
     nodeCrypto;
@@ -140,7 +140,8 @@ _extractField = function (string, regexp) {
  */
 function _getDigestAuthHeader (headers) {
     return headers.find(function (property) {
-        return (property.key.toLowerCase() === WWW_AUTHENTICATE) && (_.startsWith(property.value, DIGEST_PREFIX));
+        return (property.key.toLowerCase() === WWW_AUTHENTICATE) &&
+        (_.startsWith(property.value.toLowerCase(), DIGEST_PREFIX.toLowerCase()));
     });
 }
 

--- a/test/fixtures/auth-requests.json
+++ b/test/fixtures/auth-requests.json
@@ -40,8 +40,8 @@
             }
         }
     },
-    "digestWithQueryParams": {
-        "url": "https://postman-echo.com/digest-auth?key=value",
+    "digestWithoutAdvanceData": {
+        "url": "https://postman-echo.com/digest-auth",
         "method": "GET",
         "header": [],
         "data": {
@@ -52,17 +52,34 @@
             "type": "digest",
             "digest": {
                 "username": "postman",
-                "realm": "Users",
                 "password": "password",
-                "nonce": "bcgEc5RPU1ANglyT2I0ShU0oxqPB5jXp",
-                "nonceCount": "00000001",
-                "algorithm": "MD5",
-                "qop": "",
-                "clientNonce": "0a4f113b",
-                "opaque": "5ccc069c403ebaf9f0171e9517f40e"
+                "clientNonce": "0a4f113b"
             }
         }
     },
+    "digestWithQueryParams": {
+      "url": "https://postman-echo.com/digest-auth?key=value",
+      "method": "GET",
+      "header": [],
+      "data": {
+          "mode": "formdata",
+          "content": []
+      },
+      "auth": {
+          "type": "digest",
+          "digest": {
+              "username": "postman",
+              "realm": "Users",
+              "password": "password",
+              "nonce": "bcgEc5RPU1ANglyT2I0ShU0oxqPB5jXp",
+              "nonceCount": "00000001",
+              "algorithm": "MD5",
+              "qop": "",
+              "clientNonce": "0a4f113b",
+              "opaque": "5ccc069c403ebaf9f0171e9517f40e"
+          }
+      }
+  },
     "oauth1": {
         "auth": {
             "type": "oauth1",

--- a/test/unit/auth-handlers.test.js
+++ b/test/unit/auth-handlers.test.js
@@ -504,6 +504,41 @@ describe('Auth Handler:', function () {
     });
 
     describe('digest', function () {
+        it('should add the Auth header when we have upper case scheme and parameters names', function () {
+            var request = new Request(rawRequests.digestWithoutAdvanceData),
+                auth = request.auth,
+                authInterface = createAuthInterface(auth),
+                handler = AuthLoader.getHandler(auth.type),
+                digestData = auth.digest.members,
+                digestDataObject = {},
+                expectedDigestData = {
+                    username: 'postman',
+                    password: 'password',
+                    nonce: '123abc',
+                    realm: 'newRealm',
+                    qop: 'auth',
+                    clientNonce: '0a4f113b',
+                    nonceCount: '00000001'
+                },
+                response = {
+                    code: 401,
+                    headers: [
+                        {
+                            key: 'WWW-Authenticate',
+                            value: 'digest Realm="newRealm", Nonce="123abc", Qop="auth"'
+                        }
+                    ]
+                };
+
+            handler.post(authInterface, response, _.noop);
+
+            _.forEach(digestData, function ({ value, key }) {
+                digestDataObject[key] = value;
+            });
+
+            expect(digestDataObject).to.eql(expectedDigestData);
+        });
+
         it('should add the Auth header for (algorithm="MD5", qop=""', function () {
             var request = new Request(rawRequests.digest),
                 auth = request.auth,


### PR DESCRIPTION
As per [RFC-6617](https://datatracker.ietf.org/doc/html/rfc7617#section-2), the scheme and parameters should be handled case-insensitively.
As part of this PR I have removed the case sensitive checks

issue link - https://github.com/postmanlabs/postman-app-support/issues/12727