### PR TITLE
Fix domain matching for Vault variables

### DIFF
--- a/lib/runner/util.js
+++ b/lib/runner/util.js
@@ -201,7 +201,7 @@ module.exports = {
                 const url = new Url(domain);
 
                 // @note URL path is ignored
-                return `${url.protocol || 'https'}://${url.getRemote()}/*`;
+                return `${url.protocol || 'https'}://${url.getRemote()}:*/*`;
             }));
         });
 


### PR DESCRIPTION
This PR addresses the issue where Vault variables were being sent as {{vault:token}} instead of their actual values. The problem was caused by incorrect domain matching in the variable resolution process.

Changes made:
1. Updated the URL pattern generation in lib/runner/util.js to correctly handle domains with and without ports.

This fix should resolve the issue reported in the community post:
https://community.postman.com/t/using-vault-sends-values-as-vault-token-instead-of-real-value/68970