### PR TITLE
feat: per-partition cookie jar via requester.perPartitionCookieJar

### DIFF
--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -3,10 +3,10 @@
   new features:
     - >-
       Add requester.perPartitionCookieJar option — allocates an isolated
-      cookie jar per partition (per-VU) in parallelized runs instead of one
-      shared jar per run. Opt-in; an explicitly supplied requester.cookieJar
-      always wins. Jars are reset on stopSinglePartition under the
-      full-fresh-on-reuse contract.
+      cookie jar per parallel partition (equals per-iteration in
+      customParallelIterations mode, where recycled partitions get a fresh
+      jar) instead of one shared jar per run. Opt-in; an explicitly supplied
+      requester.cookieJar always wins.
 
 7.54.0:
   date: 2026-05-05

--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -1,3 +1,13 @@
+7.55.0:
+  date: 2026-06-10
+  new features:
+    - >-
+      Add requester.perPartitionCookieJar option — allocates an isolated
+      cookie jar per partition (per-VU) in parallelized runs instead of one
+      shared jar per run. Opt-in; an explicitly supplied requester.cookieJar
+      always wins. Jars are reset on stopSinglePartition under the
+      full-fresh-on-reuse contract.
+
 7.54.0:
   date: 2026-05-05
   new features:

--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -1,5 +1,4 @@
-7.55.0:
-  date: 2026-06-10
+unreleased:
   new features:
     - >-
       Add requester.perPartitionCookieJar option — allocates an isolated

--- a/lib/requester/requester-pool.js
+++ b/lib/requester/requester-pool.js
@@ -69,7 +69,20 @@ RequesterPool = function (options, callback) {
 };
 
 RequesterPool.prototype.create = function (trace, callback) {
-    return Requester.create(trace, this.options, callback);
+    var options = this.options;
+
+    // Per-partition cookie jar override (set by http-request.command via
+    // Run#getCookieJarFor in perPartitionCookieJar mode). Shallow-merge
+    // into a copy — the pool's shared options object must never be
+    // mutated per request. The jar reference is frozen here, at requester
+    // creation: a request in flight when its partition is recycled keeps
+    // writing to the old (dead) jar instead of the recycled partition's
+    // fresh one.
+    if (trace && trace.cookieJar) {
+        options = _.defaults({ cookieJar: trace.cookieJar }, options);
+    }
+
+    return Requester.create(trace, options, callback);
 };
 
 module.exports.RequesterPool = RequesterPool;

--- a/lib/runner/extensions/event.command.js
+++ b/lib/runner/extensions/event.command.js
@@ -341,7 +341,17 @@ module.exports = {
 
                     // in the case of nested requests, we want to make sure any exceptions, consoles etc
                     // are tagged to the parent request's scripts
-                    scriptCursor = _.clone(isNestedRequest ? this.state.nestedRequest.rootCursor : cursor);
+                    scriptCursor = _.clone(isNestedRequest ? this.state.nestedRequest.rootCursor : cursor),
+
+                    // Resolve this execution's cookie jar ONCE, at script
+                    // execution start. In perPartitionCookieJar mode a
+                    // partition recycle (stopSinglePartition → resetCookieJar)
+                    // swaps the partition's jar reference mid-flight; capturing
+                    // here means a script that was already executing keeps
+                    // writing to the dead jar (harmless, GC'd) instead of
+                    // polluting the recycled partition's fresh jar. Falls back
+                    // to the requester pool's shared jar when not in that mode.
+                    partitionCookieJar = this.getCookieJarFor(cursor);
 
                 // store the execution id in script
                 script._lastExecutionId = executionId; // please don't use it anywhere else!
@@ -389,7 +399,7 @@ module.exports = {
 
                         var self = this,
                             dispatchEvent = EXECUTION_COOKIES_EVENT_BASE + executionId,
-                            cookieJar = _.get(self, 'requester.options.cookieJar'),
+                            cookieJar = partitionCookieJar || _.get(self, 'requester.options.cookieJar'),
                             cookieStore = cookieJar && cookieJar.store,
                             cookieDomain;
 

--- a/lib/runner/extensions/http-request.command.js
+++ b/lib/runner/extensions/http-request.command.js
@@ -105,7 +105,14 @@ module.exports = {
                 self.requester.create({
                     type: 'http',
                     source: payload.source,
-                    cursor: context.coords
+                    cursor: context.coords,
+                    // per-partition cookie jar — undefined unless the run
+                    // has requester.perPartitionCookieJar enabled (see
+                    // Run#getCookieJarFor); the pool falls back to its
+                    // shared default jar when absent. context.coords
+                    // carries partitionIndex on every path into this
+                    // command (items, pm.sendRequest, auth replays).
+                    cookieJar: self.getCookieJarFor(context.coords)
                 }, function (err, requester) {
                     if (err) { return next(err); } // this should never happen
 

--- a/lib/runner/partition-manager.js
+++ b/lib/runner/partition-manager.js
@@ -288,9 +288,9 @@ class PartitionManager {
 
             // Per-partition cookie jar (requester.perPartitionCookieJar):
             // in customParallelIterations mode a stopped partition index
-            // is reused for the next virtual user — the dead VU's session
-            // cookies must not leak into it. In-flight writers hold a
-            // reference to the old jar object, so this swap is race-safe
+            // is reused by the next parallel iteration — the previous
+            // occupant's session cookies must not leak into it. In-flight
+            // writers hold a reference to the old jar object, so this swap is race-safe
             // — see Partition#resetCookieJar.
             if (this.runInstance.options && this.runInstance.options.customParallelIterations) {
                 partition.resetCookieJar();

--- a/lib/runner/partition-manager.js
+++ b/lib/runner/partition-manager.js
@@ -285,6 +285,16 @@ class PartitionManager {
 
         if (partition) {
             partition.clearPool();
+
+            // Per-partition cookie jar (requester.perPartitionCookieJar):
+            // in customParallelIterations mode a stopped partition index
+            // is reused for the next virtual user — the dead VU's session
+            // cookies must not leak into it. In-flight writers hold a
+            // reference to the old jar object, so this swap is race-safe
+            // — see Partition#resetCookieJar.
+            if (this.runInstance.options && this.runInstance.options.customParallelIterations) {
+                partition.resetCookieJar();
+            }
         }
 
 

--- a/lib/runner/partition.js
+++ b/lib/runner/partition.js
@@ -29,12 +29,14 @@ class Partition {
         this.partitionIndex = partitionIndex;
 
         // Per-partition HTTP cookie jar, used when the run has
-        // requester.perPartitionCookieJar enabled. Lazily allocated by
-        // getCookieJar() on the first request/script of this partition
-        // that touches cookies; reset by stopSinglePartition when the
-        // partition is recycled. Unlike `variables`, the jar is not
-        // cloned from run-level state — a fresh partition is born with
-        // an empty jar.
+        // requester.perPartitionCookieJar enabled. Allocated by
+        // getCookieJar() on the partition's first request or script (the
+        // first Run#getCookieJarFor resolution), NOT on run start and NOT
+        // gated on actual cookie traffic — any request/script triggers
+        // allocation even if no cookie is ever sent. Reset by
+        // stopSinglePartition when the partition is recycled. Unlike
+        // `variables`, the jar is not cloned from run-level state — a
+        // fresh partition is born with an empty jar.
         this.cookieJar = null;
     }
 

--- a/lib/runner/partition.js
+++ b/lib/runner/partition.js
@@ -28,7 +28,7 @@ class Partition {
         this.startIndex = startIteration;
         this.partitionIndex = partitionIndex;
 
-        // Per-partition (per-VU) HTTP cookie jar, used when the run has
+        // Per-partition HTTP cookie jar, used when the run has
         // requester.perPartitionCookieJar enabled. Lazily allocated by
         // getCookieJar() on the first request/script of this partition
         // that touches cookies; reset by stopSinglePartition when the
@@ -80,13 +80,14 @@ class Partition {
     /**
      * Drops the jar; the next getCookieJar() allocates a fresh one.
      *
-     * Called by stopSinglePartition when a partition is recycled — the
-     * dead VU's session cookies must not leak into the next VU that
-     * reuses the index. In-flight requesters and script cookie-bridge
-     * listeners capture the jar reference at creation/registration time,
-     * so late Set-Cookie writes from a stopped VU land in the OLD jar
-     * object (which is then garbage collected) instead of polluting the
-     * recycled partition's fresh jar — the stale reference is the guard.
+     * Called by stopSinglePartition when a partition is recycled — a
+     * stopped partition's session cookies must not leak into the next
+     * occupant of the reused index. In-flight requesters and script
+     * cookie-bridge listeners capture the jar reference at
+     * creation/registration time, so late Set-Cookie writes from a
+     * stopped partition land in the OLD jar object (which is then
+     * garbage collected) instead of polluting the recycled partition's
+     * fresh jar — the stale reference is the guard.
      */
     resetCookieJar () {
         this.cookieJar = null;

--- a/lib/runner/partition.js
+++ b/lib/runner/partition.js
@@ -1,7 +1,8 @@
 var _ = require('lodash'),
     Instruction = require('./instruction'),
     Cursor = require('./cursor'),
-    VariableScope = require('postman-collection').VariableScope;
+    VariableScope = require('postman-collection').VariableScope,
+    RequestCookieJar = require('postman-request').jar;
 
 /**
  * Represents a single execution partition that can process a subset of iterations.
@@ -26,6 +27,15 @@ class Partition {
         this.cursor = this._createCursor(startIteration, partitionSize, partitionIndex);
         this.startIndex = startIteration;
         this.partitionIndex = partitionIndex;
+
+        // Per-partition (per-VU) HTTP cookie jar, used when the run has
+        // requester.perPartitionCookieJar enabled. Lazily allocated by
+        // getCookieJar() on the first request/script of this partition
+        // that touches cookies; reset by stopSinglePartition when the
+        // partition is recycled. Unlike `variables`, the jar is not
+        // cloned from run-level state — a fresh partition is born with
+        // an empty jar.
+        this.cookieJar = null;
     }
 
     /**
@@ -47,6 +57,39 @@ class Partition {
             collectionVariables: new VariableScope(this.runInstance.state.collectionVariables),
             _variables: new VariableScope(this.runInstance.state._variables)
         };
+    }
+
+    /**
+     * Lazily creates and returns this partition's cookie jar.
+     *
+     * Only meaningful when the run has requester.perPartitionCookieJar
+     * enabled — callers resolve through Run#getCookieJarFor, which gates
+     * on that option and falls back to the RequesterPool's shared default
+     * jar otherwise.
+     *
+     * @returns {Object} a postman-request (tough-cookie) cookie jar
+     */
+    getCookieJar () {
+        if (!this.cookieJar) {
+            this.cookieJar = RequestCookieJar();
+        }
+
+        return this.cookieJar;
+    }
+
+    /**
+     * Drops the jar; the next getCookieJar() allocates a fresh one.
+     *
+     * Called by stopSinglePartition when a partition is recycled — the
+     * dead VU's session cookies must not leak into the next VU that
+     * reuses the index. In-flight requesters and script cookie-bridge
+     * listeners capture the jar reference at creation/registration time,
+     * so late Set-Cookie writes from a stopped VU land in the OLD jar
+     * object (which is then garbage collected) instead of polluting the
+     * recycled partition's fresh jar — the stale reference is the guard.
+     */
+    resetCookieJar () {
+        this.cookieJar = null;
     }
 
     /**

--- a/lib/runner/run.js
+++ b/lib/runner/run.js
@@ -50,7 +50,7 @@ Run = function PostmanCollectionRun (state, options) { // eslint-disable-line fu
         options: options || {}
     });
 
-    // Per-partition (per-VU) cookie jars, opt-in via
+    // Per-partition cookie jars, opt-in via
     // requester.perPartitionCookieJar. An explicitly supplied
     // requester.cookieJar always wins — that contract predates this flag
     // (e.g., the desktop app passes its own jar to sync with its cookie

--- a/lib/runner/run.js
+++ b/lib/runner/run.js
@@ -49,6 +49,21 @@ Run = function PostmanCollectionRun (state, options) { // eslint-disable-line fu
          */
         options: options || {}
     });
+
+    // Per-partition (per-VU) cookie jars, opt-in via
+    // requester.perPartitionCookieJar. An explicitly supplied
+    // requester.cookieJar always wins — that contract predates this flag
+    // (e.g., the desktop app passes its own jar to sync with its cookie
+    // store). See Run#getCookieJarFor for the resolution rule and
+    // lib/requester/requester-pool.js for the shared default jar this
+    // option replaces.
+    this.perPartitionCookieJar = Boolean(_.get(this.options, 'requester.perPartitionCookieJar')) &&
+        !_.get(this.options, 'requester.cookieJar');
+
+    if (_.get(this.options, 'requester.perPartitionCookieJar') && _.get(this.options, 'requester.cookieJar')) {
+        // eslint-disable-next-line no-console
+        console.warn('runtime: requester.perPartitionCookieJar is ignored because requester.cookieJar is set');
+    }
 };
 
 _.assign(Run.prototype, {
@@ -139,6 +154,39 @@ _.assign(Run.prototype, {
             this.triggers.start(null, this.state.cursor.current()); // @todo may throw error if cursor absent
             this._process(timeback);
         }.bind(this));
+    },
+
+    /**
+     * Resolves the cookie jar that requests and scripts driven by the
+     * given cursor must use.
+     *
+     * In perPartitionCookieJar mode this returns the owning partition's
+     * own (lazily allocated) jar — every path into the `httprequest`
+     * command carries `coords.partitionIndex` (collection items via
+     * parallel.command, pm.sendRequest via the cloned script cursor, auth
+     * replays via createItemContext's SAFE_CONTEXT_PROPERTIES), so this
+     * single resolution point covers all wire traffic and the
+     * execution.cookies bridge.
+     *
+     * Returns undefined otherwise (flag off, iterations not parallelized,
+     * or no matching partition — e.g. waterfall mode), which makes
+     * callers fall back to the RequesterPool's shared default jar
+     * (status quo). The priorityPartition is not in the partitions array
+     * and can never be resolved here.
+     *
+     * @param {Object} [coords] - cursor-shaped object (reads .partitionIndex)
+     * @returns {Object|undefined} a postman-request cookie jar, or undefined
+     */
+    getCookieJarFor (coords) {
+        if (!this.perPartitionCookieJar || !this.areIterationsParallelized) {
+            return undefined;
+        }
+
+        var partition = this.partitionManager &&
+            this.partitionManager.partitions &&
+            this.partitionManager.partitions[coords && coords.partitionIndex];
+
+        return partition ? partition.getCookieJar() : undefined;
     },
 
     /**

--- a/lib/runner/run.js
+++ b/lib/runner/run.js
@@ -60,10 +60,14 @@ Run = function PostmanCollectionRun (state, options) { // eslint-disable-line fu
     this.perPartitionCookieJar = Boolean(_.get(this.options, 'requester.perPartitionCookieJar')) &&
         !_.get(this.options, 'requester.cookieJar');
 
-    if (_.get(this.options, 'requester.perPartitionCookieJar') && _.get(this.options, 'requester.cookieJar')) {
-        // eslint-disable-next-line no-console
-        console.warn('runtime: requester.perPartitionCookieJar is ignored because requester.cookieJar is set');
-    }
+    // When both are set the flag is ignored; warn about it — but not here.
+    // Triggers (including `console`) don't exist until Run#start, so raw
+    // console.warn would bypass triggers.console and land on stdout where
+    // consumers (desktop app, Newman) never surface it. Record intent now,
+    // emit through the console trigger in start().
+    this._perPartitionCookieJarIgnored =
+        Boolean(_.get(this.options, 'requester.perPartitionCookieJar')) &&
+        Boolean(_.get(this.options, 'requester.cookieJar'));
 };
 
 _.assign(Run.prototype, {
@@ -152,6 +156,15 @@ _.assign(Run.prototype, {
             // save the normalised callbacks as triggers
             this.triggers = callback;
             this.triggers.start(null, this.state.cursor.current()); // @todo may throw error if cursor absent
+
+            // requester.perPartitionCookieJar was ignored because an explicit
+            // requester.cookieJar was also supplied — surface it through the
+            // console trigger now that triggers exist (see the constructor).
+            if (this._perPartitionCookieJarIgnored) {
+                this.triggers.console(this.state.cursor.current(), 'warn',
+                    'runtime: requester.perPartitionCookieJar is ignored because requester.cookieJar is set');
+            }
+
             this._process(timeback);
         }.bind(this));
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postman-runtime",
-  "version": "7.54.0",
+  "version": "7.55.0",
   "description": "Underlying library of executing Postman Collections",
   "author": "Postman Inc.",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postman-runtime",
-  "version": "7.55.0",
+  "version": "7.54.0",
   "description": "Underlying library of executing Postman Collections",
   "author": "Postman Inc.",
   "license": "Apache-2.0",

--- a/test/integration/runner-spec/perPartitionCookieJar.test.js
+++ b/test/integration/runner-spec/perPartitionCookieJar.test.js
@@ -7,11 +7,13 @@
  * observed exactly where it matters — on the wire — rather than through
  * pm.* scopes.
  *
- * All tests sequence VU loops deterministically (VU1 starts only after
- * VU0's loops complete), so assertions are exact instead of statistical:
- *   - shared jar (flag off / explicit jar): VU1's first read MUST carry
- *     VU0's cookie
- *   - per-partition jars (flag on): VU1's first read MUST carry nothing
+ * All tests sequence partition loops deterministically (partition 1
+ * starts only after partition 0's loops complete), so assertions are
+ * exact instead of statistical:
+ *   - shared jar (flag off / explicit jar): partition 1's first read
+ *     MUST carry partition 0's cookie
+ *   - per-partition jars (flag on): partition 1's first read MUST
+ *     carry nothing
  *
  * Complements test/unit/per-partition-cookie-jar.test.js, which covers
  * the allocation/lifecycle seams with mocks.
@@ -32,14 +34,14 @@ var _ = require('lodash'),
     this.timeout(30 * 1000); // local server only — should be fast
 
     var httpServer,
-        reads; // [{vu, cookie}] in arrival order, recorded by the server
+        reads; // [{partition, cookie}] in arrival order, recorded by the server
 
     before(function (done) {
         httpServer = server.createHTTPServer();
 
         httpServer.on('/read', function (req, res) {
             reads.push({
-                vu: url.parse(req.url, true).query.vu,
+                partition: url.parse(req.url, true).query.partition,
                 cookie: req.headers.cookie || ''
             });
             res.writeHead(200, { 'content-type': 'text/plain' });
@@ -66,12 +68,13 @@ var _ = require('lodash'),
     });
 
     // Collection: each loop reads first (observing whatever the jar
-    // attaches), then sets this VU's marker cookie. Read-first ordering is
-    // what makes shared-vs-isolated deterministic for the next VU.
+    // attaches), then sets this partition's marker cookie. Read-first
+    // ordering is what makes shared-vs-isolated deterministic for the
+    // next partition.
     function readThenSetCollection () {
         return new Collection({
             item: [
-                { id: 'read-item', name: 'read', request: httpServer.url + '/read?vu={{marker}}' },
+                { id: 'read-item', name: 'read', request: httpServer.url + '/read?partition={{marker}}' },
                 { id: 'set-item', name: 'set', request: httpServer.url + '/set?marker={{marker}}' }
             ]
         });
@@ -88,8 +91,8 @@ var _ = require('lodash'),
      * @param {Collection} opts.collection -
      * @param {Object} [opts.requester] - requester options for the run
      * @param {Array} opts.schedule - array of steps executed in order:
-     *   { start: <vuIndex>, marker: <String> }  → startParallelIteration
-     *   { stop: <vuIndex> }                     → stopParallelIteration
+     *   { start: <partitionIndex>, marker: <String> }  → startParallelIteration
+     *   { stop: <partitionIndex> }                     → stopParallelIteration
      *   each `start` step consumes one iteration trigger before advancing.
      * @param {Function} done - (err, spies)
      */
@@ -156,30 +159,30 @@ var _ = require('lodash'),
         });
     }
 
-    describe('flag ON — wire isolation and VU-lifetime persistence', function () {
+    describe('flag ON — wire isolation and partition-lifetime persistence', function () {
         before(function (done) {
             runSchedule({
                 collection: readThenSetCollection(),
                 requester: { perPartitionCookieJar: true },
                 schedule: [
-                    { start: 0, marker: 'vu0' }, // VU0 loop 1: read (empty), set vu0
-                    { start: 0, marker: 'vu0' }, // VU0 loop 2: read (own cookie persists)
-                    { start: 1, marker: 'vu1' }, // VU1 loop 1: read — must NOT see vu0
-                    { start: 1, marker: 'vu1' } // VU1 loop 2: read (own cookie persists)
+                    { start: 0, marker: 'p0' }, // partition 0 loop 1: read (empty), set p0
+                    { start: 0, marker: 'p0' }, // partition 0 loop 2: read (own cookie persists)
+                    { start: 1, marker: 'p1' }, // partition 1 loop 1: read — must NOT see p0
+                    { start: 1, marker: 'p1' } // partition 1 loop 2: read (own cookie persists)
                 ]
             }, done);
         });
 
-        it('keeps VU1 blind to VU0\'s cookie even though VU0 set it first', function () {
-            expect(reads[2]).to.eql({ vu: 'vu1', cookie: '' });
+        it('keeps partition 1 blind to partition 0\'s cookie even though partition 0 set it first', function () {
+            expect(reads[2]).to.eql({ partition: 'p1', cookie: '' });
         });
 
-        it('persists each VU\'s own cookie across loop iterations (sign-in-once pattern)', function () {
+        it('persists each partition\'s own cookie across loop iterations (sign-in-once pattern)', function () {
             expect(reads).to.eql([
-                { vu: 'vu0', cookie: '' },
-                { vu: 'vu0', cookie: 'marker=vu0' },
-                { vu: 'vu1', cookie: '' },
-                { vu: 'vu1', cookie: 'marker=vu1' }
+                { partition: 'p0', cookie: '' },
+                { partition: 'p0', cookie: 'marker=p0' },
+                { partition: 'p1', cookie: '' },
+                { partition: 'p1', cookie: 'marker=p1' }
             ]);
         });
     });
@@ -189,16 +192,16 @@ var _ = require('lodash'),
             runSchedule({
                 collection: readThenSetCollection(),
                 schedule: [
-                    { start: 0, marker: 'vu0' },
-                    { start: 1, marker: 'vu1' }
+                    { start: 0, marker: 'p0' },
+                    { start: 1, marker: 'p1' }
                 ]
             }, done);
         });
 
-        it('leaks VU0\'s cookie into VU1\'s first request (the bug this option fixes)', function () {
+        it('leaks partition 0\'s cookie into partition 1\'s first request (the bug this option fixes)', function () {
             expect(reads).to.eql([
-                { vu: 'vu0', cookie: '' },
-                { vu: 'vu1', cookie: 'marker=vu0' }
+                { partition: 'p0', cookie: '' },
+                { partition: 'p1', cookie: 'marker=p0' }
             ]);
         });
     });
@@ -214,16 +217,16 @@ var _ = require('lodash'),
                     cookieJar: RequestCookieJar()
                 },
                 schedule: [
-                    { start: 0, marker: 'vu0' },
-                    { start: 1, marker: 'vu1' }
+                    { start: 0, marker: 'p0' },
+                    { start: 1, marker: 'p1' }
                 ]
             }, done);
         });
 
         it('behaves as a shared (caller-owned) jar across partitions', function () {
             expect(reads).to.eql([
-                { vu: 'vu0', cookie: '' },
-                { vu: 'vu1', cookie: 'marker=vu0' }
+                { partition: 'p0', cookie: '' },
+                { partition: 'p1', cookie: 'marker=p0' }
             ]);
         });
     });
@@ -234,19 +237,19 @@ var _ = require('lodash'),
                 collection: readThenSetCollection(),
                 requester: { perPartitionCookieJar: true },
                 schedule: [
-                    { start: 0, marker: 'vu0' }, // loop 1: read (empty), set vu0
-                    { start: 0, marker: 'vu0' }, // loop 2: read (cookie present)
-                    { stop: 0 }, // VU recycled — jar must reset
-                    { start: 0, marker: 'vu0-reborn' } // loop 3: read must be empty again
+                    { start: 0, marker: 'p0' }, // loop 1: read (empty), set p0
+                    { start: 0, marker: 'p0' }, // loop 2: read (cookie present)
+                    { stop: 0 }, // partition recycled — jar must reset
+                    { start: 0, marker: 'p0-reborn' } // loop 3: read must be empty again
                 ]
             }, done);
         });
 
-        it('gives the reborn VU an empty jar (no residue from the dead VU)', function () {
+        it('gives the recycled partition an empty jar (no residue from the stopped one)', function () {
             expect(reads).to.eql([
-                { vu: 'vu0', cookie: '' },
-                { vu: 'vu0', cookie: 'marker=vu0' },
-                { vu: 'vu0-reborn', cookie: '' }
+                { partition: 'p0', cookie: '' },
+                { partition: 'p0', cookie: 'marker=p0' },
+                { partition: 'p0-reborn', cookie: '' }
             ]);
         });
     });
@@ -257,7 +260,7 @@ var _ = require('lodash'),
                 item: [{
                     id: 'prog-item',
                     name: 'programmatic',
-                    request: httpServer.url + '/read?vu={{marker}}',
+                    request: httpServer.url + '/read?partition={{marker}}',
                     event: [{
                         listen: 'prerequest',
                         script: {
@@ -280,16 +283,16 @@ var _ = require('lodash'),
                 collection: collection,
                 requester: { perPartitionCookieJar: true },
                 schedule: [
-                    { start: 0, marker: 'vu0' },
-                    { start: 1, marker: 'vu1' }
+                    { start: 0, marker: 'p0' },
+                    { start: 1, marker: 'p1' }
                 ]
             }, done);
         });
 
-        it('routes script jar writes to the writing VU\'s own jar only', function () {
+        it('routes script jar writes to the writing partition\'s own jar only', function () {
             expect(reads).to.eql([
-                { vu: 'vu0', cookie: 'prog=vu0' },
-                { vu: 'vu1', cookie: 'prog=vu1' } // NOT 'prog=vu0; prog=vu1'
+                { partition: 'p0', cookie: 'prog=p0' },
+                { partition: 'p1', cookie: 'prog=p1' } // NOT 'prog=p0; prog=p1'
             ]);
         });
     });
@@ -300,7 +303,7 @@ var _ = require('lodash'),
                 item: [{
                     id: 'sr-item',
                     name: 'send-request',
-                    request: httpServer.url + '/read?vu={{marker}}',
+                    request: httpServer.url + '/read?partition={{marker}}',
                     event: [{
                         listen: 'test',
                         script: {
@@ -324,18 +327,18 @@ var _ = require('lodash'),
                 collection: collection,
                 requester: { perPartitionCookieJar: true },
                 schedule: [
-                    { start: 0, marker: 'vu0' }, // loop 1: read empty, sendRequest sets sr-vu0
-                    { start: 0, marker: 'vu0' }, // loop 2: read must carry sr-vu0
-                    { start: 1, marker: 'vu1' } // VU1 must not see VU0's sendRequest cookie
+                    { start: 0, marker: 'p0' }, // loop 1: read empty, sendRequest sets sr-p0
+                    { start: 0, marker: 'p0' }, // loop 2: read must carry sr-p0
+                    { start: 1, marker: 'p1' } // partition 1 must not see partition 0's sendRequest cookie
                 ]
             }, done);
         });
 
-        it('makes the nested request\'s Set-Cookie visible to the same VU only', function () {
+        it('makes the nested request\'s Set-Cookie visible to the same partition only', function () {
             expect(reads).to.eql([
-                { vu: 'vu0', cookie: '' },
-                { vu: 'vu0', cookie: 'marker=sr-vu0' },
-                { vu: 'vu1', cookie: '' }
+                { partition: 'p0', cookie: '' },
+                { partition: 'p0', cookie: 'marker=sr-p0' },
+                { partition: 'p1', cookie: '' }
             ]);
         });
     });

--- a/test/integration/runner-spec/perPartitionCookieJar.test.js
+++ b/test/integration/runner-spec/perPartitionCookieJar.test.js
@@ -25,9 +25,10 @@ var _ = require('lodash'),
     VariableScope = require('postman-collection').VariableScope,
     RequestCookieJar = require('postman-request').jar,
     Runner = require('../../../index.js').Runner,
-    server = require('../../fixtures/servers/_servers');
+    IS_NODE = typeof window === 'undefined',
+    server = IS_NODE && require('../../fixtures/servers/_servers');
 
-describe('requester.perPartitionCookieJar end-to-end', function () {
+(IS_NODE ? describe : describe.skip)('requester.perPartitionCookieJar end-to-end', function () {
     this.timeout(30 * 1000); // local server only — should be fast
 
     var httpServer,
@@ -96,6 +97,8 @@ describe('requester.perPartitionCookieJar end-to-end', function () {
         var runner = new Runner({}),
             spies = {},
             stepIndex = 0,
+            completed = false,
+            aborting = false,
             run;
 
         // each schedule owns the server-side observation log (describe
@@ -107,11 +110,25 @@ describe('requester.perPartitionCookieJar end-to-end', function () {
             spies[name] = sinon.spy();
         });
 
+        function finish (err) {
+            if (completed) { return; }
+
+            completed = true;
+            run && run.host && setTimeout(function () { run.host.dispose(); }, 0);
+            done(err, spies);
+        }
+
         function advance () {
+            if (completed || aborting) { return; }
+
             var step = opts.schedule[stepIndex];
 
             // schedule exhausted — wind down
-            if (!step) { return run.abort(_.noop); }
+            if (!step) {
+                aborting = true;
+
+                return run.abort(_.noop);
+            }
 
             stepIndex += 1;
 
@@ -128,15 +145,12 @@ describe('requester.perPartitionCookieJar end-to-end', function () {
             iterationCount: 1,
             maxConcurrency: 1
         }, opts.requester ? { requester: opts.requester } : {}), function (err, runInstance) {
-            if (err) { return done(err); }
+            if (err) { return finish(err); }
             run = runInstance;
 
             spies.start = sinon.spy(function () { advance(); });
             spies.iteration = sinon.spy(function () { advance(); });
-            spies.done = sinon.spy(function () {
-                setTimeout(function () { run.host.dispose(); }, 0);
-                done(null, spies);
-            });
+            spies.done = sinon.spy(function () { finish(null); });
 
             run.start(spies);
         });

--- a/test/integration/runner-spec/perPartitionCookieJar.test.js
+++ b/test/integration/runner-spec/perPartitionCookieJar.test.js
@@ -1,0 +1,328 @@
+/**
+ * End-to-end integration tests for requester.perPartitionCookieJar.
+ *
+ * Wire-level proof against a LOCAL http server (no external network):
+ * the server records the Cookie header it receives on every /read and
+ * issues Set-Cookie on every /set, so cross-partition contamination is
+ * observed exactly where it matters — on the wire — rather than through
+ * pm.* scopes.
+ *
+ * All tests sequence VU loops deterministically (VU1 starts only after
+ * VU0's loops complete), so assertions are exact instead of statistical:
+ *   - shared jar (flag off / explicit jar): VU1's first read MUST carry
+ *     VU0's cookie
+ *   - per-partition jars (flag on): VU1's first read MUST carry nothing
+ *
+ * Complements test/unit/per-partition-cookie-jar.test.js, which covers
+ * the allocation/lifecycle seams with mocks.
+ */
+
+var _ = require('lodash'),
+    url = require('url'),
+    sinon = require('sinon').createSandbox(),
+    expect = require('chai').expect,
+    Collection = require('postman-collection').Collection,
+    VariableScope = require('postman-collection').VariableScope,
+    RequestCookieJar = require('postman-request').jar,
+    Runner = require('../../../index.js').Runner,
+    server = require('../../fixtures/servers/_servers');
+
+describe('requester.perPartitionCookieJar end-to-end', function () {
+    this.timeout(30 * 1000); // local server only — should be fast
+
+    var httpServer,
+        reads; // [{vu, cookie}] in arrival order, recorded by the server
+
+    before(function (done) {
+        httpServer = server.createHTTPServer();
+
+        httpServer.on('/read', function (req, res) {
+            reads.push({
+                vu: url.parse(req.url, true).query.vu,
+                cookie: req.headers.cookie || ''
+            });
+            res.writeHead(200, { 'content-type': 'text/plain' });
+            res.end('ok');
+        });
+
+        httpServer.on('/set', function (req, res) {
+            res.writeHead(200, {
+                'content-type': 'text/plain',
+                'set-cookie': 'marker=' + url.parse(req.url, true).query.marker + '; Path=/'
+            });
+            res.end('ok');
+        });
+
+        httpServer.listen(0, done);
+    });
+
+    after(function (done) {
+        httpServer.destroy(done);
+    });
+
+    afterEach(function () {
+        sinon.restore();
+    });
+
+    // Collection: each loop reads first (observing whatever the jar
+    // attaches), then sets this VU's marker cookie. Read-first ordering is
+    // what makes shared-vs-isolated deterministic for the next VU.
+    function readThenSetCollection () {
+        return new Collection({
+            item: [
+                { id: 'read-item', name: 'read', request: httpServer.url + '/read?vu={{marker}}' },
+                { id: 'set-item', name: 'set', request: httpServer.url + '/set?marker={{marker}}' }
+            ]
+        });
+    }
+
+    function markerScope (marker) {
+        return new VariableScope({ values: [{ key: 'marker', value: marker }] });
+    }
+
+    /**
+     * Drives a custom-mode run through an explicit schedule.
+     *
+     * @param {Object} opts -
+     * @param {Collection} opts.collection -
+     * @param {Object} [opts.requester] - requester options for the run
+     * @param {Array} opts.schedule - array of steps executed in order:
+     *   { start: <vuIndex>, marker: <String> }  → startParallelIteration
+     *   { stop: <vuIndex> }                     → stopParallelIteration
+     *   each `start` step consumes one iteration trigger before advancing.
+     * @param {Function} done - (err, spies)
+     */
+    function runSchedule (opts, done) {
+        var runner = new Runner({}),
+            spies = {},
+            stepIndex = 0,
+            run;
+
+        // each schedule owns the server-side observation log (describe
+        // blocks call runSchedule from their before-all hook, which runs
+        // before any root-level beforeEach could reset this)
+        reads = [];
+
+        _.forEach(_.keys(Runner.Run.triggers), function (name) {
+            spies[name] = sinon.spy();
+        });
+
+        function advance () {
+            var step = opts.schedule[stepIndex];
+
+            // schedule exhausted — wind down
+            if (!step) { return run.abort(_.noop); }
+
+            stepIndex += 1;
+
+            if (typeof step.stop === 'number') {
+                // stop consumes no iteration trigger; advance immediately
+                return run.stopParallelIteration(step.stop, function () { advance(); });
+            }
+
+            run.startParallelIteration(step.start, markerScope(step.marker), _.noop);
+        }
+
+        runner.run(opts.collection, _.assign({
+            customParallelIterations: true,
+            iterationCount: 1,
+            maxConcurrency: 1
+        }, opts.requester ? { requester: opts.requester } : {}), function (err, runInstance) {
+            if (err) { return done(err); }
+            run = runInstance;
+
+            spies.start = sinon.spy(function () { advance(); });
+            spies.iteration = sinon.spy(function () { advance(); });
+            spies.done = sinon.spy(function () {
+                setTimeout(function () { run.host.dispose(); }, 0);
+                done(null, spies);
+            });
+
+            run.start(spies);
+        });
+    }
+
+    describe('flag ON — wire isolation and VU-lifetime persistence', function () {
+        before(function (done) {
+            runSchedule({
+                collection: readThenSetCollection(),
+                requester: { perPartitionCookieJar: true },
+                schedule: [
+                    { start: 0, marker: 'vu0' }, // VU0 loop 1: read (empty), set vu0
+                    { start: 0, marker: 'vu0' }, // VU0 loop 2: read (own cookie persists)
+                    { start: 1, marker: 'vu1' }, // VU1 loop 1: read — must NOT see vu0
+                    { start: 1, marker: 'vu1' } // VU1 loop 2: read (own cookie persists)
+                ]
+            }, done);
+        });
+
+        it('keeps VU1 blind to VU0\'s cookie even though VU0 set it first', function () {
+            expect(reads[2]).to.eql({ vu: 'vu1', cookie: '' });
+        });
+
+        it('persists each VU\'s own cookie across loop iterations (sign-in-once pattern)', function () {
+            expect(reads).to.eql([
+                { vu: 'vu0', cookie: '' },
+                { vu: 'vu0', cookie: 'marker=vu0' },
+                { vu: 'vu1', cookie: '' },
+                { vu: 'vu1', cookie: 'marker=vu1' }
+            ]);
+        });
+    });
+
+    describe('flag OFF — pins the shared-jar status quo', function () {
+        before(function (done) {
+            runSchedule({
+                collection: readThenSetCollection(),
+                schedule: [
+                    { start: 0, marker: 'vu0' },
+                    { start: 1, marker: 'vu1' }
+                ]
+            }, done);
+        });
+
+        it('leaks VU0\'s cookie into VU1\'s first request (the bug this option fixes)', function () {
+            expect(reads).to.eql([
+                { vu: 'vu0', cookie: '' },
+                { vu: 'vu1', cookie: 'marker=vu0' }
+            ]);
+        });
+    });
+
+    describe('flag ON + explicit requester.cookieJar — explicit jar wins', function () {
+        before(function (done) {
+            sinon.stub(console, 'warn'); // the constructor warns; keep output clean
+
+            runSchedule({
+                collection: readThenSetCollection(),
+                requester: {
+                    perPartitionCookieJar: true,
+                    cookieJar: RequestCookieJar()
+                },
+                schedule: [
+                    { start: 0, marker: 'vu0' },
+                    { start: 1, marker: 'vu1' }
+                ]
+            }, done);
+        });
+
+        it('behaves as a shared (caller-owned) jar across partitions', function () {
+            expect(reads).to.eql([
+                { vu: 'vu0', cookie: '' },
+                { vu: 'vu1', cookie: 'marker=vu0' }
+            ]);
+        });
+    });
+
+    describe('flag ON — full fresh on reuse (stop + restart)', function () {
+        before(function (done) {
+            runSchedule({
+                collection: readThenSetCollection(),
+                requester: { perPartitionCookieJar: true },
+                schedule: [
+                    { start: 0, marker: 'vu0' }, // loop 1: read (empty), set vu0
+                    { start: 0, marker: 'vu0' }, // loop 2: read (cookie present)
+                    { stop: 0 }, // VU recycled — jar must reset
+                    { start: 0, marker: 'vu0-reborn' } // loop 3: read must be empty again
+                ]
+            }, done);
+        });
+
+        it('gives the reborn VU an empty jar (no residue from the dead VU)', function () {
+            expect(reads).to.eql([
+                { vu: 'vu0', cookie: '' },
+                { vu: 'vu0', cookie: 'marker=vu0' },
+                { vu: 'vu0-reborn', cookie: '' }
+            ]);
+        });
+    });
+
+    describe('flag ON — programmatic access (pm.cookies.jar()) is partition-scoped', function () {
+        before(function (done) {
+            var collection = new Collection({
+                item: [{
+                    id: 'prog-item',
+                    name: 'programmatic',
+                    request: httpServer.url + '/read?vu={{marker}}',
+                    event: [{
+                        listen: 'prerequest',
+                        script: {
+                            type: 'text/javascript',
+                            exec: [
+                                '// write into the jar via the sandbox cookie-store bridge,',
+                                '// then let the request prove (on the wire) which jar took it',
+                                'const jar = pm.cookies.jar();',
+                                'const marker = pm.variables.get("marker");',
+                                'jar.set("' + httpServer.url + '", "prog", marker, function (err) {',
+                                '    if (err) { throw err; }',
+                                '});'
+                            ].join('\n')
+                        }
+                    }]
+                }]
+            });
+
+            runSchedule({
+                collection: collection,
+                requester: { perPartitionCookieJar: true },
+                schedule: [
+                    { start: 0, marker: 'vu0' },
+                    { start: 1, marker: 'vu1' }
+                ]
+            }, done);
+        });
+
+        it('routes script jar writes to the writing VU\'s own jar only', function () {
+            expect(reads).to.eql([
+                { vu: 'vu0', cookie: 'prog=vu0' },
+                { vu: 'vu1', cookie: 'prog=vu1' } // NOT 'prog=vu0; prog=vu1'
+            ]);
+        });
+    });
+
+    describe('flag ON — pm.sendRequest cookies land in the sender\'s partition jar', function () {
+        before(function (done) {
+            var collection = new Collection({
+                item: [{
+                    id: 'sr-item',
+                    name: 'send-request',
+                    request: httpServer.url + '/read?vu={{marker}}',
+                    event: [{
+                        listen: 'test',
+                        script: {
+                            type: 'text/javascript',
+                            exec: [
+                                '// nested request sets a cookie; it must land in THIS',
+                                '// partition\'s jar so the next loop\'s read item sees it',
+                                '// (note: pm.sendRequest does not template-resolve {{vars}},',
+                                '// so build the URL from pm.variables explicitly)',
+                                'const url = "' + httpServer.url + '/set?marker=sr-" + pm.variables.get("marker");',
+                                'pm.sendRequest(url, function (err) {',
+                                '    if (err) { throw err; }',
+                                '});'
+                            ].join('\n')
+                        }
+                    }]
+                }]
+            });
+
+            runSchedule({
+                collection: collection,
+                requester: { perPartitionCookieJar: true },
+                schedule: [
+                    { start: 0, marker: 'vu0' }, // loop 1: read empty, sendRequest sets sr-vu0
+                    { start: 0, marker: 'vu0' }, // loop 2: read must carry sr-vu0
+                    { start: 1, marker: 'vu1' } // VU1 must not see VU0's sendRequest cookie
+                ]
+            }, done);
+        });
+
+        it('makes the nested request\'s Set-Cookie visible to the same VU only', function () {
+            expect(reads).to.eql([
+                { vu: 'vu0', cookie: '' },
+                { vu: 'vu0', cookie: 'marker=sr-vu0' },
+                { vu: 'vu1', cookie: '' }
+            ]);
+        });
+    });
+});

--- a/test/integration/runner-spec/perPartitionCookieJar.test.js
+++ b/test/integration/runner-spec/perPartitionCookieJar.test.js
@@ -207,9 +207,9 @@ var _ = require('lodash'),
     });
 
     describe('flag ON + explicit requester.cookieJar — explicit jar wins', function () {
-        before(function (done) {
-            sinon.stub(console, 'warn'); // the constructor warns; keep output clean
+        var runSpies;
 
+        before(function (done) {
             runSchedule({
                 collection: readThenSetCollection(),
                 requester: {
@@ -220,7 +220,10 @@ var _ = require('lodash'),
                     { start: 0, marker: 'p0' },
                     { start: 1, marker: 'p1' }
                 ]
-            }, done);
+            }, function (err, spies) {
+                runSpies = spies;
+                done(err);
+            });
         });
 
         it('behaves as a shared (caller-owned) jar across partitions', function () {
@@ -228,6 +231,16 @@ var _ = require('lodash'),
                 { partition: 'p0', cookie: '' },
                 { partition: 'p1', cookie: 'marker=p0' }
             ]);
+        });
+
+        it('surfaces the ignored warning through the console trigger (not raw stdout)', function () {
+            var warned = runSpies.console.getCalls().filter(function (call) {
+                return call.args[1] === 'warn' &&
+                    typeof call.args[2] === 'string' &&
+                    _.includes(call.args[2], 'perPartitionCookieJar is ignored');
+            });
+
+            expect(warned).to.have.lengthOf(1);
         });
     });
 

--- a/test/unit/per-partition-cookie-jar.test.js
+++ b/test/unit/per-partition-cookie-jar.test.js
@@ -1,5 +1,5 @@
 /**
- * Unit tests for the per-partition (per-VU) cookie jar.
+ * Unit tests for the per-partition cookie jar.
  *
  * Covers the allocation/lifecycle seams in isolation:
  *   - Partition#getCookieJar / Partition#resetCookieJar

--- a/test/unit/per-partition-cookie-jar.test.js
+++ b/test/unit/per-partition-cookie-jar.test.js
@@ -222,8 +222,6 @@ var sinon = require('sinon').createSandbox(),
         });
 
         it('is disabled when an explicit requester.cookieJar is supplied (explicit jar wins)', function () {
-            sinon.stub(console, 'warn'); // silence the one-time warning
-
             var run = makeRun({
                 customParallelIterations: true,
                 requester: {
@@ -236,10 +234,11 @@ var sinon = require('sinon').createSandbox(),
             expect(run.getCookieJarFor({ partitionIndex: 0 })).to.be.undefined;
         });
 
-        it('warns when both perPartitionCookieJar and cookieJar are supplied', function () {
-            var warn = sinon.stub(console, 'warn');
-
-            makeRun({
+        it('flags the ignored-warning intent when both perPartitionCookieJar and cookieJar are supplied', function () {
+            // the warning itself is emitted through the console trigger in
+            // Run#start (see the end-to-end suite); the constructor only
+            // records that it must fire.
+            var run = makeRun({
                 customParallelIterations: true,
                 requester: {
                     perPartitionCookieJar: true,
@@ -247,8 +246,16 @@ var sinon = require('sinon').createSandbox(),
                 }
             });
 
-            expect(warn.calledOnce).to.be.true;
-            expect(warn.firstCall.args[0]).to.include('perPartitionCookieJar');
+            expect(run._perPartitionCookieJarIgnored).to.be.true;
+        });
+
+        it('does not flag the ignored-warning intent when only perPartitionCookieJar is supplied', function () {
+            var run = makeRun({
+                customParallelIterations: true,
+                requester: { perPartitionCookieJar: true }
+            });
+
+            expect(run._perPartitionCookieJarIgnored).to.be.false;
         });
     });
 

--- a/test/unit/per-partition-cookie-jar.test.js
+++ b/test/unit/per-partition-cookie-jar.test.js
@@ -259,7 +259,12 @@ var sinon = require('sinon').createSandbox(),
             };
         }
 
-        function runEvent (getCookieJarFor, sharedCookieJar, done) {
+        function runEvent (getCookieJarFor, sharedCookieJar, options, done) {
+            if (typeof options === 'function') {
+                done = options;
+                options = {};
+            }
+
             var host = new EventEmitter(),
                 item = new sdk.Item({
                     name: 'request',
@@ -284,7 +289,7 @@ var sinon = require('sinon').createSandbox(),
 
             runnerContext = {
                 options: {},
-                state: {},
+                state: options.state || {},
                 requester: {
                     options: {
                         cookieJar: sharedCookieJar
@@ -308,7 +313,7 @@ var sinon = require('sinon').createSandbox(),
             }, function (err) {
                 if (err) { return done(err); }
 
-                done(null, host);
+                done(null, host, runnerContext);
             });
         }
 
@@ -354,6 +359,39 @@ var sinon = require('sinon').createSandbox(),
                     .to.be.true;
                 expect(host.dispatch.calledWith('execution.cookies.' +
                     host.execute.firstCall.args[1].id, 'cookie-event-id', null, ['shared-cookie'])).to.be.true;
+
+                done();
+            });
+        });
+
+        it('uses the nested request root cursor for script callbacks', function (done) {
+            var rootCursor = {
+                    partitionIndex: 0,
+                    ref: 'root-cursor'
+                },
+                sharedStore = {
+                    findCookies: sinon.stub().callsArgWith(2, null, ['shared-cookie'])
+                },
+                sharedCookieJar = cookieJarWithStore(sharedStore),
+                getCookieJarFor = sinon.stub().returns();
+
+            runEvent(getCookieJarFor, sharedCookieJar, {
+                state: {
+                    nestedRequest: {
+                        rootCursor: rootCursor,
+                        rootItem: { id: 'root-item-id' }
+                    }
+                }
+            }, function (err, host, runnerContext) {
+                var scriptCursor;
+
+                if (err) { return done(err); }
+
+                expect(runnerContext.triggers.beforeScript.calledOnce).to.be.true;
+
+                scriptCursor = runnerContext.triggers.beforeScript.firstCall.args[1];
+                expect(scriptCursor).to.deep.equal(rootCursor);
+                expect(scriptCursor).to.not.equal(rootCursor);
 
                 done();
             });

--- a/test/unit/per-partition-cookie-jar.test.js
+++ b/test/unit/per-partition-cookie-jar.test.js
@@ -14,6 +14,7 @@
 
 var sinon = require('sinon').createSandbox(),
     expect = require('chai').expect,
+    IS_NODE = typeof window === 'undefined',
 
     /**
      * Minimal jar stand-in for option-precedence tests.
@@ -28,7 +29,7 @@ var sinon = require('sinon').createSandbox(),
     RequesterPool = require('../../lib/requester').RequesterPool,
     Run = require('../../lib/runner/run');
 
-describe('per-partition cookie jar (unit)', function () {
+(IS_NODE ? describe : describe.skip)('per-partition cookie jar (unit)', function () {
     afterEach(function () {
         sinon.restore();
     });

--- a/test/unit/per-partition-cookie-jar.test.js
+++ b/test/unit/per-partition-cookie-jar.test.js
@@ -1,0 +1,250 @@
+/**
+ * Unit tests for the per-partition (per-VU) cookie jar.
+ *
+ * Covers the allocation/lifecycle seams in isolation:
+ *   - Partition#getCookieJar / Partition#resetCookieJar
+ *   - PartitionManager#stopSinglePartition jar reset (custom mode only)
+ *   - RequesterPool#create per-trace jar override (no shared-options mutation)
+ *   - Run#getCookieJarFor resolution + gating rules
+ *
+ * The end-to-end wire behavior (Set-Cookie isolation across partitions
+ * against a real HTTP server) lives in
+ * test/integration/runner-spec/perPartitionCookieJar.test.js.
+ */
+
+var sinon = require('sinon').createSandbox(),
+    expect = require('chai').expect,
+
+    /**
+     * Minimal jar stand-in for option-precedence tests.
+     *
+     * @returns {Object} object that looks like a cookie jar
+     */
+    stubJar = function () {
+        return { getCookies () { return undefined; } };
+    },
+    Partition = require('../../lib/runner/partition'),
+    PartitionManager = require('../../lib/runner/partition-manager'),
+    RequesterPool = require('../../lib/requester').RequesterPool,
+    Run = require('../../lib/runner/run');
+
+describe('per-partition cookie jar (unit)', function () {
+    afterEach(function () {
+        sinon.restore();
+    });
+
+    describe('Partition#getCookieJar', function () {
+        var runInstance = {
+            state: null,
+            options: {}
+        };
+
+        it('starts with no jar allocated (lazy)', function () {
+            var partition = new Partition(runInstance, 0, 1, 0);
+
+            expect(partition.cookieJar).to.be.null;
+        });
+
+        it('lazily allocates a tough-cookie jar with a store and memoizes it', function () {
+            var partition = new Partition(runInstance, 0, 1, 0),
+                jar = partition.getCookieJar();
+
+            expect(jar).to.be.an('object');
+            // programmatic access (pm.cookies.jar()) requires .store
+            expect(jar.store).to.be.an('object');
+            expect(jar.getCookies).to.be.a('function');
+
+            // memoized — same instance on every subsequent call
+            expect(partition.getCookieJar()).to.equal(jar);
+            expect(partition.cookieJar).to.equal(jar);
+        });
+
+        it('never shares a jar between two partitions', function () {
+            var p0 = new Partition(runInstance, 0, 1, 0),
+                p1 = new Partition(runInstance, 0, 1, 1);
+
+            expect(p0.getCookieJar()).to.not.equal(p1.getCookieJar());
+        });
+
+        it('resetCookieJar drops the jar; next getCookieJar allocates a fresh one', function () {
+            var after,
+                partition = new Partition(runInstance, 0, 1, 0),
+                before = partition.getCookieJar();
+
+            partition.resetCookieJar();
+            expect(partition.cookieJar).to.be.null;
+
+            after = partition.getCookieJar();
+
+            expect(after).to.be.an('object');
+            expect(after).to.not.equal(before);
+        });
+    });
+
+    describe('PartitionManager#stopSinglePartition', function () {
+        function managerFor (isCustom) {
+            var mockRunInstance = {
+                    options: {
+                        iterationCount: 1,
+                        maxConcurrency: 1,
+                        customParallelIterations: isCustom
+                    },
+                    state: { items: [{ id: 'item1' }] },
+                    queue: sinon.stub(),
+                    triggers: sinon.stub()
+                },
+                manager = new PartitionManager(mockRunInstance);
+
+            manager.spawn();
+            manager.options = mockRunInstance.options;
+            manager.createSinglePartition(0);
+
+            return manager;
+        }
+
+        it('resets the jar in customParallelIterations mode', function () {
+            var manager = managerFor(true),
+                partition = manager.partitions[0],
+                deadJar = partition.getCookieJar();
+
+            manager.stopSinglePartition(0);
+
+            expect(partition.cookieJar).to.be.null;
+            expect(partition.getCookieJar()).to.not.equal(deadJar);
+        });
+
+        it('leaves the jar alone outside customParallelIterations mode', function () {
+            var manager = managerFor(false),
+                partition = manager.partitions[0],
+                jar = partition.getCookieJar();
+
+            manager.stopSinglePartition(0);
+
+            expect(partition.cookieJar).to.equal(jar);
+        });
+    });
+
+    describe('RequesterPool#create', function () {
+        var pool;
+
+        beforeEach(function (done) {
+            // the constructor invokes its callback synchronously (no
+            // extendedRootCA path) — defer so the assignment completes
+            // before the test body runs
+            pool = new RequesterPool({}, function () { setImmediate(done); });
+        });
+
+        it('allocates a shared default jar when none is supplied', function () {
+            expect(pool.options.cookieJar).to.be.an('object');
+        });
+
+        it('passes the pool options by reference when trace has no jar (status quo)', function (done) {
+            pool.create({ type: 'http' }, function (err, requester) {
+                if (err) { return done(err); }
+
+                expect(requester.options).to.equal(pool.options);
+                done();
+            });
+        });
+
+        it('overrides the jar via a merged copy when trace.cookieJar is set', function (done) {
+            var perPartitionJar = stubJar(),
+                sharedJar = pool.options.cookieJar;
+
+            pool.create({ type: 'http', cookieJar: perPartitionJar }, function (err, requester) {
+                if (err) { return done(err); }
+
+                // requester sees the per-partition jar...
+                expect(requester.options.cookieJar).to.equal(perPartitionJar);
+                // ...other pool options are inherited...
+                expect(requester.options.keepAlive).to.equal(pool.options.keepAlive);
+                // ...and the shared pool options are NOT mutated
+                expect(requester.options).to.not.equal(pool.options);
+                expect(pool.options.cookieJar).to.equal(sharedJar);
+                done();
+            });
+        });
+    });
+
+    describe('Run#getCookieJarFor', function () {
+        function makeRun (options) {
+            var run = new Run({ items: [] }, options);
+
+            // areIterationsParallelized is normally set in Run#start;
+            // set it directly to unit-test the resolution rule.
+            run.areIterationsParallelized = true;
+            run.partitionManager.spawn();
+            run.partitionManager.options = run.options;
+            run.partitionManager.createSinglePartition(0);
+
+            return run;
+        }
+
+        it('returns undefined when the flag is off', function () {
+            var run = makeRun({ customParallelIterations: true });
+
+            expect(run.getCookieJarFor({ partitionIndex: 0 })).to.be.undefined;
+        });
+
+        it('returns the owning partition jar when the flag is on', function () {
+            var run = makeRun({
+                    customParallelIterations: true,
+                    requester: { perPartitionCookieJar: true }
+                }),
+                jar = run.getCookieJarFor({ partitionIndex: 0 });
+
+            expect(jar).to.be.an('object');
+            expect(jar).to.equal(run.partitionManager.partitions[0].getCookieJar());
+        });
+
+        it('returns undefined when iterations are not parallelized', function () {
+            var run = new Run({ items: [] }, {
+                requester: { perPartitionCookieJar: true }
+            });
+
+            // waterfall mode — Run#start never set areIterationsParallelized
+            expect(run.getCookieJarFor({ partitionIndex: 0 })).to.be.undefined;
+        });
+
+        it('returns undefined for an unknown partition index', function () {
+            var run = makeRun({
+                customParallelIterations: true,
+                requester: { perPartitionCookieJar: true }
+            });
+
+            expect(run.getCookieJarFor({ partitionIndex: 7 })).to.be.undefined;
+            expect(run.getCookieJarFor({})).to.be.undefined;
+            expect(run.getCookieJarFor()).to.be.undefined;
+        });
+
+        it('is disabled when an explicit requester.cookieJar is supplied (explicit jar wins)', function () {
+            sinon.stub(console, 'warn'); // silence the one-time warning
+
+            var run = makeRun({
+                customParallelIterations: true,
+                requester: {
+                    perPartitionCookieJar: true,
+                    cookieJar: stubJar()
+                }
+            });
+
+            expect(run.perPartitionCookieJar).to.be.false;
+            expect(run.getCookieJarFor({ partitionIndex: 0 })).to.be.undefined;
+        });
+
+        it('warns when both perPartitionCookieJar and cookieJar are supplied', function () {
+            var warn = sinon.stub(console, 'warn');
+
+            makeRun({
+                customParallelIterations: true,
+                requester: {
+                    perPartitionCookieJar: true,
+                    cookieJar: stubJar()
+                }
+            });
+
+            expect(warn.calledOnce).to.be.true;
+            expect(warn.firstCall.args[0]).to.include('perPartitionCookieJar');
+        });
+    });
+});

--- a/test/unit/per-partition-cookie-jar.test.js
+++ b/test/unit/per-partition-cookie-jar.test.js
@@ -14,6 +14,8 @@
 
 var sinon = require('sinon').createSandbox(),
     expect = require('chai').expect,
+    EventEmitter = require('events').EventEmitter,
+    sdk = require('postman-collection'),
     IS_NODE = typeof window === 'undefined',
 
     /**
@@ -26,6 +28,7 @@ var sinon = require('sinon').createSandbox(),
     },
     Partition = require('../../lib/runner/partition'),
     PartitionManager = require('../../lib/runner/partition-manager'),
+    EventCommand = require('../../lib/runner/extensions/event.command'),
     RequesterPool = require('../../lib/requester').RequesterPool,
     Run = require('../../lib/runner/run');
 
@@ -246,6 +249,114 @@ var sinon = require('sinon').createSandbox(),
 
             expect(warn.calledOnce).to.be.true;
             expect(warn.firstCall.args[0]).to.include('perPartitionCookieJar');
+        });
+    });
+
+    describe('event.command cookie jar resolution', function () {
+        function cookieJarWithStore (store) {
+            return {
+                store
+            };
+        }
+
+        function runEvent (getCookieJarFor, sharedCookieJar, done) {
+            var host = new EventEmitter(),
+                item = new sdk.Item({
+                    name: 'request',
+                    request: 'https://example.com',
+                    event: [{
+                        listen: 'prerequest',
+                        script: {
+                            type: 'text/javascript',
+                            exec: ['var value = 1;']
+                        }
+                    }]
+                }),
+                runnerContext;
+
+            host.dispatch = sinon.stub();
+            host.execute = sinon.stub().callsFake(function (event, options, callback) {
+                host.emit('execution.cookies.' + options.id, 'cookie-event-id', 'store', 'findCookies',
+                    ['example.com', '/']);
+
+                callback(null, {});
+            });
+
+            runnerContext = {
+                options: {},
+                state: {},
+                requester: {
+                    options: {
+                        cookieJar: sharedCookieJar
+                    }
+                },
+                host: host,
+                getCookieJarFor: getCookieJarFor,
+                triggers: {
+                    beforePrerequest: sinon.stub(),
+                    beforeScript: sinon.stub(),
+                    script: sinon.stub(),
+                    prerequest: sinon.stub()
+                }
+            };
+
+            EventCommand.process.event.call(runnerContext, {
+                name: 'prerequest',
+                item: item,
+                coords: { partitionIndex: 0 },
+                context: {}
+            }, function (err) {
+                if (err) { return done(err); }
+
+                done(null, host);
+            });
+        }
+
+        it('uses the partition cookie jar when one is resolved for the cursor', function (done) {
+            var partitionStore = {
+                    findCookies: sinon.stub().callsArgWith(2, null, ['partition-cookie'])
+                },
+                sharedStore = {
+                    findCookies: sinon.stub().callsArgWith(2, null, ['shared-cookie'])
+                },
+                partitionCookieJar = cookieJarWithStore(partitionStore),
+                sharedCookieJar = cookieJarWithStore(sharedStore),
+                getCookieJarFor = sinon.stub().returns(partitionCookieJar);
+
+            runEvent(getCookieJarFor, sharedCookieJar, function (err, host) {
+                if (err) { return done(err); }
+
+                expect(getCookieJarFor.calledOnce).to.be.true;
+                expect(getCookieJarFor.firstCall.args[0]).to.deep.equal({ partitionIndex: 0 });
+                expect(partitionStore.findCookies.calledOnceWithExactly('example.com', '/', sinon.match.func))
+                    .to.be.true;
+                expect(sharedStore.findCookies.called).to.be.false;
+                expect(host.dispatch.calledWith('execution.cookies.' +
+                    host.execute.firstCall.args[1].id, 'cookie-event-id', null, ['partition-cookie'])).to.be.true;
+
+                done();
+            });
+        });
+
+        it('falls back to the shared requester cookie jar when no partition jar is resolved', function (done) {
+            var sharedStore = {
+                    findCookies: sinon.stub().callsArgWith(2, null, ['shared-cookie'])
+                },
+                sharedCookieJar = cookieJarWithStore(sharedStore),
+                getCookieJarFor = sinon.stub().returns();
+
+            runEvent(getCookieJarFor, sharedCookieJar, function (err, host) {
+                if (err) { return done(err); }
+
+                expect(getCookieJarFor.calledOnce).to.be.true;
+                expect(getCookieJarFor.firstCall.args[0]).to.deep.equal({ partitionIndex: 0 });
+                expect(sharedStore.findCookies.calledOnceWithExactly('example.com', '/', sinon.match.func))
+                    .to.be.true;
+                expect(host.dispatch.calledWith('execution.cookies.' +
+                    host.execute.firstCall.args[1].id, 'cookie-event-id', null, ['shared-cookie'])).to.be.true;
+
+                done();
+            });
         });
     });
 });


### PR DESCRIPTION
## Summary

Adds opt-in `requester.perPartitionCookieJar` support so each parallel partition/VU can use its own HTTP cookie jar instead of sharing the runner-level jar.

## Changes

- Adds lazy per-partition cookie jar allocation and reset-on-partition-reuse.
- Routes collection requests, `pm.sendRequest`, auth replays, and `pm.cookies.jar()` through the partition jar when enabled.
- Keeps default behavior unchanged; explicit `requester.cookieJar` still takes precedence.
- Adds focused unit and integration coverage for isolation, precedence, lifecycle, and browser-safe test loading.

## Validation

- `npm run test-lint`
- `npm run test-unit`
- Focused per-partition unit/integration specs
- Codecov patch coverage: 100%
