### PR TITLE
Updated error message when vault script access is not provided.

### DIFF
--- a/lib/runner/extensions/event.command.js
+++ b/lib/runner/extensions/event.command.js
@@ -411,7 +411,8 @@ module.exports = {
                     const dispatch = (e, r) => { this.host.dispatch(EXECUTION_VAULT_BASE + executionId, id, e, r); };
 
                     if (!hasVaultAccess) {
-                        return dispatch('Vault access denied');
+                        return dispatch('Vault access denied.' +
+                            ' To allow script access, go to Vault settings and turn on "Enable support in scripts"');
                     }
 
                     if (!['get', 'set', 'unset'].includes(cmd)) {

--- a/test/integration/sanity/vaultSecrets.test.js
+++ b/test/integration/sanity/vaultSecrets.test.js
@@ -1064,7 +1064,8 @@ describe('vaultSecrets', function () {
                     'exception.calledOnce': true
                 });
 
-                expect(testrun.exception.firstCall.args[1]).to.have.property('message', 'Vault access denied');
+                expect(testrun.exception.firstCall.args[1]).to.have.property('message', 'Vault access denied.' +
+                    ' To allow script access, go to Vault settings and turn on "Enable support in scripts"');
             });
 
             it('should not contain vault secrets', function () {
@@ -1138,7 +1139,8 @@ describe('vaultSecrets', function () {
             it('should deny vault access for item2', function () {
                 var prConsoleArgs = testrun.console.getCall(1).args.slice(2);
 
-                expect(prConsoleArgs).to.deep.equal(['Vault access denied']);
+                expect(prConsoleArgs).to.deep.equal(['Vault access denied.' +
+                    ' To allow script access, go to Vault settings and turn on "Enable support in scripts"']);
             });
         });
 
@@ -1188,7 +1190,8 @@ describe('vaultSecrets', function () {
                 var consoleArgs = testrun.console.getCall(0).args.slice(2);
 
                 expect(consoleArgs[0]).to.equal('Vault error:');
-                expect(consoleArgs[1]).to.equal('Vault access denied');
+                expect(consoleArgs[1]).to.equal('Vault access denied.' +
+                    ' To allow script access, go to Vault settings and turn on "Enable support in scripts"');
             });
         });
 
@@ -1238,7 +1241,8 @@ describe('vaultSecrets', function () {
                 var consoleArgs = testrun.console.getCall(0).args.slice(2);
 
                 expect(consoleArgs[0]).to.equal('Vault error:');
-                expect(consoleArgs[1]).to.equal('Vault access denied');
+                expect(consoleArgs[1]).to.equal('Vault access denied.' +
+                    ' To allow script access, go to Vault settings and turn on "Enable support in scripts"');
             });
         });
     });


### PR DESCRIPTION
## Overview

This PR improves the error message provided when vault access is not provided from Postman App while script execution happens.

We're adding extra line to give more meaningful message to help fix the issue.

Error shown after change in App.

![image](https://github.com/user-attachments/assets/f7f873c1-7236-46a9-943f-368bda06b51a)
