### PR TITLE
[TRUST-1439] Remove port from host when matching vault scope patterns

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -29,9 +29,9 @@
         "no-await-in-loop": "error",
         "no-compare-neg-zero": "error",
         "no-cond-assign": "error",
-        // "no-console": ["error", {
-        //     "allow": ["info", "warn", "error"]
-        // }],
+        "no-console": ["error", {
+            "allow": ["info", "warn", "error"]
+        }],
         "no-constant-condition": "error",
         "no-control-regex": "error",
         "no-constructor-return": "error",

--- a/.eslintrc
+++ b/.eslintrc
@@ -29,9 +29,9 @@
         "no-await-in-loop": "error",
         "no-compare-neg-zero": "error",
         "no-cond-assign": "error",
-        "no-console": ["error", {
-            "allow": ["info", "warn", "error"]
-        }],
+        // "no-console": ["error", {
+        //     "allow": ["info", "warn", "error"]
+        // }],
         "no-constant-condition": "error",
         "no-control-regex": "error",
         "no-constructor-return": "error",

--- a/lib/runner/util.js
+++ b/lib/runner/util.js
@@ -198,10 +198,16 @@ module.exports = {
 
             // convert the domains to UrlMatchPattern
             variable._.domainPatterns = new UrlMatchPatternList(null, domains.map((domain) => {
-                const url = new Url(domain);
+                const url = new Url(domain),
+
+                    // Get the host without port
+                    hostWithoutPort = url.getRemote().replace(/:\d+$/, ''),
+
+                    // Create a pattern that matches with or without port
+                    hostPattern = `${hostWithoutPort}(:\\d+)?`;
 
                 // @note URL path is ignored
-                return `${url.protocol || 'https'}://${url.getRemote()}/*`;
+                return `${url.protocol || 'https'}://${hostPattern}/*`;
             }));
         });
 
@@ -219,16 +225,15 @@ module.exports = {
                 return scope.values;
             }
 
-            const urlWithoutPort = urlString.replace(/:\d+/, ''),
-                variables = scope.values.filter((variable) => {
-                    const domainPatterns = variable && variable._ && variable._.domainPatterns;
+            const variables = scope.values.filter((variable) => {
+                const domainPatterns = variable && variable._ && variable._.domainPatterns;
 
-                    if (!domainPatterns) {
-                        return true;
-                    }
+                if (!domainPatterns) {
+                    return true;
+                }
 
-                    return domainPatterns.test(urlWithoutPort);
-                });
+                return domainPatterns.test(urlString);
+            });
 
             return new VariableList(null, variables.map((variable) => {
                 return variable.toJSON(); // clone the variable

--- a/lib/runner/util.js
+++ b/lib/runner/util.js
@@ -219,15 +219,16 @@ module.exports = {
                 return scope.values;
             }
 
-            const variables = scope.values.filter((variable) => {
-                const domainPatterns = variable && variable._ && variable._.domainPatterns;
+            const urlWithoutPort = urlString.replace(/:\d+/, ''),
+                variables = scope.values.filter((variable) => {
+                    const domainPatterns = variable && variable._ && variable._.domainPatterns;
 
-                if (!domainPatterns) {
-                    return true;
-                }
+                    if (!domainPatterns) {
+                        return true;
+                    }
 
-                return domainPatterns.test(urlString);
-            });
+                    return domainPatterns.test(urlWithoutPort);
+                });
 
             return new VariableList(null, variables.map((variable) => {
                 return variable.toJSON(); // clone the variable

--- a/lib/runner/util.js
+++ b/lib/runner/util.js
@@ -206,6 +206,8 @@ module.exports = {
                     // Create a pattern that matches with or without port
                     hostPattern = `${hostWithoutPort}(:\\d+)?`;
 
+                console.log(hostPattern, 'hostPattern');
+
                 // @note URL path is ignored
                 return `${url.protocol || 'https'}://${hostPattern}/*`;
             }));
@@ -227,6 +229,8 @@ module.exports = {
 
             const variables = scope.values.filter((variable) => {
                 const domainPatterns = variable && variable._ && variable._.domainPatterns;
+
+                console.log(domainPatterns, urlString, 'domainPatterns, urlString');
 
                 if (!domainPatterns) {
                     return true;

--- a/lib/runner/util.js
+++ b/lib/runner/util.js
@@ -223,6 +223,9 @@ module.exports = {
                 variables = scope.values.filter((variable) => {
                     const domainPatterns = variable && variable._ && variable._.domainPatterns;
 
+                    console.log(domainPatterns, 'domainPatterns');
+                    console.log(urlWithoutPort, 'urlWithoutPort');
+
                     if (!domainPatterns) {
                         return true;
                     }

--- a/lib/runner/util.js
+++ b/lib/runner/util.js
@@ -223,9 +223,6 @@ module.exports = {
                 variables = scope.values.filter((variable) => {
                     const domainPatterns = variable && variable._ && variable._.domainPatterns;
 
-                    console.log(domainPatterns, 'domainPatterns');
-                    console.log(urlWithoutPort, 'urlWithoutPort');
-
                     if (!domainPatterns) {
                         return true;
                     }


### PR DESCRIPTION
## Changes
This PR modifies the vault scope matching logic to ignore the port number when comparing against domain patterns. This change ensures that variables are correctly filtered regardless of whether a port is specified in the URL.

## Implementation
- In `lib/runner/util.js`, we now strip the port from the URL before testing it against domain patterns.
- This is achieved by using a regex to remove any port number (`:digits`) from the URL string.

## Motivation
This change addresses an issue where vault scopes were not being correctly applied when the URL included a port number, potentially leading to incorrect variable filtering.

## Testing
- Verify that vault scopes are correctly applied for URLs both with and without port numbers.
- Ensure existing functionality remains intact for URLs without ports.

## Related
Ticket: TRUST-1439