### PR TITLE
Defer loading the 'serialised-error' module

### DIFF
--- a/lib/runner/extensions/event.command.js
+++ b/lib/runner/extensions/event.command.js
@@ -47,6 +47,7 @@ postProcessContext = function (execution, failures) { // function determines whe
         return undefined;
     }
     const serialisedError = require('serialised-error');
+
     return serialisedError(error, true);
 };
 
@@ -475,8 +476,8 @@ module.exports = {
                                     // instance once it is fully supported
                                     result && { cookies: result.cookies });
                             }).catch(function (err) {
-                                const serialisedError = require('serialised-error');
-                                const error = serialisedError(err);
+                                const serialisedError = require('serialised-error'),
+                                    error = serialisedError(err);
 
                                 delete error.stack; // remove stack to avoid leaking runtime internals
                                 this.host.dispatch(EXECUTION_RESPONSE_EVENT_BASE + id, requestId, error);
@@ -528,6 +529,7 @@ module.exports = {
                             // electron IPC does not bubble errors to the browser process, so we serialize it here.
                             if (err) {
                                 const serialisedError = require('serialised-error');
+
                                 err = serialisedError(err, true);
                             }
 

--- a/lib/runner/extensions/event.command.js
+++ b/lib/runner/extensions/event.command.js
@@ -5,7 +5,6 @@ var _ = require('lodash'),
     util = require('../util'),
     sdk = require('postman-collection'),
     sandbox = require('postman-sandbox'),
-    serialisedError = require('serialised-error'),
     ToughCookie = require('@postman/tough-cookie').Cookie,
 
     createItemContext = require('../create-item-context'),
@@ -44,7 +43,11 @@ postProcessContext = function (execution, failures) { // function determines whe
         error.name = ASSERTION_FAILURE;
     }
 
-    return error ? serialisedError(error, true) : undefined;
+    if (!error) {
+        return undefined;
+    }
+    const serialisedError = require('serialised-error');
+    return serialisedError(error, true);
 };
 
 /**
@@ -472,6 +475,7 @@ module.exports = {
                                     // instance once it is fully supported
                                     result && { cookies: result.cookies });
                             }).catch(function (err) {
+                                const serialisedError = require('serialised-error');
                                 const error = serialisedError(err);
 
                                 delete error.stack; // remove stack to avoid leaking runtime internals
@@ -522,7 +526,10 @@ module.exports = {
                             }
 
                             // electron IPC does not bubble errors to the browser process, so we serialize it here.
-                            err && (err = serialisedError(err, true));
+                            if (err) {
+                                const serialisedError = require('serialised-error');
+                                err = serialisedError(err, true);
+                            }
 
                             // if it is defined that certain variables are to be synced back to result, we do the same
                             track && result && track.forEach(function (variable) {


### PR DESCRIPTION
The 'serialised-error' module is only required when there is an error, so this change improves the loading time of this module by loading it only when it is needed for error processing.

Refs: https://github.com/postman-eng/postman-app/pull/16666
cc @postmanlabs/starship 