### PR TITLE
Serialised errors received on executing pm.sendRequest

### DIFF
--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -1,3 +1,7 @@
+unreleased:
+  fixed bugs:
+    - Fixed a bug where errors from `pm.sendRequest` were not transmitted correctly
+
 7.40.0:
   date: 2024-06-19
   new features:

--- a/lib/requester/requester.js
+++ b/lib/requester/requester.js
@@ -418,7 +418,7 @@ class Requester extends EventEmitter {
         // we can't trust the integrity of this request
         // bail out if request url is empty
         if (!(request && request.url && request.url.toString && request.url.toString())) {
-            return onEnd(new Error('runtime:extensions~request: request url is empty'));
+            return onEnd(new Error('runtime: request url is empty'));
         }
 
         cookieJar = self.options.cookieJar;

--- a/lib/runner/extensions/event.command.js
+++ b/lib/runner/extensions/event.command.js
@@ -434,7 +434,10 @@ module.exports = {
                                     // instance once it is fully supported
                                     result && { cookies: result.cookies });
                             }).catch(function (err) {
-                                this.host.dispatch(EXECUTION_RESPONSE_EVENT_BASE + id, requestId, err);
+                                const error = serialisedError(err);
+
+                                delete error.stack; // remove stack to avoid leaking runtime internals
+                                this.host.dispatch(EXECUTION_RESPONSE_EVENT_BASE + id, requestId, error);
                             });
                         }.bind(this));
                     }.bind(this));

--- a/test/integration/request-flow/requests-from-sandbox.test.js
+++ b/test/integration/request-flow/requests-from-sandbox.test.js
@@ -290,6 +290,7 @@ describe('requests from sandbox', function () {
                                 pm.sendRequest({}, function(err, _response) {
                                     pm.test('request did not complete', function () {
                                         pm.expect(err).to.not.eql(null);
+                                        pm.expect(err).to.have.property('message');
                                         pm.expect(_response).to.not.be.ok;
                                     });
                                 });

--- a/test/integration/sanity/url-sanity-before-request.test.js
+++ b/test/integration/sanity/url-sanity-before-request.test.js
@@ -188,7 +188,7 @@ describe('url', function () {
         });
 
         it('should have called request event once', function () {
-            var emptyUrlErrorMessage = 'runtime:extensions~request: request url is empty';
+            var emptyUrlErrorMessage = 'runtime: request url is empty';
 
             expect(testrun).to.nested.include({
                 'request.callCount': 1


### PR DESCRIPTION
Issue:

Errors from pm.sendRequest, when transmitted out of postman-runtime didn't have the complete message, stack trace and other related information. This happened because of sending the error object inside the sandbox using messagePort lost certain information during serialization.

Fix:

Serialize error (convert to plan JS object) to make it safe for transmission across different realms.