### PR TITLE
fix: Multiple digest auth headers not filtered by opted algorithm

### DIFF
--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -3,6 +3,7 @@ unreleased:
     - GH-1522 Add support for referencing pre-defined collection requests using `pm.execution.runRequest`
   fixed bugs:
     - GH-1523 Fixed downloadedBytes tracking for redirected requests
+    - GH-1524 Fixed a bug where incorrect digest auth header was getting used to compute hash.
   chores:
     - Updated dependencies
 

--- a/lib/authorizer/digest.js
+++ b/lib/authorizer/digest.js
@@ -136,12 +136,17 @@ _extractField = function (string, regexp) {
  * there can be more than one header with the same key. So need to loop over and check each one.
  *
  * @param {VariableList} headers -
+ * @param {String} selectedAlgorithm - The user opted algorithm (MD5, SHA-256 etc)
  * @private
  */
-function _getDigestAuthHeader (headers) {
+function _getDigestAuthHeader (headers, selectedAlgorithm) {
     return headers.find(function (property) {
         return (property.key.toLowerCase() === WWW_AUTHENTICATE) &&
-        (_.startsWith(String(property.value).toLowerCase(), DIGEST_PREFIX.toLowerCase()));
+        (_.startsWith(String(property.value).toLowerCase(), DIGEST_PREFIX.toLowerCase())) &&
+        (selectedAlgorithm ?
+            String(property.value).toLowerCase().includes(`algorithm=${selectedAlgorithm.toLowerCase()}`) :
+            // If no algorithm is selected, fall back to the first default one
+            true);
     });
 }
 
@@ -314,6 +319,7 @@ module.exports = {
 
         var code,
             nonceCount,
+            algorithm,
             realm,
             nonce,
             qop,
@@ -323,7 +329,9 @@ module.exports = {
 
         code = response.code;
         nonceCount = auth.get('nonceCount');
-        authHeader = _getDigestAuthHeader(response.headers);
+        algorithm = auth.get('algorithm');
+
+        authHeader = _getDigestAuthHeader(response.headers, algorithm);
 
         // If code is forbidden or unauthorized, and an auth header exists,
         // we can extract the realm & the nonce, and replay the request.

--- a/lib/authorizer/digest.js
+++ b/lib/authorizer/digest.js
@@ -140,14 +140,27 @@ _extractField = function (string, regexp) {
  * @private
  */
 function _getDigestAuthHeader (headers, selectedAlgorithm) {
-    return headers.find(function (property) {
+    const digestAuthHeaders = headers.filter(function (property) {
         return (property.key.toLowerCase() === WWW_AUTHENTICATE) &&
-        (_.startsWith(String(property.value).toLowerCase(), DIGEST_PREFIX.toLowerCase())) &&
-        (selectedAlgorithm ?
-            String(property.value).toLowerCase().includes(`algorithm=${selectedAlgorithm.toLowerCase()}`) :
-            // If no algorithm is selected, fall back to the first default one
-            true);
+        (_.startsWith(String(property.value).toLowerCase(), DIGEST_PREFIX.toLowerCase()));
     });
+
+    if (selectedAlgorithm) {
+        const headerWithMatchingOptedAlgorithm = digestAuthHeaders.find(function (header) {
+            const headerValue = String(header.value).toLowerCase();
+
+            if (!headerValue.includes('algorithm=')) {
+                // This is an MD5 header. Ref: https://datatracker.ietf.org/doc/html/rfc7616
+                return selectedAlgorithm.toLowerCase() === 'md5';
+            }
+
+            return headerValue.includes(`algorithm=${selectedAlgorithm.toLowerCase()}`);
+        });
+
+        return headerWithMatchingOptedAlgorithm;
+    }
+
+    return digestAuthHeaders.length ? digestAuthHeaders[0] : null;
 }
 
 /**

--- a/lib/authorizer/digest.js
+++ b/lib/authorizer/digest.js
@@ -157,7 +157,9 @@ function _getDigestAuthHeader (headers, selectedAlgorithm) {
             return headerValue.includes(`algorithm=${selectedAlgorithm.toLowerCase()}`);
         });
 
-        return headerWithMatchingOptedAlgorithm;
+        if (headerWithMatchingOptedAlgorithm) {
+            return headerWithMatchingOptedAlgorithm;
+        }
     }
 
     return digestAuthHeaders.length ? digestAuthHeaders[0] : null;

--- a/lib/authorizer/digest.js
+++ b/lib/authorizer/digest.js
@@ -145,24 +145,24 @@ function _getDigestAuthHeader (headers, selectedAlgorithm) {
         (_.startsWith(String(property.value).toLowerCase(), DIGEST_PREFIX.toLowerCase()));
     });
 
+    let headerWithMatchingOptedAlgorithm;
+
     if (selectedAlgorithm) {
-        const headerWithMatchingOptedAlgorithm = digestAuthHeaders.find(function (header) {
+        const targetAlgorithm = selectedAlgorithm.toLowerCase();
+
+        headerWithMatchingOptedAlgorithm = digestAuthHeaders.find(function (header) {
             const headerValue = String(header.value).toLowerCase();
 
             if (!headerValue.includes('algorithm=')) {
                 // This is an MD5 header. Ref: https://datatracker.ietf.org/doc/html/rfc7616
-                return selectedAlgorithm.toLowerCase() === 'md5';
+                return targetAlgorithm === 'md5';
             }
 
-            return headerValue.includes(`algorithm=${selectedAlgorithm.toLowerCase()}`);
+            return headerValue.includes(`algorithm=${targetAlgorithm}`);
         });
-
-        if (headerWithMatchingOptedAlgorithm) {
-            return headerWithMatchingOptedAlgorithm;
-        }
     }
 
-    return digestAuthHeaders.length ? digestAuthHeaders[0] : null;
+    return headerWithMatchingOptedAlgorithm || digestAuthHeaders[0];
 }
 
 /**


### PR DESCRIPTION
Works to fix https://github.com/postmanlabs/postman-app-support/issues/13756

### Context

Since servers can return multiple values for `www-authenticate` headers to present clients with multiple options, we need to filter the right header based on the `auth.algorithm` setting passed by `postman-runtime`'s consumer.