### PR TITLE
Adds an option to stop run after an assertion has failed

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ runner.run(collection, {
     //   calls the `item` and `iteration` callbacks and does not run any further items (requests)
     stopOnFailure: true,
 
+    // - gracefully halts on test failures only (not on errors).
+    //   calls the `item` and `iteration` callbacks and does not run any further items (requests)
+    stopOnAssertionFailure: true,
+
     // - abruptly halts the run on errors or test failures, and directly calls the `done` callback
     abortOnFailure: true,
 

--- a/lib/runner/extensions/event.command.js
+++ b/lib/runner/extensions/event.command.js
@@ -221,6 +221,7 @@ module.exports = {
          * execution of a script will stop executing any further scripts
          * @param {Boolean} [payload.abortOnFailure] -
          * @param {Boolean} [payload.stopOnFailure] -
+         * @param {Boolean} [payload.stopOnAssertionFailure] -
          * @param {Function} next -
          *
          * @note - in order to raise trigger for the entire event, ensure your extension has registered the triggers
@@ -243,6 +244,7 @@ module.exports = {
                 // @todo: find a better home for this option processing
                 abortOnFailure = payload.abortOnFailure,
                 stopOnFailure = payload.stopOnFailure,
+                stopOnAssertionFailure = payload.stopOnAssertionFailure,
 
                 packageResolver = _.get(this, 'options.script.packageResolver'),
 
@@ -318,7 +320,7 @@ module.exports = {
 
                 // add event listener to trap all assertion events, but only if needed. to avoid needlessly accumulate
                 // stuff in memory.
-                (abortOnFailure || stopOnFailure) &&
+                (abortOnFailure || stopOnFailure || stopOnAssertionFailure) &&
                     this.host.on(EXECUTION_ASSERTION_EVENT_BASE + executionId, function (scriptCursor, assertions) {
                         _.forEach(assertions, function (assertion) {
                             assertion && !assertion.passed && assertionFailed.push(assertion.name);
@@ -581,8 +583,16 @@ module.exports = {
                             });
 
                             // Get the failures. If there was an error running the script itself, that takes precedence
-                            if (!err && (abortOnFailure || stopOnFailure)) {
-                                err = postProcessContext(result, assertionFailed); // also use async assertions
+                            // For stopOnAssertionFailure, we only create an error if there are assertion failures
+                            // For stopOnFailure/abortOnFailure, we create error for any failures
+                            if (!err && (abortOnFailure || stopOnFailure || stopOnAssertionFailure)) {
+                                var assertionError = postProcessContext(result, assertionFailed);
+
+                                // For stopOnAssertionFailure, only set err if it's an assertion failure
+                                // For stopOnFailure/abortOnFailure, set err for any error
+                                if (abortOnFailure || stopOnFailure || (stopOnAssertionFailure && assertionError)) {
+                                    err = assertionError;
+                                }
                             }
 
                             // Ensure that we have SDK instances, not serialized plain objects.
@@ -642,7 +652,21 @@ module.exports = {
                             }
 
                             // move to next script and pass on the results for accumulation
-                            done(((stopOnScriptError || abortOnError || stopOnFailure) && err) ? err : null, _.assign({
+                            // For stopOnAssertionFailure, only stop if the error is an assertion failure
+                            var shouldStop = false;
+
+                            if (err) {
+                                var isAssertionFailure = err.name === ASSERTION_FAILURE ||
+                                    (err.error && err.error.name === ASSERTION_FAILURE);
+
+                                if (stopOnScriptError || abortOnError || stopOnFailure) {
+                                    shouldStop = true;
+                                } else if (stopOnAssertionFailure && isAssertionFailure) {
+                                    shouldStop = true;
+                                }
+                            }
+
+                            done(shouldStop ? err : null, _.assign({
                                 event,
                                 script,
                                 result

--- a/lib/runner/extensions/event.command.js
+++ b/lib/runner/extensions/event.command.js
@@ -538,6 +538,10 @@ module.exports = {
                                 _eventItemName: currentEventItem && currentEventItem.name
                             }
                         }, function (err, result) {
+                            var assertionError,
+                                shouldStop = false,
+                                isAssertionFailure;
+
                             this.host.removeAllListeners(EXECUTION_REQUEST_EVENT_BASE + executionId);
                             this.host.removeAllListeners(EXECUTION_ASSERTION_EVENT_BASE + executionId);
                             this.host.removeAllListeners(EXECUTION_RESPONSE_EVENT_BASE + executionId);
@@ -586,7 +590,7 @@ module.exports = {
                             // For stopOnAssertionFailure, we only create an error if there are assertion failures
                             // For stopOnFailure/abortOnFailure, we create error for any failures
                             if (!err && (abortOnFailure || stopOnFailure || stopOnAssertionFailure)) {
-                                var assertionError = postProcessContext(result, assertionFailed);
+                                assertionError = postProcessContext(result, assertionFailed);
 
                                 // For stopOnAssertionFailure, only set err if it's an assertion failure
                                 // For stopOnFailure/abortOnFailure, set err for any error
@@ -653,15 +657,14 @@ module.exports = {
 
                             // move to next script and pass on the results for accumulation
                             // For stopOnAssertionFailure, only stop if the error is an assertion failure
-                            var shouldStop = false;
-
                             if (err) {
-                                var isAssertionFailure = err.name === ASSERTION_FAILURE ||
+                                isAssertionFailure = err.name === ASSERTION_FAILURE ||
                                     (err.error && err.error.name === ASSERTION_FAILURE);
 
                                 if (stopOnScriptError || abortOnError || stopOnFailure) {
                                     shouldStop = true;
-                                } else if (stopOnAssertionFailure && isAssertionFailure) {
+                                }
+                                else if (stopOnAssertionFailure && isAssertionFailure) {
                                     shouldStop = true;
                                 }
                             }

--- a/lib/runner/extensions/item.command.js
+++ b/lib/runner/extensions/item.command.js
@@ -246,7 +246,9 @@ module.exports = {
                             stopOnAssertionFailure: stopOnAssertionFailure
                         }).done(function (testExecutions, testExecutionError) {
                             var visualizerData = extractVisualizerData(prereqExecutions, testExecutions),
-                                visualizerResult;
+                                visualizerResult,
+                                shouldStop = false,
+                                isAssertionFailure;
 
                             if (visualizerData) {
                                 visualizer.processTemplate(visualizerData.template,
@@ -278,14 +280,14 @@ module.exports = {
 
                             // Check if we should stop: stopOnError/stopOnFailure stop on any error,
                             // stopOnAssertionFailure only stops on assertion failures
-                            var shouldStop = false;
                             if (testExecutionError) {
-                                var isAssertionFailure = testExecutionError.name === 'AssertionFailure' ||
+                                isAssertionFailure = testExecutionError.name === 'AssertionFailure' ||
                                     (testExecutionError.error && testExecutionError.error.name === 'AssertionFailure');
 
                                 if (stopOnError || stopOnFailure) {
                                     shouldStop = true;
-                                } else if (stopOnAssertionFailure && isAssertionFailure) {
+                                }
+                                else if (stopOnAssertionFailure && isAssertionFailure) {
                                     shouldStop = true;
                                 }
                             }

--- a/lib/runner/extensions/item.command.js
+++ b/lib/runner/extensions/item.command.js
@@ -119,6 +119,7 @@ module.exports = {
                 // still not sure whether that is the right place for it to be.
                 abortOnFailure = this.options.abortOnFailure,
                 stopOnFailure = this.options.stopOnFailure,
+                stopOnAssertionFailure = this.options.stopOnAssertionFailure,
                 delay = _.get(this.options, 'delay.item'),
 
                 ctxTemplate;
@@ -155,10 +156,12 @@ module.exports = {
                     // No need to include vaultSecrets here as runtime takes care of tracking internally
                     trackContext: ['globals', 'environment', 'collectionVariables'],
                     stopOnScriptError: stopOnError,
-                    stopOnFailure: stopOnFailure
+                    stopOnFailure: stopOnFailure,
+                    stopOnAssertionFailure: stopOnAssertionFailure
                 }).done(function (prereqExecutions, prereqExecutionError, shouldSkipExecution) {
                     // if stop on error is marked and script executions had an error,
                     // do not proceed with more commands, instead we bail out
+                    // Note: stopOnAssertionFailure doesn't stop on execution errors, only assertion failures
                     if ((stopOnError || stopOnFailure) && prereqExecutionError) {
                         this.triggers.item(null, coords, item); // @todo - should this trigger receive error?
 
@@ -239,7 +242,8 @@ module.exports = {
                             trackContext: ['tests', 'globals', 'environment', 'collectionVariables'],
                             stopOnScriptError: stopOnError,
                             abortOnFailure: abortOnFailure,
-                            stopOnFailure: stopOnFailure
+                            stopOnFailure: stopOnFailure,
+                            stopOnAssertionFailure: stopOnAssertionFailure
                         }).done(function (testExecutions, testExecutionError) {
                             var visualizerData = extractVisualizerData(prereqExecutions, testExecutions),
                                 visualizerResult;
@@ -272,8 +276,21 @@ module.exports = {
                             // @note request mutations are not persisted across iterations
                             item.request = originalRequest;
 
-                            callback && callback.call(this, ((stopOnError || stopOnFailure) && testExecutionError) ?
-                                testExecutionError : null, {
+                            // Check if we should stop: stopOnError/stopOnFailure stop on any error,
+                            // stopOnAssertionFailure only stops on assertion failures
+                            var shouldStop = false;
+                            if (testExecutionError) {
+                                var isAssertionFailure = testExecutionError.name === 'AssertionFailure' ||
+                                    (testExecutionError.error && testExecutionError.error.name === 'AssertionFailure');
+
+                                if (stopOnError || stopOnFailure) {
+                                    shouldStop = true;
+                                } else if (stopOnAssertionFailure && isAssertionFailure) {
+                                    shouldStop = true;
+                                }
+                            }
+
+                            callback && callback.call(this, shouldStop ? testExecutionError : null, {
                                 prerequest: prereqExecutions,
                                 request: request,
                                 response: response,

--- a/lib/runner/util.js
+++ b/lib/runner/util.js
@@ -344,7 +344,8 @@ module.exports = {
             seekingToStart,
             stopRunNow,
             stopOnFailure = runnerOptions.stopOnFailure,
-            stopOnAssertionFailure = runnerOptions.stopOnAssertionFailure;
+            stopOnAssertionFailure = runnerOptions.stopOnAssertionFailure,
+            isAssertionFailure;
 
         if (!executionError) {
             // extract set next request
@@ -383,12 +384,13 @@ module.exports = {
             // If we need to stop on a run, we set the stop flag to true.
             // stopOnFailure stops on any error, stopOnAssertionFailure only stops on assertion failures
             if (executionError) {
-                var isAssertionFailure = executionError.name === 'AssertionFailure' ||
+                isAssertionFailure = executionError.name === 'AssertionFailure' ||
                     (executionError.error && executionError.error.name === 'AssertionFailure');
 
                 if (stopOnFailure) {
                     stopRunNow = true;
-                } else if (stopOnAssertionFailure && isAssertionFailure) {
+                }
+                else if (stopOnAssertionFailure && isAssertionFailure) {
                     stopRunNow = true;
                 }
             }

--- a/lib/runner/util.js
+++ b/lib/runner/util.js
@@ -332,7 +332,7 @@ module.exports = {
      * @param {Object} options.coords - Current coordinates
      * @param {Object} options.executions - Execution results (prerequest and test)
      * @param {Error} options.executionError - Any execution error
-     * @param {Object} options.runnerOptions - Runner options (disableSNR, stopOnFailure)
+     * @param {Object} options.runnerOptions - Runner options (disableSNR, stopOnFailure, stopOnAssertionFailure)
      * @param {Object} options.snrHash - SNR lookup hash
      * @param {Array} options.items - Collection items for SNR hash preparation
      * @returns {Object} Processing result with nextCoords, seekingToStart, stopRunNow flags
@@ -343,7 +343,8 @@ module.exports = {
             nextCoords,
             seekingToStart,
             stopRunNow,
-            stopOnFailure = runnerOptions.stopOnFailure;
+            stopOnFailure = runnerOptions.stopOnFailure,
+            stopOnAssertionFailure = runnerOptions.stopOnAssertionFailure;
 
         if (!executionError) {
             // extract set next request
@@ -380,7 +381,17 @@ module.exports = {
             (snr.defined || executionError) && (nextCoords.position = nextCoords.length - 1);
 
             // If we need to stop on a run, we set the stop flag to true.
-            (stopOnFailure && executionError) && (stopRunNow = true);
+            // stopOnFailure stops on any error, stopOnAssertionFailure only stops on assertion failures
+            if (executionError) {
+                var isAssertionFailure = executionError.name === 'AssertionFailure' ||
+                    (executionError.error && executionError.error.name === 'AssertionFailure');
+
+                if (stopOnFailure) {
+                    stopRunNow = true;
+                } else if (stopOnAssertionFailure && isAssertionFailure) {
+                    stopRunNow = true;
+                }
+            }
         }
 
         // @todo - do this in unhacky way

--- a/test/integration/runner-spec/stop-on-assertion-failure.test.js
+++ b/test/integration/runner-spec/stop-on-assertion-failure.test.js
@@ -1,0 +1,360 @@
+var expect = require('chai').expect;
+
+describe('Stop on assertion failure', function () {
+    describe('with stopOnAssertionFailure: true', function () {
+        describe('should stop on assertion failures', function () {
+            var testrun;
+
+            before(function (done) {
+                this.run({
+                    stopOnAssertionFailure: true,
+                    collection: {
+                        item: [{
+                            name: 'First Request',
+                            event: [{
+                                listen: 'test',
+                                script: {
+                                    exec: [
+                                        'pm.test("This test will pass", function () {',
+                                        '    pm.expect(pm.response.code).to.equal(200);',
+                                        '});',
+                                        'pm.test("This test will fail", function () {',
+                                        '    pm.expect(pm.response.code).to.equal(404);',
+                                        '});'
+                                    ]
+                                }
+                            }],
+                            request: {
+                                url: 'https://postman-echo.com/get',
+                                method: 'GET'
+                            }
+                        }, {
+                            name: 'Second Request',
+                            event: [{
+                                listen: 'test',
+                                script: {
+                                    exec: [
+                                        'pm.test("This should not run", function () {',
+                                        '    pm.expect(pm.response.code).to.equal(200);',
+                                        '});'
+                                    ]
+                                }
+                            }],
+                            request: {
+                                url: 'https://postman-echo.com/get',
+                                method: 'GET'
+                            }
+                        }]
+                    }
+                }, function (err, results) {
+                    testrun = results;
+                    done(err);
+                });
+            });
+
+            it('should have completed the run', function () {
+                expect(testrun).to.be.ok;
+                expect(testrun.done.getCall(0).args[0]).to.be.null;
+                expect(testrun).to.nested.include({
+                    'done.calledOnce': true,
+                    'start.calledOnce': true
+                });
+            });
+
+            it('should gracefully stop the run on assertion failures', function () {
+                expect(testrun).to.nested.include({
+                    'item.calledOnce': true,
+                    'request.calledOnce': true,
+                    'test.calledOnce': true,
+                    'iteration.calledOnce': true
+                });
+
+                // Second request should not have been executed
+                expect(testrun.request.callCount).to.equal(1);
+            });
+
+            it('should have assertion failures', function () {
+                expect(testrun.assertion.callCount).to.be.at.least(2);
+
+                // Check if any assertion call has a failed assertion
+                var hasFailedAssertion = testrun.assertion.args.some(function (args) {
+                    return args[1] && args[1].some(function (assertion) {
+                        return assertion && assertion.passed === false;
+                    });
+                });
+
+                expect(hasFailedAssertion).to.be.true;
+            });
+        });
+
+        describe('should stop on legacy tests assertion failures', function () {
+            var testrun;
+
+            before(function (done) {
+                this.run({
+                    stopOnAssertionFailure: true,
+                    collection: {
+                        item: [{
+                            name: 'First Request',
+                            event: [{
+                                listen: 'test',
+                                script: {
+                                    exec: [
+                                        'tests["Body contains headers"] = responseBody.has("headers");',
+                                        'tests["Body contains args"] = responseBody.has("args");',
+                                        'tests["fail"] = false;' // This will cause an assertion failure
+                                    ]
+                                }
+                            }],
+                            request: {
+                                url: 'https://postman-echo.com/get',
+                                method: 'GET'
+                            }
+                        }, {
+                            name: 'Second Request',
+                            event: [{
+                                listen: 'test',
+                                script: {
+                                    exec: [
+                                        'tests["should not run"] = true;'
+                                    ]
+                                }
+                            }],
+                            request: {
+                                url: 'https://postman-echo.com/get',
+                                method: 'GET'
+                            }
+                        }]
+                    }
+                }, function (err, results) {
+                    testrun = results;
+                    done(err);
+                });
+            });
+
+            it('should have completed the run', function () {
+                expect(testrun).to.be.ok;
+                expect(testrun.done.getCall(0).args[0]).to.be.null;
+                expect(testrun).to.nested.include({
+                    'done.calledOnce': true,
+                    'start.calledOnce': true
+                });
+            });
+
+            it('should gracefully stop the run on assertion failures', function () {
+                expect(testrun).to.nested.include({
+                    'item.calledOnce': true,
+                    'request.calledOnce': true,
+                    'test.calledOnce': true,
+                    'iteration.calledOnce': true
+                });
+
+                // Second request should not have been executed
+                expect(testrun.request.callCount).to.equal(1);
+            });
+        });
+
+        describe('should NOT stop on script execution errors', function () {
+            var testrun;
+
+            before(function (done) {
+                this.run({
+                    stopOnAssertionFailure: true,
+                    collection: {
+                        item: [{
+                            name: 'First Request',
+                            event: [{
+                                listen: 'test',
+                                script: {
+                                    exec: [
+                                        'console.log(foo);' // deliberate reference error
+                                    ]
+                                }
+                            }],
+                            request: {
+                                url: 'https://postman-echo.com/get',
+                                method: 'GET'
+                            }
+                        }, {
+                            name: 'Second Request',
+                            event: [{
+                                listen: 'test',
+                                script: {
+                                    exec: [
+                                        'pm.test("This should run", function () {',
+                                        '    pm.expect(pm.response.code).to.equal(200);',
+                                        '});'
+                                    ]
+                                }
+                            }],
+                            request: {
+                                url: 'https://postman-echo.com/get',
+                                method: 'GET'
+                            }
+                        }]
+                    }
+                }, function (err, results) {
+                    testrun = results;
+                    done(err);
+                });
+            });
+
+            it('should have completed the run', function () {
+                expect(testrun).to.be.ok;
+                expect(testrun.done.getCall(0).args[0]).to.be.null;
+                expect(testrun).to.nested.include({
+                    'done.calledOnce': true,
+                    'start.calledOnce': true
+                });
+            });
+
+            it('should NOT stop the run on script execution errors', function () {
+                // Both requests should have been executed
+                expect(testrun.request.callCount).to.equal(2);
+                expect(testrun.item.callCount).to.equal(2);
+            });
+
+            it('should have script error in first request', function () {
+                expect(testrun.script.getCall(0).args[0]).to.be.ok;
+                expect(testrun.script.getCall(0).args[0]).to.have.property('message');
+            });
+        });
+
+        describe('should stop on assertion failures with multiple iterations', function () {
+            var testrun;
+
+            before(function (done) {
+                this.run({
+                    stopOnAssertionFailure: true,
+                    iterationCount: 3,
+                    collection: {
+                        item: [{
+                            name: 'First Request',
+                            event: [{
+                                listen: 'test',
+                                script: {
+                                    exec: [
+                                        'pm.test("This test will pass", function () {',
+                                        '    pm.expect(pm.response.code).to.equal(200);',
+                                        '});',
+                                        'if (iteration === 1) {',
+                                        '    pm.test("This test will fail", function () {',
+                                        '        pm.expect(pm.response.code).to.equal(404);',
+                                        '    });',
+                                        '}'
+                                    ]
+                                }
+                            }],
+                            request: {
+                                url: 'https://postman-echo.com/get',
+                                method: 'GET'
+                            }
+                        }, {
+                            name: 'Second Request',
+                            event: [{
+                                listen: 'test',
+                                script: {
+                                    exec: [
+                                        'pm.test("This should not run in iteration 1", function () {',
+                                        '    pm.expect(pm.response.code).to.equal(200);',
+                                        '});'
+                                    ]
+                                }
+                            }],
+                            request: {
+                                url: 'https://postman-echo.com/get',
+                                method: 'GET'
+                            }
+                        }]
+                    }
+                }, function (err, results) {
+                    testrun = results;
+                    done(err);
+                });
+            });
+
+            it('should have completed the run', function () {
+                expect(testrun).to.be.ok;
+                expect(testrun.done.getCall(0).args[0]).to.be.null;
+                expect(testrun).to.nested.include({
+                    'done.calledOnce': true,
+                    'start.calledOnce': true
+                });
+            });
+
+            it('should stop on assertion failure in iteration 1', function () {
+                // First iteration: both requests should run
+                // Second iteration: first request fails, second should not run
+                // Third iteration: should not run at all
+                expect(testrun.request.callCount).to.be.at.least(2);
+                expect(testrun.request.callCount).to.be.lessThan(6); // Less than 3 iterations * 2 requests
+            });
+        });
+    });
+
+    describe('with stopOnAssertionFailure: false', function () {
+        describe('should NOT stop on assertion failures', function () {
+            var testrun;
+
+            before(function (done) {
+                this.run({
+                    stopOnAssertionFailure: false,
+                    collection: {
+                        item: [{
+                            name: 'First Request',
+                            event: [{
+                                listen: 'test',
+                                script: {
+                                    exec: [
+                                        'pm.test("This test will fail", function () {',
+                                        '    pm.expect(pm.response.code).to.equal(404);',
+                                        '});'
+                                    ]
+                                }
+                            }],
+                            request: {
+                                url: 'https://postman-echo.com/get',
+                                method: 'GET'
+                            }
+                        }, {
+                            name: 'Second Request',
+                            event: [{
+                                listen: 'test',
+                                script: {
+                                    exec: [
+                                        'pm.test("This should run", function () {',
+                                        '    pm.expect(pm.response.code).to.equal(200);',
+                                        '});'
+                                    ]
+                                }
+                            }],
+                            request: {
+                                url: 'https://postman-echo.com/get',
+                                method: 'GET'
+                            }
+                        }]
+                    }
+                }, function (err, results) {
+                    testrun = results;
+                    done(err);
+                });
+            });
+
+            it('should have completed the run', function () {
+                expect(testrun).to.be.ok;
+                expect(testrun.done.getCall(0).args[0]).to.be.null;
+                expect(testrun).to.nested.include({
+                    'done.calledOnce': true,
+                    'start.calledOnce': true
+                });
+            });
+
+            it('should NOT stop the run on assertion failures', function () {
+                // Both requests should have been executed
+                expect(testrun.request.callCount).to.equal(2);
+                expect(testrun.item.callCount).to.equal(2);
+            });
+        });
+    });
+});
+

--- a/test/integration/runner-spec/stop-on-assertion-failure.test.js
+++ b/test/integration/runner-spec/stop-on-assertion-failure.test.js
@@ -290,6 +290,283 @@ describe('Stop on assertion failure', function () {
                 expect(testrun.request.callCount).to.be.lessThan(6); // Less than 3 iterations * 2 requests
             });
         });
+
+        describe('should stop on prerequest script assertion failures', function () {
+            var testrun;
+
+            before(function (done) {
+                this.run({
+                    stopOnAssertionFailure: true,
+                    collection: {
+                        item: [{
+                            name: 'First Request',
+                            event: [{
+                                listen: 'prerequest',
+                                script: {
+                                    exec: [
+                                        'pm.test("This prerequest test will fail", function () {',
+                                        '    pm.expect(1).to.equal(2);',
+                                        '});'
+                                    ]
+                                }
+                            }, {
+                                listen: 'test',
+                                script: {
+                                    exec: [
+                                        'pm.test("This test should not run", function () {',
+                                        '    pm.expect(pm.response.code).to.equal(200);',
+                                        '});'
+                                    ]
+                                }
+                            }],
+                            request: {
+                                url: 'https://postman-echo.com/get',
+                                method: 'GET'
+                            }
+                        }, {
+                            name: 'Second Request',
+                            event: [{
+                                listen: 'test',
+                                script: {
+                                    exec: [
+                                        'pm.test("This should not run", function () {',
+                                        '    pm.expect(pm.response.code).to.equal(200);',
+                                        '});'
+                                    ]
+                                }
+                            }],
+                            request: {
+                                url: 'https://postman-echo.com/get',
+                                method: 'GET'
+                            }
+                        }]
+                    }
+                }, function (err, results) {
+                    testrun = results;
+                    done(err);
+                });
+            });
+
+            it('should have completed the run', function () {
+                expect(testrun).to.be.ok;
+                expect(testrun.done.getCall(0).args[0]).to.be.null;
+                expect(testrun).to.nested.include({
+                    'done.calledOnce': true,
+                    'start.calledOnce': true
+                });
+            });
+
+            it('should stop on prerequest assertion failure', function () {
+                // Request should not be sent, test script should not run
+                expect(testrun.request.callCount).to.equal(0);
+                expect(testrun.test.callCount).to.equal(0);
+                expect(testrun.item.callCount).to.equal(1);
+            });
+
+            it('should have assertion failures in prerequest', function () {
+                expect(testrun.assertion.callCount).to.be.at.least(1);
+
+                // Check if any assertion call has a failed assertion
+                var hasFailedAssertion = testrun.assertion.args.some(function (args) {
+                    return args[1] && args[1].some(function (assertion) {
+                        return assertion && assertion.passed === false;
+                    });
+                });
+
+                expect(hasFailedAssertion).to.be.true;
+            });
+        });
+
+        describe('should NOT stop when stopOnFailure is also true and takes precedence', function () {
+            var testrun;
+
+            before(function (done) {
+                this.run({
+                    stopOnAssertionFailure: true,
+                    stopOnFailure: true,
+                    collection: {
+                        item: [{
+                            name: 'First Request',
+                            event: [{
+                                listen: 'test',
+                                script: {
+                                    exec: [
+                                        'pm.test("This test will fail", function () {',
+                                        '    pm.expect(pm.response.code).to.equal(404);',
+                                        '});'
+                                    ]
+                                }
+                            }],
+                            request: {
+                                url: 'https://postman-echo.com/get',
+                                method: 'GET'
+                            }
+                        }, {
+                            name: 'Second Request',
+                            event: [{
+                                listen: 'test',
+                                script: {
+                                    exec: [
+                                        'pm.test("This should not run", function () {',
+                                        '    pm.expect(pm.response.code).to.equal(200);',
+                                        '});'
+                                    ]
+                                }
+                            }],
+                            request: {
+                                url: 'https://postman-echo.com/get',
+                                method: 'GET'
+                            }
+                        }]
+                    }
+                }, function (err, results) {
+                    testrun = results;
+                    done(err);
+                });
+            });
+
+            it('should have completed the run', function () {
+                expect(testrun).to.be.ok;
+                expect(testrun.done.getCall(0).args[0]).to.be.null;
+                expect(testrun).to.nested.include({
+                    'done.calledOnce': true,
+                    'start.calledOnce': true
+                });
+            });
+
+            it('should stop on assertion failure (stopOnFailure takes precedence)', function () {
+                // stopOnFailure should stop on any failure, including assertion failures
+                expect(testrun.request.callCount).to.equal(1);
+                expect(testrun.item.callCount).to.equal(1);
+            });
+        });
+
+        describe('should NOT stop when stopOnError is also true and takes precedence', function () {
+            var testrun;
+
+            before(function (done) {
+                this.run({
+                    stopOnAssertionFailure: true,
+                    stopOnError: true,
+                    collection: {
+                        item: [{
+                            name: 'First Request',
+                            event: [{
+                                listen: 'test',
+                                script: {
+                                    exec: [
+                                        'pm.test("This test will fail", function () {',
+                                        '    pm.expect(pm.response.code).to.equal(404);',
+                                        '});'
+                                    ]
+                                }
+                            }],
+                            request: {
+                                url: 'https://postman-echo.com/get',
+                                method: 'GET'
+                            }
+                        }, {
+                            name: 'Second Request',
+                            event: [{
+                                listen: 'test',
+                                script: {
+                                    exec: [
+                                        'pm.test("This should not run", function () {',
+                                        '    pm.expect(pm.response.code).to.equal(200);',
+                                        '});'
+                                    ]
+                                }
+                            }],
+                            request: {
+                                url: 'https://postman-echo.com/get',
+                                method: 'GET'
+                            }
+                        }]
+                    }
+                }, function (err, results) {
+                    testrun = results;
+                    done(err);
+                });
+            });
+
+            it('should have completed the run', function () {
+                expect(testrun).to.be.ok;
+                expect(testrun.done.getCall(0).args[0]).to.be.null;
+                expect(testrun).to.nested.include({
+                    'done.calledOnce': true,
+                    'start.calledOnce': true
+                });
+            });
+
+            it('should stop on assertion failure (stopOnError takes precedence)', function () {
+                // stopOnError should stop on any error, including assertion failures
+                expect(testrun.request.callCount).to.equal(1);
+                expect(testrun.item.callCount).to.equal(1);
+            });
+        });
+
+        describe('should stop on assertion failure in prerequest and prevent request execution', function () {
+            var testrun;
+
+            before(function (done) {
+                this.run({
+                    stopOnAssertionFailure: true,
+                    collection: {
+                        item: [{
+                            name: 'First Request',
+                            event: [{
+                                listen: 'prerequest',
+                                script: {
+                                    exec: [
+                                        'pm.test("Prerequest assertion will fail", function () {',
+                                        '    pm.expect(1).to.equal(2);',
+                                        '});'
+                                    ]
+                                }
+                            }],
+                            request: {
+                                url: 'https://postman-echo.com/get',
+                                method: 'GET'
+                            }
+                        }, {
+                            name: 'Second Request',
+                            event: [{
+                                listen: 'test',
+                                script: {
+                                    exec: [
+                                        'pm.test("This should not run", function () {',
+                                        '    pm.expect(pm.response.code).to.equal(200);',
+                                        '});'
+                                    ]
+                                }
+                            }],
+                            request: {
+                                url: 'https://postman-echo.com/get',
+                                method: 'GET'
+                            }
+                        }]
+                    }
+                }, function (err, results) {
+                    testrun = results;
+                    done(err);
+                });
+            });
+
+            it('should have completed the run', function () {
+                expect(testrun).to.be.ok;
+                expect(testrun.done.getCall(0).args[0]).to.be.null;
+                expect(testrun).to.nested.include({
+                    'done.calledOnce': true,
+                    'start.calledOnce': true
+                });
+            });
+
+            it('should stop before sending request when prerequest fails', function () {
+                // Request should not be sent due to prerequest assertion failure
+                expect(testrun.request.callCount).to.equal(0);
+                expect(testrun.item.callCount).to.equal(1);
+            });
+        });
     });
 
     describe('with stopOnAssertionFailure: false', function () {
@@ -299,6 +576,70 @@ describe('Stop on assertion failure', function () {
             before(function (done) {
                 this.run({
                     stopOnAssertionFailure: false,
+                    collection: {
+                        item: [{
+                            name: 'First Request',
+                            event: [{
+                                listen: 'test',
+                                script: {
+                                    exec: [
+                                        'pm.test("This test will fail", function () {',
+                                        '    pm.expect(pm.response.code).to.equal(404);',
+                                        '});'
+                                    ]
+                                }
+                            }],
+                            request: {
+                                url: 'https://postman-echo.com/get',
+                                method: 'GET'
+                            }
+                        }, {
+                            name: 'Second Request',
+                            event: [{
+                                listen: 'test',
+                                script: {
+                                    exec: [
+                                        'pm.test("This should run", function () {',
+                                        '    pm.expect(pm.response.code).to.equal(200);',
+                                        '});'
+                                    ]
+                                }
+                            }],
+                            request: {
+                                url: 'https://postman-echo.com/get',
+                                method: 'GET'
+                            }
+                        }]
+                    }
+                }, function (err, results) {
+                    testrun = results;
+                    done(err);
+                });
+            });
+
+            it('should have completed the run', function () {
+                expect(testrun).to.be.ok;
+                expect(testrun.done.getCall(0).args[0]).to.be.null;
+                expect(testrun).to.nested.include({
+                    'done.calledOnce': true,
+                    'start.calledOnce': true
+                });
+            });
+
+            it('should NOT stop the run on assertion failures', function () {
+                // Both requests should have been executed
+                expect(testrun.request.callCount).to.equal(2);
+                expect(testrun.item.callCount).to.equal(2);
+            });
+        });
+
+        describe('should NOT stop when stopOnAssertionFailure is false even with stopOnFailure false', function () {
+            var testrun;
+
+            before(function (done) {
+                this.run({
+                    stopOnAssertionFailure: false,
+                    stopOnFailure: false,
                     collection: {
                         item: [{
                             name: 'First Request',

--- a/test/unit/runner-util.test.js
+++ b/test/unit/runner-util.test.js
@@ -269,6 +269,50 @@ describe('runner util', function () {
             expect(result.stopRunNow).to.be.true;
         });
 
+        it('should set stopRunNow on AssertionFailure error with stopOnAssertionFailure', function () {
+            var assertionError = new Error('Assertion failed');
+            assertionError.name = 'AssertionFailure';
+            mockOptions.executionError = assertionError;
+            mockOptions.runnerOptions.stopOnAssertionFailure = true;
+
+            var result = runnerUtil.processExecutionResult(mockOptions);
+
+            expect(result.stopRunNow).to.be.true;
+        });
+
+        it('should set stopRunNow on AssertionFailure error nested in error property with stopOnAssertionFailure', function () {
+            var assertionError = new Error('Assertion failed');
+            assertionError.name = 'AssertionFailure';
+            var wrapperError = new Error('Wrapper error');
+            wrapperError.error = assertionError;
+            mockOptions.executionError = wrapperError;
+            mockOptions.runnerOptions.stopOnAssertionFailure = true;
+
+            var result = runnerUtil.processExecutionResult(mockOptions);
+
+            expect(result.stopRunNow).to.be.true;
+        });
+
+        it('should NOT set stopRunNow on regular error with stopOnAssertionFailure', function () {
+            mockOptions.executionError = new Error('Test error');
+            mockOptions.runnerOptions.stopOnAssertionFailure = true;
+
+            var result = runnerUtil.processExecutionResult(mockOptions);
+
+            expect(result.stopRunNow).to.be.undefined;
+        });
+
+        it('should NOT set stopRunNow on AssertionFailure error when stopOnAssertionFailure is false', function () {
+            var assertionError = new Error('Assertion failed');
+            assertionError.name = 'AssertionFailure';
+            mockOptions.executionError = assertionError;
+            mockOptions.runnerOptions.stopOnAssertionFailure = false;
+
+            var result = runnerUtil.processExecutionResult(mockOptions);
+
+            expect(result.stopRunNow).to.be.undefined;
+        });
+
         it('should handle position -1 by setting seekingToStart', function () {
             mockOptions.coords.position = 0;
             mockOptions.executions.test = [{

--- a/test/unit/runner-util.test.js
+++ b/test/unit/runner-util.test.js
@@ -270,25 +270,31 @@ describe('runner util', function () {
         });
 
         it('should set stopRunNow on AssertionFailure error with stopOnAssertionFailure', function () {
-            var assertionError = new Error('Assertion failed');
+            var assertionError = new Error('Assertion failed'),
+                result;
+
             assertionError.name = 'AssertionFailure';
             mockOptions.executionError = assertionError;
             mockOptions.runnerOptions.stopOnAssertionFailure = true;
 
-            var result = runnerUtil.processExecutionResult(mockOptions);
+            result = runnerUtil.processExecutionResult(mockOptions);
 
             expect(result.stopRunNow).to.be.true;
         });
 
-        it('should set stopRunNow on AssertionFailure error nested in error property with stopOnAssertionFailure', function () {
-            var assertionError = new Error('Assertion failed');
+        it('should set stopRunNow on AssertionFailure error nested in error property ' +
+            'with stopOnAssertionFailure', function () {
+            var assertionError = new Error('Assertion failed'),
+                wrapperError = new Error('Wrapper error'),
+                result;
+
             assertionError.name = 'AssertionFailure';
-            var wrapperError = new Error('Wrapper error');
+
             wrapperError.error = assertionError;
             mockOptions.executionError = wrapperError;
             mockOptions.runnerOptions.stopOnAssertionFailure = true;
 
-            var result = runnerUtil.processExecutionResult(mockOptions);
+            result = runnerUtil.processExecutionResult(mockOptions);
 
             expect(result.stopRunNow).to.be.true;
         });
@@ -303,12 +309,14 @@ describe('runner util', function () {
         });
 
         it('should NOT set stopRunNow on AssertionFailure error when stopOnAssertionFailure is false', function () {
-            var assertionError = new Error('Assertion failed');
+            var assertionError = new Error('Assertion failed'),
+                result;
+
             assertionError.name = 'AssertionFailure';
             mockOptions.executionError = assertionError;
             mockOptions.runnerOptions.stopOnAssertionFailure = false;
 
-            var result = runnerUtil.processExecutionResult(mockOptions);
+            result = runnerUtil.processExecutionResult(mockOptions);
 
             expect(result.stopRunNow).to.be.undefined;
         });


### PR DESCRIPTION
Adds the option of `stopOnAssertionFailure` which stops the execution of a collection when an assertion fails.