### PR TITLE
feat: Send nested request cached metadata from item to request resolver

### DIFF
--- a/lib/runner/extensions/event.command.js
+++ b/lib/runner/extensions/event.command.js
@@ -293,7 +293,7 @@ module.exports = {
 
                     isNestedRequest = this.state.nestedRequest !== undefined,
 
-                    rootItemId = isNestedRequest ? this.state.nestedRequest.rootItemId : item.id,
+                    rootItem = isNestedRequest ? this.state.nestedRequest.rootItem : item,
 
                     // create copy of cursor so we don't leak script ids outside `event.command`
                     // and across scripts
@@ -420,7 +420,7 @@ module.exports = {
                         try {
                             // eslint-disable-next-line require-atomic-updates
                             hasVaultAccess = Boolean(this.state.nestedRequest?.hasVaultAccess ||
-                                await vaultSecrets?._?.allowScriptAccess(rootItemId));
+                                await vaultSecrets?._?.allowScriptAccess(rootItem.id));
                         }
                         catch (_) {
                             // eslint-disable-next-line require-atomic-updates

--- a/lib/runner/index.js
+++ b/lib/runner/index.js
@@ -73,9 +73,10 @@ _.assign(Runner.prototype, {
      * @param {Number} [options.nestedRequest.rootCursor] - The cursor of the root request that spun up this
      * nested request runner. This is recursively passed down to keep track of which execution started the chain
      * and modify cursors for all nested req events for reporters built on top of postman-runtime.
-     * @param {Number} [options.nestedRequest.rootItemId] - The id of the root item that spawned this nested request.
+     * @param {Number} [options.nestedRequest.rootItem] - The root item that spawned this nested request.
      * Used by vault to get consent for root request and determine whether vault access check was performed even once
-     * throughout the chain.
+     * throughout the chain. And by request resolver bridge to receive any stored metadata like name/location of
+     * the request being resolved
      * @param {Number} [options.nestedRequest.hasVaultAccess] - Mutated and set by any nested or parent request
      * to indicate whether vault access check has been performed.
      * @param {Number} [options.nestedRequest.invocationCount] - The number of requests currently accummulated

--- a/lib/runner/nested-request.js
+++ b/lib/runner/nested-request.js
@@ -27,7 +27,7 @@ function runNestedRequest ({ executionId, isExecutionSkipped, vaultSecrets, item
         self.state.nestedRequest = _.defaults(self.state.nestedRequest || {}, {
             isNestedRequest: true,
             rootCursor: cursor,
-            rootItemId: item.id,
+            rootItem: item,
             invocationCount: 0
         });
 
@@ -39,8 +39,23 @@ function runNestedRequest ({ executionId, isExecutionSkipped, vaultSecrets, item
                 ' calls have been reached for this request.'));
         }
 
+        let rootRequestEventsList = self.state.nestedRequest.rootItem.events?.all?.() || [],
+            requestMetadataFromItem = null,
+            additionalInfo = { rootRequestId: self.state.nestedRequest.rootItem.id };
+
+        for (const event of rootRequestEventsList) {
+            if (event.script && event.script.requests && event.script.requests[requestToRunId]) {
+                requestMetadataFromItem = event.script.requests[requestToRunId];
+                break;
+            }
+        }
+
+        if (requestMetadataFromItem) {
+            additionalInfo.requestMetadataFromItem = requestMetadataFromItem;
+        }
+
         // Should fetch the request from the consumer of postman-runtime & resolve scripts and variables
-        requestResolver(requestToRunId, function (err, collection) {
+        requestResolver(requestToRunId, additionalInfo, function (err, collection) {
             if (err) {
                 return dispatchErrorToListener(err);
             }


### PR DESCRIPTION
To facilitate better debugging and consumption of cached requests data, we have added cached nested request metadata as well as the `rootRequestId` to a new second argument passed to the nested request resolver.

> This would mean the semver version bump would have to be bumped up to `7.48.0` as the consumers of runtime would have to update the contract used for `requestResolver`