### PR TITLE
[POC] Base setup for reusable collection requests

### DIFF
--- a/lib/requester/collection-request-resolver.js
+++ b/lib/requester/collection-request-resolver.js
@@ -1,0 +1,16 @@
+const PostmanRequest = require('postman-collection').Request;
+
+module.exports = function resolveCollectionRequest (requestId, callback) {
+    const mockedCollectionRequest = new PostmanRequest({
+        method: 'GET',
+        header: [],
+        url: {
+            raw: 'https://postman-echo.com/get',
+            protocol: 'https',
+            host: ['postman-echo', 'com'],
+            path: ['get']
+        }
+    });
+
+    return callback(null, mockedCollectionRequest);
+};

--- a/lib/runner/extensions/event.command.js
+++ b/lib/runner/extensions/event.command.js
@@ -9,12 +9,14 @@ var _ = require('lodash'),
     ToughCookie = require('@postman/tough-cookie').Cookie,
 
     createItemContext = require('../create-item-context'),
+    collectionRequestResolver = require('../../requester/collection-request-resolver'),
 
     ASSERTION_FAILURE = 'AssertionFailure',
     SAFE_CONTEXT_VARIABLES = ['_variables', 'environment', 'globals', 'collectionVariables', 'cookies', 'data',
         'request', 'response'],
 
     EXECUTION_REQUEST_EVENT_BASE = 'execution.request.',
+    EXECUTION_RUN_REQUEST_EVENT_BASE = 'execution.run_collection_request.',
     EXECUTION_RESPONSE_EVENT_BASE = 'execution.response.',
     EXECUTION_ASSERTION_EVENT_BASE = 'execution.assertion.',
     EXECUTION_ERROR_EVENT_BASE = 'execution.error.',
@@ -478,6 +480,46 @@ module.exports = {
                                 this.host.dispatch(EXECUTION_RESPONSE_EVENT_BASE + id, requestId, error);
                             });
                         }.bind(this));
+                    }.bind(this));
+
+                this.host.on(EXECUTION_RUN_REQUEST_EVENT_BASE + executionId,
+                    function (scriptCursor, id, requestId, requestToRunId) {
+                        // TODO: Add a proper cloud resolver that talks to the ipc to get request from a collection
+                        // Should fetch the request from the enclosing Postman App & resolve scripts and variables
+                        collectionRequestResolver(requestToRunId, (err, runnableRequest) => {
+                            if (err) {
+                                // Stop execution of the entire request
+                                return this.host.dispatch(EXECUTION_RESPONSE_EVENT_BASE + id, requestId, err);
+                            }
+
+                            const nextPayload = {
+                                item: new sdk.Item({ request: runnableRequest }),
+                                coords: scriptCursor,
+                                source: 'script',
+                                abortOnError: true
+                            };
+
+                            // create context for executing this request
+                            nextPayload.context = createItemContext(nextPayload);
+
+                            // TODO: Change this to a proper collection send request that takes care of script runs
+                            // as well instead of just the http request
+                            this.immediate('httprequest', nextPayload).done(function (result) {
+                                this.host.dispatch(EXECUTION_RESPONSE_EVENT_BASE + id,
+                                    requestId,
+                                    null,
+                                    result && result.response,
+
+                                    // @todo get cookies from result.history or pass PostmanHistory
+                                    // instance once it is fully supported
+                                    result && { cookies: result.cookies });
+                            }).catch(function (err) {
+                                const error = serialisedError(err);
+
+                                delete error.stack; // remove stack to avoid leaking runtime internals
+                                this.host.dispatch(EXECUTION_RESPONSE_EVENT_BASE + id, requestId, error);
+                            });
+                        });
                     }.bind(this));
 
                 this.host.on(EXECUTION_SKIP_REQUEST_EVENT_BASE + executionId, function () {


### PR DESCRIPTION
- Adds bridge events to listen for `pm.execution.runRequest` calls and to respond to them for handing back flow of control to `postman-sandbox`
- Adds a mocked collection request resolver