### PR TITLE
also pass environment to beforeItem

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,9 +264,10 @@ runner.run(collection, { /* options */ }, function(err, run) {
         },
 
         // Called before running a new Item (check the postman collection v2 format for what Item means)
-        beforeItem: function (err, cursor, item) {
+        beforeItem: function (err, cursor, item, environment) {
             // err, cursor: Same as arguments for "start"
             // item: sdk.Item
+            // environment: <VariableScope>
         },
 
         // Called after completion of an Item

--- a/lib/runner/extensions/item.command.js
+++ b/lib/runner/extensions/item.command.js
@@ -132,7 +132,7 @@ module.exports = {
             coords.ref = uuid.v4();
 
             // here we code to queue prerequest script, then make a request and then execute test script
-            this.triggers.beforeItem(null, coords, item);
+            this.triggers.beforeItem(null, coords, item, environment);
 
             this.queueDelay(function () {
                 // create the context object for scripts to run


### PR DESCRIPTION
pass environment to beforeItem. This way I can use it in a custom reporter in the context of newman (requires also an adjustment in newman/run/index.js `runtimeEvents` to work).

I don't know whether it makes sense to also pass globals etc. for my use case I only need env