### PR TITLE
Refactor vault access handling in event command

### DIFF
--- a/lib/runner/extensions/event.command.js
+++ b/lib/runner/extensions/event.command.js
@@ -239,19 +239,13 @@ module.exports = {
                 // @todo: find a better home for this option processing
                 abortOnFailure = payload.abortOnFailure,
                 stopOnFailure = payload.stopOnFailure,
-
-                packageResolver = _.get(this, 'options.script.packageResolver'),
-
                 vaultSecrets = payload.context.vaultSecrets,
-                allowVaultAccess = _.get(vaultSecrets, '_.allowScriptAccess'),
-
+                isVaultAccessInScriptsAllowed = vaultSecrets._.allowScriptAccess,
+                packageResolver = _.get(this, 'options.script.packageResolver'),
                 events;
 
             // Explicitly enable tracking for vault secrets here as this will
             // not be sent to sandbox who otherwise takes care of mutation tracking
-            if (allowVaultAccess) {
-                vaultSecrets.enableTracking({ autoCompact: true });
-            }
 
             // @todo: find a better place to code this so that event is not aware of such options
             if (abortOnFailure) {
@@ -398,12 +392,23 @@ module.exports = {
                         }
                     }.bind(this));
 
-                this.host.on(EXECUTION_VAULT_BASE + executionId, function (id, cmd, ...args) {
+                this.host.on(EXECUTION_VAULT_BASE + executionId, async function (id, cmd, ...args) {
+                    let isVaultAccessAllowed;
+
+                    if (typeof isVaultAccessInScriptsAllowed === 'function') {
+                        isVaultAccessAllowed = await isVaultAccessInScriptsAllowed(item.id);
+                    }
+                    else {
+                        isVaultAccessAllowed = isVaultAccessInScriptsAllowed;
+                    }
+                    if (isVaultAccessAllowed) {
+                        vaultSecrets.enableTracking({ autoCompact: true });
+                    }
                     // Ensure error is string
                     // TODO identify why error objects are not being serialized correctly
                     const dispatch = (e, r) => { this.host.dispatch(EXECUTION_VAULT_BASE + executionId, id, e, r); };
 
-                    if (!allowVaultAccess) {
+                    if (!isVaultAccessAllowed) {
                         return dispatch('Vault access denied');
                     }
 
@@ -556,7 +561,7 @@ module.exports = {
                             result && result.request && (result.request = new sdk.Request(result.request));
 
                             // vault secrets are not sent to sandbox, thus using the scope from run context.
-                            if (allowVaultAccess && vaultSecrets) {
+                            if (isVaultAccessInScriptsAllowed && vaultSecrets) {
                                 result.vaultSecrets = vaultSecrets;
 
                                 // Prevent mutations from being carry-forwarded to subsequent events

--- a/lib/runner/extensions/event.command.js
+++ b/lib/runner/extensions/event.command.js
@@ -242,7 +242,8 @@ module.exports = {
                 vaultSecrets = payload.context.vaultSecrets,
                 isVaultAccessInScriptsAllowed = vaultSecrets._.allowScriptAccess,
                 packageResolver = _.get(this, 'options.script.packageResolver'),
-                events;
+                events,
+                isVaultAccessAllowed;
 
             // Explicitly enable tracking for vault secrets here as this will
             // not be sent to sandbox who otherwise takes care of mutation tracking
@@ -393,8 +394,6 @@ module.exports = {
                     }.bind(this));
 
                 this.host.on(EXECUTION_VAULT_BASE + executionId, async function (id, cmd, ...args) {
-                    let isVaultAccessAllowed;
-
                     if (typeof isVaultAccessInScriptsAllowed === 'function') {
                         isVaultAccessAllowed = await isVaultAccessInScriptsAllowed(item.id);
                     }
@@ -561,7 +560,7 @@ module.exports = {
                             result && result.request && (result.request = new sdk.Request(result.request));
 
                             // vault secrets are not sent to sandbox, thus using the scope from run context.
-                            if (isVaultAccessInScriptsAllowed && vaultSecrets) {
+                            if (isVaultAccessAllowed && vaultSecrets) {
                                 result.vaultSecrets = vaultSecrets;
 
                                 // Prevent mutations from being carry-forwarded to subsequent events

--- a/lib/runner/extensions/event.command.js
+++ b/lib/runner/extensions/event.command.js
@@ -394,14 +394,20 @@ module.exports = {
                     }.bind(this));
 
                 this.host.on(EXECUTION_VAULT_BASE + executionId, async function (id, cmd, ...args) {
-                    if (typeof isVaultAccessInScriptsAllowed === 'function') {
-                        isVaultAccessAllowed = await isVaultAccessInScriptsAllowed(item.id);
+                    try {
+                        if (typeof isVaultAccessInScriptsAllowed === 'function') {
+                            isVaultAccessAllowed = await isVaultAccessInScriptsAllowed(item.id);
+                        }
+                        else {
+                            isVaultAccessAllowed = isVaultAccessInScriptsAllowed;
+                        }
+                        if (isVaultAccessAllowed) {
+                            vaultSecrets.enableTracking({ autoCompact: true });
+                        }
                     }
-                    else {
-                        isVaultAccessAllowed = isVaultAccessInScriptsAllowed;
-                    }
-                    if (isVaultAccessAllowed) {
-                        vaultSecrets.enableTracking({ autoCompact: true });
+                    catch (error) {
+                        console.error(error.message);
+                        isVaultAccessAllowed = false;
                     }
                     // Ensure error is string
                     // TODO identify why error objects are not being serialized correctly

--- a/lib/runner/extensions/event.command.js
+++ b/lib/runner/extensions/event.command.js
@@ -240,7 +240,7 @@ module.exports = {
                 abortOnFailure = payload.abortOnFailure,
                 stopOnFailure = payload.stopOnFailure,
                 vaultSecrets = payload.context.vaultSecrets,
-                isVaultAccessInScriptsAllowed = vaultSecrets._.allowScriptAccess,
+                isVaultAccessInScriptsAllowed = _.get(vaultSecrets, '_.allowScriptAccess'),
                 packageResolver = _.get(this, 'options.script.packageResolver'),
                 events,
                 isVaultAccessAllowed;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "postman-runtime",
-  "version": "7.42.0",
+  "name": "postman-runtime-saksham-dev",
+  "version": "7.42.2-dev",
   "description": "Underlying library of executing Postman Collections",
   "author": "Postman Inc.",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "postman-runtime-saksham-dev",
-  "version": "7.42.2-dev",
+  "name": "postman-runtime",
+  "version": "7.42.0",
   "description": "Underlying library of executing Postman Collections",
   "author": "Postman Inc.",
   "license": "Apache-2.0",


### PR DESCRIPTION
This PR refactors how vault access is handled in the event command extension:

- Renames allowVaultAccess to isVaultAccessInScriptsAllowed for clarity
- Moves vault access check and tracking enablement into the vault execution handler
- Adds support for isVaultAccessInScriptsAllowed to be either a boolean or an async function
- Updates vault access check to use the new isVaultAccessInScriptsAllowed approach