### PR TITLE
fix: Nested Requests aborting execution on error in scripts

### DIFF
--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -1,3 +1,8 @@
+unreleased:
+  date: 2025-09-11
+  fixed bugs:
+    - GH-1525 Fixed a bug where nested requests were not aborting the run on failure in assertions
+
 7.46.0:
   date: 2025-09-08
   new features:

--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -1,7 +1,7 @@
 unreleased:
   date: 2025-09-11
   fixed bugs:
-    - GH-1525 Fixed a bug where nested requests were not aborting the run on failure in assertions
+    - GH-1526 Fixed a bug where nested requests were not aborting the run on failure in assertions
 
 7.46.0:
   date: 2025-09-08

--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -1,5 +1,4 @@
 unreleased:
-  date: 2025-09-11
   fixed bugs:
     - GH-1526 Fixed a bug where nested requests were not aborting the run on failure in assertions
 

--- a/lib/runner/nested-request.js
+++ b/lib/runner/nested-request.js
@@ -109,7 +109,7 @@ function runNestedRequest ({ executionId, isExecutionSkipped, vaultSecrets, item
                     environment: environment,
                     localVariables: localVariables,
                     vaultSecrets: clonedVaultSecrets,
-                    abortOnFailure: true,
+                    stopOnError: true,
                     host: {
                         // Reuse current run's sandbox host across nested executions
                         external: true,


### PR DESCRIPTION
- Replaces the `abortOnFailure` prop to nested requests with `stopOnError` prop.
- Adds tests to ensure there are no aborts due to failures in nested request's script assertions.