### PR TITLE
feat: Add host-side handler for pm.datasets API

### DIFF
--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -1,3 +1,9 @@
+unreleased:
+  new features:
+    - GH-1546 Add support for pm.datasets in scripts
+  chores:
+    - Updated dependencies
+
 7.53.0:
   date: 2026-03-28
   new features:

--- a/lib/runner/extensions/event.command.js
+++ b/lib/runner/extensions/event.command.js
@@ -489,13 +489,13 @@ module.exports = {
                 }.bind(this));
 
                 this.host.on(EXECUTION_DATASETS_BASE + executionId, function (id, cmd, datasetId, ...args) {
-                    var datasetsResolver = _.get(this, 'options.script.datasetsResolver');
+                    const datasetsResolver = _.get(this, 'options.script.datasetsResolver'),
 
-                    // Ensure error is string
-                    // TODO identify why error objects are not being serialized correctly
-                    const dispatch = (e, r) => {
-                        this.host.dispatch(EXECUTION_DATASETS_BASE + executionId, id, e, r);
-                    };
+                        // Ensure error is string
+                        // TODO identify why error objects are not being serialized correctly
+                        dispatch = (e, r) => {
+                            this.host.dispatch(EXECUTION_DATASETS_BASE + executionId, id, e, r);
+                        };
 
                     if (!datasetsResolver) {
                         return dispatch('Datasets API is not available');
@@ -508,14 +508,17 @@ module.exports = {
                     try {
                         datasetsResolver(cmd, datasetId, args, function (err, result) {
                             if (err) {
-                                return dispatch(err instanceof Error ? err.message : err);
+                                return dispatch(err instanceof Error ? err.message :
+                                    (typeof err === 'string' ? err : String(err && err.message || err)));
                             }
 
                             dispatch(null, result);
                         });
                     }
                     catch (error) {
-                        dispatch(`Datasets: error executing "${cmd}"`);
+                        const detail = error && error.message ? `: ${error.message}` : '';
+
+                        dispatch(`Datasets: error executing "${cmd}"${detail}`);
                     }
                 }.bind(this));
 

--- a/lib/runner/extensions/event.command.js
+++ b/lib/runner/extensions/event.command.js
@@ -501,7 +501,7 @@ module.exports = {
                         return dispatch('Datasets API is not available');
                     }
 
-                    if (!['addView', 'removeView', 'executeView', 'executeQuery'].includes(cmd)) {
+                    if (!['addView', 'executeView', 'executeQuery'].includes(cmd)) {
                         return dispatch(`Invalid datasets command: ${cmd}`);
                     }
 

--- a/lib/runner/extensions/event.command.js
+++ b/lib/runner/extensions/event.command.js
@@ -501,7 +501,7 @@ module.exports = {
                         return dispatch('Datasets API is not available');
                     }
 
-                    if (!['addView', 'executeView', 'executeQuery'].includes(cmd)) {
+                    if (!['executeView', 'executeQuery'].includes(cmd)) {
                         return dispatch(`Invalid datasets command: ${cmd}`);
                     }
 

--- a/lib/runner/extensions/event.command.js
+++ b/lib/runner/extensions/event.command.js
@@ -24,6 +24,7 @@ var _ = require('lodash'),
     EXECUTION_SKIP_REQUEST_EVENT_BASE = 'execution.skipRequest.',
 
     EXECUTION_VAULT_BASE = 'execution.vault.',
+    EXECUTION_DATASETS_BASE = 'execution.datasets.',
 
     COOKIES_EVENT_STORE_ACTION = 'store',
     COOKIE_STORE_PUT_METHOD = 'putCookie',
@@ -487,6 +488,37 @@ module.exports = {
                     dispatch(null, vaultSecrets[cmd](...args));
                 }.bind(this));
 
+                this.host.on(EXECUTION_DATASETS_BASE + executionId, function (id, cmd, datasetId, ...args) {
+                    var datasetsResolver = _.get(this, 'options.script.datasetsResolver');
+
+                    // Ensure error is string
+                    // TODO identify why error objects are not being serialized correctly
+                    const dispatch = (e, r) => {
+                        this.host.dispatch(EXECUTION_DATASETS_BASE + executionId, id, e, r);
+                    };
+
+                    if (!datasetsResolver) {
+                        return dispatch('Datasets API is not available');
+                    }
+
+                    if (!['addView', 'removeView', 'executeView', 'executeQuery'].includes(cmd)) {
+                        return dispatch(`Invalid datasets command: ${cmd}`);
+                    }
+
+                    try {
+                        datasetsResolver(cmd, datasetId, args, function (err, result) {
+                            if (err) {
+                                return dispatch(err instanceof Error ? err.message : err);
+                            }
+
+                            dispatch(null, result);
+                        });
+                    }
+                    catch (error) {
+                        dispatch(`Datasets: error executing "${cmd}"`);
+                    }
+                }.bind(this));
+
                 this.host.on(EXECUTION_REQUEST_EVENT_BASE + executionId,
                     function (scriptCursor, id, requestId, request) {
                         // remove files in request body if any
@@ -570,8 +602,12 @@ module.exports = {
                             context: contextToUse,
                             resolvedPackages: resolvedPackages,
 
-                            disabledAPIs: !_.get(this, 'options.script.requestResolver') ?
-                                ['execution.runRequest'] : [],
+                            disabledAPIs: [
+                                ...(!_.get(this, 'options.script.requestResolver') ?
+                                    ['execution.runRequest'] : []),
+                                ...(!_.get(this, 'options.script.datasetsResolver') ?
+                                    ['datasets'] : [])
+                            ],
 
                             // legacy options
                             legacy: {
@@ -589,6 +625,7 @@ module.exports = {
                             this.host.removeAllListeners(EXECUTION_ERROR_EVENT_BASE + executionId);
                             this.host.removeAllListeners(EXECUTION_SKIP_REQUEST_EVENT_BASE + executionId);
                             this.host.removeAllListeners(EXECUTION_VAULT_BASE + executionId);
+                            this.host.removeAllListeners(EXECUTION_DATASETS_BASE + executionId);
 
                             // Handle async errors as well.
                             // If there was an error running the script itself, that takes precedence

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "performance-now": "2.1.0",
         "postman-collection": "5.3.0",
         "postman-request": "2.88.1-postman.48",
-        "postman-sandbox": "6.6.1",
+        "postman-sandbox": "6.7.0",
         "postman-url-encoder": "3.0.8",
         "serialised-error": "1.1.3",
         "strip-json-comments": "3.1.1",
@@ -7904,9 +7904,9 @@
       }
     },
     "node_modules/postman-sandbox": {
-      "version": "6.6.1",
-      "resolved": "https://registry.npmjs.org/postman-sandbox/-/postman-sandbox-6.6.1.tgz",
-      "integrity": "sha512-w5MNCiEi0ramE5PFDqi1JeYEUjED2ZDf9FE9XzX5AHga+uFOZAWnsQRVcogZU8ZP4Jy/0M3VtwVMr+FcVzDdqA==",
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/postman-sandbox/-/postman-sandbox-6.7.0.tgz",
+      "integrity": "sha512-sl5JRHG41XRwkv0z4SpHsrP68XW/9eyqAQohCYqB/giYvYNUp/8tnqshPKwRr72EEeDSPM0XFE+Y4jsfDhsSPQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "lodash": "4.17.23",
@@ -16368,9 +16368,9 @@
       }
     },
     "postman-sandbox": {
-      "version": "6.6.1",
-      "resolved": "https://registry.npmjs.org/postman-sandbox/-/postman-sandbox-6.6.1.tgz",
-      "integrity": "sha512-w5MNCiEi0ramE5PFDqi1JeYEUjED2ZDf9FE9XzX5AHga+uFOZAWnsQRVcogZU8ZP4Jy/0M3VtwVMr+FcVzDdqA==",
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/postman-sandbox/-/postman-sandbox-6.7.0.tgz",
+      "integrity": "sha512-sl5JRHG41XRwkv0z4SpHsrP68XW/9eyqAQohCYqB/giYvYNUp/8tnqshPKwRr72EEeDSPM0XFE+Y4jsfDhsSPQ==",
       "requires": {
         "lodash": "4.17.23",
         "postman-collection": "5.3.0",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "performance-now": "2.1.0",
     "postman-collection": "5.3.0",
     "postman-request": "2.88.1-postman.48",
-    "postman-sandbox": "6.6.1",
+    "postman-sandbox": "6.7.0",
     "postman-url-encoder": "3.0.8",
     "serialised-error": "1.1.3",
     "strip-json-comments": "3.1.1",

--- a/test/integration/sanity/datasets.test.js
+++ b/test/integration/sanity/datasets.test.js
@@ -1,0 +1,210 @@
+var expect = require('chai').expect,
+    sinon = require('sinon');
+
+describe('datasets', function () {
+    describe('should be able to call pm.datasets(id).executeQuery via datasetsResolver', function () {
+        var testrun,
+            datasetsResolverStub = sinon.stub().callsFake(function (cmd, datasetId, args, callback) {
+                if (cmd === 'executeQuery' && datasetId === 'ds-123') {
+                    return callback(null, { rows: [{ id: 1, name: 'Alice' }] });
+                }
+
+                callback(new Error('unexpected call'));
+            });
+
+        before(function (done) {
+            this.run({
+                collection: {
+                    item: {
+                        event: [{
+                            listen: 'prerequest',
+                            script: {
+                                exec: `
+                                    const result = await pm.datasets('ds-123').executeQuery('SELECT * FROM users');
+                                    console.log(JSON.stringify(result));
+                                `
+                            }
+                        }],
+                        request: global.servers.http
+                    }
+                },
+                script: {
+                    datasetsResolver: datasetsResolverStub
+                }
+            }, function (err, results) {
+                testrun = results;
+                done(err);
+            });
+        });
+
+        it('should have completed the run', function () {
+            expect(testrun).to.be.ok;
+            expect(testrun.done.getCall(0).args[0]).to.be.null;
+            expect(testrun).to.nested.include({
+                'done.calledOnce': true,
+                'start.calledOnce': true
+            });
+        });
+
+        it('should have called the datasetsResolver with correct arguments', function () {
+            expect(datasetsResolverStub.calledOnce).to.be.true;
+
+            var call = datasetsResolverStub.getCall(0);
+
+            expect(call.args[0]).to.equal('executeQuery');
+            expect(call.args[1]).to.equal('ds-123');
+            expect(call.args[2]).to.deep.include.members(['SELECT * FROM users']);
+        });
+
+        it('should have received the result in the script', function () {
+            var consoleArgs = testrun.console.getCall(0).args.slice(2);
+
+            expect(JSON.parse(consoleArgs[0])).to.deep.equal({ rows: [{ id: 1, name: 'Alice' }] });
+        });
+    });
+
+    describe('should be able to call pm.datasets(id).addView via datasetsResolver', function () {
+        var testrun,
+            datasetsResolverStub = sinon.stub().callsFake(function (cmd, datasetId, args, callback) {
+                if (cmd === 'addView' && datasetId === 'ds-456') {
+                    return callback(null, { id: 'view-1', name: args[0].name, query: args[0].sql });
+                }
+
+                callback(new Error('unexpected call'));
+            });
+
+        before(function (done) {
+            this.run({
+                collection: {
+                    item: {
+                        event: [{
+                            listen: 'prerequest',
+                            script: {
+                                exec: `
+                                    const result = await pm.datasets('ds-456')
+                                        .addView({ name: 'myView', sql: 'SELECT 1' });
+                                    console.log(JSON.stringify(result));
+                                `
+                            }
+                        }],
+                        request: global.servers.http
+                    }
+                },
+                script: {
+                    datasetsResolver: datasetsResolverStub
+                }
+            }, function (err, results) {
+                testrun = results;
+                done(err);
+            });
+        });
+
+        it('should have completed the run', function () {
+            expect(testrun).to.be.ok;
+            expect(testrun.done.getCall(0).args[0]).to.be.null;
+        });
+
+        it('should have called the datasetsResolver with correct arguments', function () {
+            expect(datasetsResolverStub.calledOnce).to.be.true;
+
+            var call = datasetsResolverStub.getCall(0);
+
+            expect(call.args[0]).to.equal('addView');
+            expect(call.args[1]).to.equal('ds-456');
+            expect(call.args[2][0]).to.deep.equal({ name: 'myView', sql: 'SELECT 1' });
+        });
+
+        it('should have received the result in the script', function () {
+            var consoleArgs = testrun.console.getCall(0).args.slice(2);
+
+            expect(JSON.parse(consoleArgs[0])).to.deep.equal({ id: 'view-1', name: 'myView', query: 'SELECT 1' });
+        });
+    });
+
+    describe('should handle datasetsResolver errors', function () {
+        var testrun,
+            datasetsResolverStub = sinon.stub().callsFake(function (cmd, datasetId, args, callback) {
+                callback(new Error('Dataset not found'));
+            });
+
+        before(function (done) {
+            this.run({
+                collection: {
+                    item: {
+                        event: [{
+                            listen: 'prerequest',
+                            script: {
+                                exec: `
+                                    try {
+                                        await pm.datasets('ds-missing').executeQuery('SELECT 1');
+                                        console.log('no-error');
+                                    } catch (e) {
+                                        console.log('error:' + e.message);
+                                    }
+                                `
+                            }
+                        }],
+                        request: global.servers.http
+                    }
+                },
+                script: {
+                    datasetsResolver: datasetsResolverStub
+                }
+            }, function (err, results) {
+                testrun = results;
+                done(err);
+            });
+        });
+
+        it('should have completed the run', function () {
+            expect(testrun).to.be.ok;
+            expect(testrun.done.getCall(0).args[0]).to.be.null;
+        });
+
+        it('should have called the datasetsResolver', function () {
+            expect(datasetsResolverStub.calledOnce).to.be.true;
+        });
+
+        it('should have caught the error in the script', function () {
+            var consoleArgs = testrun.console.getCall(0).args.slice(2);
+
+            expect(consoleArgs[0]).to.equal('error:Dataset not found');
+        });
+    });
+
+    describe('pm.datasets should not be available when datasetsResolver is not provided', function () {
+        var testrun;
+
+        before(function (done) {
+            this.run({
+                collection: {
+                    item: {
+                        event: [{
+                            listen: 'prerequest',
+                            script: {
+                                exec: `
+                                    console.log(typeof pm.datasets);
+                                `
+                            }
+                        }],
+                        request: global.servers.http
+                    }
+                }
+            }, function (err, results) {
+                testrun = results;
+                done(err);
+            });
+        });
+
+        it('should have completed the run', function () {
+            expect(testrun).to.be.ok;
+            expect(testrun.done.getCall(0).args[0]).to.be.null;
+        });
+
+        it('should report pm.datasets as undefined', function () {
+            var consoleArgs = testrun.console.getCall(0).args.slice(2);
+
+            expect(consoleArgs[0]).to.equal('undefined');
+        });
+    });
+});

--- a/test/integration/sanity/datasets.test.js
+++ b/test/integration/sanity/datasets.test.js
@@ -21,7 +21,13 @@ describe('datasets', function () {
                             script: {
                                 exec: `
                                     const result = await pm.datasets('ds-123').executeQuery('SELECT * FROM users');
-                                    console.log(JSON.stringify(result));
+                                    const rows = [];
+
+                                    for await (const row of result.rows) {
+                                        rows.push(row);
+                                    }
+
+                                    console.log(JSON.stringify({ columns: result.columns, rows: rows }));
                                 `
                             }
                         }],
@@ -59,15 +65,21 @@ describe('datasets', function () {
         it('should have received the result in the script', function () {
             var consoleArgs = testrun.console.getCall(0).args.slice(2);
 
-            expect(JSON.parse(consoleArgs[0])).to.deep.equal({ rows: [{ id: 1, name: 'Alice' }] });
+            expect(JSON.parse(consoleArgs[0])).to.deep.equal({
+                columns: [],
+                rows: [{ id: 1, name: 'Alice' }]
+            });
         });
     });
 
-    describe('should be able to call pm.datasets(id).addView via datasetsResolver', function () {
+    describe('should be able to call pm.datasets(id).executeView via datasetsResolver', function () {
         var testrun,
             datasetsResolverStub = sinon.stub().callsFake(function (cmd, datasetId, args, callback) {
-                if (cmd === 'addView' && datasetId === 'ds-456') {
-                    return callback(null, { id: 'view-1', name: args[0].name, query: args[0].sql });
+                if (cmd === 'executeView' && datasetId === 'ds-456') {
+                    return callback(null, {
+                        columns: ['id', 'status'],
+                        rows: [{ id: 1, status: args[1][0] }]
+                    });
                 }
 
                 callback(new Error('unexpected call'));
@@ -82,8 +94,14 @@ describe('datasets', function () {
                             script: {
                                 exec: `
                                     const result = await pm.datasets('ds-456')
-                                        .addView({ name: 'myView', sql: 'SELECT 1' });
-                                    console.log(JSON.stringify(result));
+                                        .executeView('active-users', ['active']);
+                                    const rows = [];
+
+                                    for await (const row of result.rows) {
+                                        rows.push(row);
+                                    }
+
+                                    console.log(JSON.stringify({ columns: result.columns, rows: rows }));
                                 `
                             }
                         }],
@@ -109,15 +127,18 @@ describe('datasets', function () {
 
             var call = datasetsResolverStub.getCall(0);
 
-            expect(call.args[0]).to.equal('addView');
+            expect(call.args[0]).to.equal('executeView');
             expect(call.args[1]).to.equal('ds-456');
-            expect(call.args[2][0]).to.deep.equal({ name: 'myView', sql: 'SELECT 1' });
+            expect(call.args[2]).to.deep.equal(['active-users', ['active']]);
         });
 
         it('should have received the result in the script', function () {
             var consoleArgs = testrun.console.getCall(0).args.slice(2);
 
-            expect(JSON.parse(consoleArgs[0])).to.deep.equal({ id: 'view-1', name: 'myView', query: 'SELECT 1' });
+            expect(JSON.parse(consoleArgs[0])).to.deep.equal({
+                columns: ['id', 'status'],
+                rows: [{ id: 1, status: 'active' }]
+            });
         });
     });
 


### PR DESCRIPTION
## Summary
Wire up the `execution.datasets` event handler that delegates to `options.script.datasetsResolver`. Disables `pm.datasets` when no resolver is provided.

- Add `EXECUTION_DATASETS_BASE` event constant
- Add host-side handler with command validation, error normalisation, and try/catch
- Valid commands: `addView`, `executeView`, `executeQuery`
- Extend `disabledAPIs` to include `datasets` when no resolver is provided
- Add cleanup in listener removal block
- Integration tests covering `executeQuery`, `addView`, error handling, and disabled state

The host relays results unchanged; sandbox-side wrapping shapes the user-facing iterator contract.

## Related PRs
- postman-sandbox: postmanlabs/postman-sandbox#1106

## Test plan
- [x] All integration tests pass
- [x] Lint clean