### PR TITLE
Refactor vault access handling in event command

### DIFF
--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -1,3 +1,7 @@
+unreleased:
+  new features:
+    - GH-1478 Added support for lazily fetching vault access status
+
 7.42.0:
   date: 2024-09-04
   new features:

--- a/lib/runner/extensions/event.command.js
+++ b/lib/runner/extensions/event.command.js
@@ -239,12 +239,15 @@ module.exports = {
                 // @todo: find a better home for this option processing
                 abortOnFailure = payload.abortOnFailure,
                 stopOnFailure = payload.stopOnFailure,
-                vaultSecrets = payload.context.vaultSecrets,
-                isVaultAccessInScriptsAllowed = _.get(vaultSecrets, '_.allowScriptAccess'),
-                packageResolver = _.get(this, 'options.script.packageResolver'),
-                events,
-                isVaultAccessAllowed;
 
+                packageResolver = _.get(this, 'options.script.packageResolver'),
+
+                vaultSecrets = payload.context.vaultSecrets,
+                // Do not assign any initial value here as it will be used
+                // to determine if the vault access check was done or not
+                hasVaultAccess,
+
+                events;
 
             // @todo: find a better place to code this so that event is not aware of such options
             if (abortOnFailure) {
@@ -392,38 +395,32 @@ module.exports = {
                     }.bind(this));
 
                 this.host.on(EXECUTION_VAULT_BASE + executionId, async function (id, cmd, ...args) {
-                    let currentIsVaultAccessAllowed = false;
-
-                    if (isVaultAccessAllowed === undefined) {
+                    if (hasVaultAccess === undefined) {
                         try {
-                            currentIsVaultAccessAllowed = Boolean(await isVaultAccessInScriptsAllowed(item.id));
+                            // eslint-disable-next-line require-atomic-updates
+                            hasVaultAccess = Boolean(await vaultSecrets?._?.allowScriptAccess(item.id));
                         }
-                        catch (error) {
-                            currentIsVaultAccessAllowed = false;
+                        catch (_) {
+                            // eslint-disable-next-line require-atomic-updates
+                            hasVaultAccess = false;
                         }
-                        // eslint-disable-next-line require-atomic-updates
-                        isVaultAccessAllowed = currentIsVaultAccessAllowed;
-                    }
-                    else {
-                        currentIsVaultAccessAllowed = isVaultAccessAllowed;
                     }
 
-                    // Explicitly enable tracking for vault secrets here as this will
-                    // not be sent to sandbox who otherwise takes care of mutation tracking
-                    if (currentIsVaultAccessAllowed) {
-                        vaultSecrets.enableTracking({ autoCompact: true });
-                    }
                     // Ensure error is string
                     // TODO identify why error objects are not being serialized correctly
                     const dispatch = (e, r) => { this.host.dispatch(EXECUTION_VAULT_BASE + executionId, id, e, r); };
 
-                    if (!currentIsVaultAccessAllowed) {
+                    if (!hasVaultAccess) {
                         return dispatch('Vault access denied');
                     }
 
                     if (!['get', 'set', 'unset'].includes(cmd)) {
                         return dispatch(`Invalid vault command: ${cmd}`);
                     }
+
+                    // Explicitly enable tracking for vault secrets here as this will
+                    // not be sent to sandbox who otherwise takes care of mutation tracking
+                    vaultSecrets.enableTracking({ autoCompact: true });
 
                     dispatch(null, vaultSecrets[cmd](...args));
                 }.bind(this));
@@ -570,7 +567,7 @@ module.exports = {
                             result && result.request && (result.request = new sdk.Request(result.request));
 
                             // vault secrets are not sent to sandbox, thus using the scope from run context.
-                            if (isVaultAccessAllowed && vaultSecrets) {
+                            if (hasVaultAccess && vaultSecrets) {
                                 result.vaultSecrets = vaultSecrets;
 
                                 // Prevent mutations from being carry-forwarded to subsequent events

--- a/lib/runner/extensions/event.command.js
+++ b/lib/runner/extensions/event.command.js
@@ -245,8 +245,6 @@ module.exports = {
                 events,
                 isVaultAccessAllowed;
 
-            // Explicitly enable tracking for vault secrets here as this will
-            // not be sent to sandbox who otherwise takes care of mutation tracking
 
             // @todo: find a better place to code this so that event is not aware of such options
             if (abortOnFailure) {
@@ -394,26 +392,32 @@ module.exports = {
                     }.bind(this));
 
                 this.host.on(EXECUTION_VAULT_BASE + executionId, async function (id, cmd, ...args) {
-                    try {
-                        if (typeof isVaultAccessInScriptsAllowed === 'function') {
-                            isVaultAccessAllowed = await isVaultAccessInScriptsAllowed(item.id);
+                    let currentIsVaultAccessAllowed = false;
+
+                    if (isVaultAccessAllowed === undefined) {
+                        try {
+                            currentIsVaultAccessAllowed = Boolean(await isVaultAccessInScriptsAllowed(item.id));
                         }
-                        else {
-                            isVaultAccessAllowed = isVaultAccessInScriptsAllowed;
+                        catch (error) {
+                            currentIsVaultAccessAllowed = false;
                         }
-                        if (isVaultAccessAllowed) {
-                            vaultSecrets.enableTracking({ autoCompact: true });
-                        }
+                        // eslint-disable-next-line require-atomic-updates
+                        isVaultAccessAllowed = currentIsVaultAccessAllowed;
                     }
-                    catch (error) {
-                        console.error(error.message);
-                        isVaultAccessAllowed = false;
+                    else {
+                        currentIsVaultAccessAllowed = isVaultAccessAllowed;
+                    }
+
+                    // Explicitly enable tracking for vault secrets here as this will
+                    // not be sent to sandbox who otherwise takes care of mutation tracking
+                    if (currentIsVaultAccessAllowed) {
+                        vaultSecrets.enableTracking({ autoCompact: true });
                     }
                     // Ensure error is string
                     // TODO identify why error objects are not being serialized correctly
                     const dispatch = (e, r) => { this.host.dispatch(EXECUTION_VAULT_BASE + executionId, id, e, r); };
 
-                    if (!isVaultAccessAllowed) {
+                    if (!currentIsVaultAccessAllowed) {
                         return dispatch('Vault access denied');
                     }
 

--- a/lib/runner/extensions/event.command.js
+++ b/lib/runner/extensions/event.command.js
@@ -239,19 +239,14 @@ module.exports = {
                 // @todo: find a better home for this option processing
                 abortOnFailure = payload.abortOnFailure,
                 stopOnFailure = payload.stopOnFailure,
-
-                packageResolver = _.get(this, 'options.script.packageResolver'),
-
                 vaultSecrets = payload.context.vaultSecrets,
-                allowVaultAccess = _.get(vaultSecrets, '_.allowScriptAccess'),
-
-                events;
+                isVaultAccessInScriptsAllowed = _.get(vaultSecrets, '_.allowScriptAccess'),
+                packageResolver = _.get(this, 'options.script.packageResolver'),
+                events,
+                isVaultAccessAllowed;
 
             // Explicitly enable tracking for vault secrets here as this will
             // not be sent to sandbox who otherwise takes care of mutation tracking
-            if (allowVaultAccess) {
-                vaultSecrets.enableTracking({ autoCompact: true });
-            }
 
             // @todo: find a better place to code this so that event is not aware of such options
             if (abortOnFailure) {
@@ -398,12 +393,27 @@ module.exports = {
                         }
                     }.bind(this));
 
-                this.host.on(EXECUTION_VAULT_BASE + executionId, function (id, cmd, ...args) {
+                this.host.on(EXECUTION_VAULT_BASE + executionId, async function (id, cmd, ...args) {
+                    try {
+                        if (typeof isVaultAccessInScriptsAllowed === 'function') {
+                            isVaultAccessAllowed = await isVaultAccessInScriptsAllowed(item.id);
+                        }
+                        else {
+                            isVaultAccessAllowed = isVaultAccessInScriptsAllowed;
+                        }
+                        if (isVaultAccessAllowed) {
+                            vaultSecrets.enableTracking({ autoCompact: true });
+                        }
+                    }
+                    catch (error) {
+                        console.error(error.message);
+                        isVaultAccessAllowed = false;
+                    }
                     // Ensure error is string
                     // TODO identify why error objects are not being serialized correctly
                     const dispatch = (e, r) => { this.host.dispatch(EXECUTION_VAULT_BASE + executionId, id, e, r); };
 
-                    if (!allowVaultAccess) {
+                    if (!isVaultAccessAllowed) {
                         return dispatch('Vault access denied');
                     }
 
@@ -556,7 +566,7 @@ module.exports = {
                             result && result.request && (result.request = new sdk.Request(result.request));
 
                             // vault secrets are not sent to sandbox, thus using the scope from run context.
-                            if (allowVaultAccess && vaultSecrets) {
+                            if (isVaultAccessAllowed && vaultSecrets) {
                                 result.vaultSecrets = vaultSecrets;
 
                                 // Prevent mutations from being carry-forwarded to subsequent events

--- a/test/integration/sanity/variable-changes.test.js
+++ b/test/integration/sanity/variable-changes.test.js
@@ -9,7 +9,7 @@ describe('variable changes', function () {
             requester: { followRedirects: false },
             vaultSecrets: {
                 id: 'vault',
-                _allowScriptAccess: true,
+                _allowScriptAccess: function () { return true; },
                 values: [
                     { key: 'vault:key5', value: 'vault-value-5', enabled: true },
                     { key: 'vault:key6', value: 'vault-value-6', enabled: true }

--- a/test/integration/sanity/vaultSecrets.test.js
+++ b/test/integration/sanity/vaultSecrets.test.js
@@ -619,7 +619,7 @@ describe('vaultSecrets', function () {
                     vaultSecrets: {
                         id: 'vault',
                         prefix: 'vault:',
-                        _allowScriptAccess: true,
+                        _allowScriptAccess: function () { return true; },
                         values: [
                             {
                                 key: 'vault:var1',
@@ -714,7 +714,7 @@ describe('vaultSecrets', function () {
                     vaultSecrets: {
                         id: 'vault',
                         prefix: 'vault:',
-                        _allowScriptAccess: true,
+                        _allowScriptAccess: function () { return true; },
                         values: [
                             {
                                 key: 'vault:var1',
@@ -766,7 +766,7 @@ describe('vaultSecrets', function () {
                     vaultSecrets: {
                         id: 'vault',
                         prefix: 'vault:',
-                        _allowScriptAccess: true,
+                        _allowScriptAccess: function () { return true; },
                         values: [
                             {
                                 key: 'vault:var1',
@@ -819,7 +819,7 @@ describe('vaultSecrets', function () {
                     vaultSecrets: {
                         id: 'vault',
                         prefix: 'vault:',
-                        _allowScriptAccess: true,
+                        _allowScriptAccess: function () { return true; },
                         values: [
                             {
                                 key: 'vault:var1',
@@ -876,7 +876,7 @@ describe('vaultSecrets', function () {
                     vaultSecrets: {
                         id: 'vault',
                         prefix: 'vault:',
-                        _allowScriptAccess: true,
+                        _allowScriptAccess: function () { return true; },
                         values: [
                             {
                                 key: 'vault:var1',


### PR DESCRIPTION
This PR refactors how vault access is handled in the event command extension:

Renames allowVaultAccess to isVaultAccessInScriptsAllowed for clarity
Moves vault access check and tracking enablement into the vault execution handler
Adds support for isVaultAccessInScriptsAllowed to be either a boolean or an async function
Updates vault access check to use the new isVaultAccessInScriptsAllowed approach