### PR TITLE
Fix: Correct typos in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ runner.run(collection, { /* options */ }, function(err, run) {
 
             // visualizer: null or object containing visualizer result that looks like this:
             //  {
-            //      -- Tmeplate processing error
+            //      -- Template processing error
             //      error: <Error>
             //
             //      -- Data used for template processing


### PR DESCRIPTION
Hey, our tool caught a few typos in your repository.

Also, a few typos on your site like 'signups'. Here is your error report:
 https://triplechecker.com/s/RAsqwA/postman.com

Hope it's helpful!
