### PR TITLE
Vendor NTLM message builder and remove httpntlm dependency

### DIFF
--- a/.nycrc.js
+++ b/.nycrc.js
@@ -22,10 +22,10 @@ function configOverrides(testType) {
             };
         case 'integration-legacy':
             return {
-                statements: 42,
-                branches: 31,
-                functions: 38,
-                lines: 42
+                statements: 39,
+                branches: 30,
+                functions: 37,
+                lines: 40
             };
         default:
             return {}

--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -1,6 +1,8 @@
 unreleased:
   chores:
-    - Vendored the NTLM message builder and removed the `httpntlm` dependency
+    - >-
+      GH-1556 Vendored the NTLM message builder and removed the `httpntlm`
+      dependency
 
 7.55.1:
   date: 2026-07-21

--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -1,3 +1,7 @@
+unreleased:
+  chores:
+    - Vendored the NTLM message builder and removed the `httpntlm` dependency
+
 7.55.1:
   date: 2026-07-21
   chores:

--- a/lib/authorizer/ntlm-message.js
+++ b/lib/authorizer/ntlm-message.js
@@ -1,0 +1,673 @@
+/**
+ * @fileOverview
+ *
+ * Builds and parses the NTLM negotiate (type 1), challenge (type 2) and authenticate (type 3)
+ * messages described by [MS-NLMP]: https://msdn.microsoft.com/en-us/library/cc236621.aspx
+ *
+ * Vendored from https://github.com/SamDecrock/node-http-ntlm/blob/v1.8.13/ntlm.js and restyled to
+ * this repository's lint rules. `httpntlm` pins `underscore: ~1.12.1`, which can never resolve to
+ * the version that fixes GHSA-qpx9-hpmf-5gmw, and 1.8.13 is its latest release. Only `ntlm.js`
+ * was ever used here, and it does not depend on `underscore` at all — so vendoring this one file
+ * drops both `underscore` and `httpreq` from the dependency tree.
+ *
+ * Deliberate differences from upstream, all covered by test/unit/ntlm-message.test.js:
+ *   1. The NTLMv2 client challenge uses `crypto.randomBytes` instead of `Math.random`.
+ *   2. The FILETIME timestamp avoids `BigInt` / `Buffer.prototype.writeBigUInt64LE` (see
+ *      `writeFileTime`).
+ *   3. Only the three functions this package consumes are exported, and the unused
+ *      `options.lm_password` / `options.nt_password` overrides are dropped.
+ *
+ * Copyright (c) 2013 Sam Decrock https://github.com/SamDecrock/
+ * All rights reserved.
+ */
+
+var crypto = require('crypto'),
+    jsmd4 = require('js-md4'),
+    desjs = require('des.js'),
+
+    PROTOCOL = 'NTLMSSP\0',
+
+    // page 57 in [MS-NLMP]
+    MAGIC_KEY = Buffer.from('KGS!@#$%', 'ascii'),
+
+    HEX2BINARY = {
+        0: [0, 0, 0, 0],
+        1: [0, 0, 0, 1],
+        2: [0, 0, 1, 0],
+        3: [0, 0, 1, 1],
+        4: [0, 1, 0, 0],
+        5: [0, 1, 0, 1],
+        6: [0, 1, 1, 0],
+        7: [0, 1, 1, 1],
+        8: [1, 0, 0, 0],
+        9: [1, 0, 0, 1],
+        A: [1, 0, 1, 0],
+        B: [1, 0, 1, 1],
+        C: [1, 1, 0, 0],
+        D: [1, 1, 0, 1],
+        E: [1, 1, 1, 0],
+        F: [1, 1, 1, 1]
+    },
+
+    BINARY2HEX = {
+        '0000': 0,
+        '0001': 1,
+        '0010': 2,
+        '0011': 3,
+        '0100': 4,
+        '0101': 5,
+        '0110': 6,
+        '0111': 7,
+        1000: 8,
+        1001: 9,
+        1010: 'A',
+        1011: 'B',
+        1100: 'C',
+        1101: 'D',
+        1110: 'E',
+        1111: 'F'
+    },
+
+    flags = {
+        NTLM_NegotiateUnicode: 0x00000001,
+        NTLM_NegotiateOEM: 0x00000002,
+        NTLM_RequestTarget: 0x00000004,
+        NTLM_Unknown9: 0x00000008,
+        NTLM_NegotiateSign: 0x00000010,
+        NTLM_NegotiateSeal: 0x00000020,
+        NTLM_NegotiateDatagram: 0x00000040,
+        NTLM_NegotiateLanManagerKey: 0x00000080,
+        NTLM_Unknown8: 0x00000100,
+        NTLM_NegotiateNTLM: 0x00000200,
+        NTLM_NegotiateNTOnly: 0x00000400,
+        NTLM_Anonymous: 0x00000800,
+        NTLM_NegotiateOemDomainSupplied: 0x00001000,
+        NTLM_NegotiateOemWorkstationSupplied: 0x00002000,
+        NTLM_Unknown6: 0x00004000,
+        NTLM_NegotiateAlwaysSign: 0x00008000,
+        NTLM_TargetTypeDomain: 0x00010000,
+        NTLM_TargetTypeServer: 0x00020000,
+        NTLM_TargetTypeShare: 0x00040000,
+        NTLM_NegotiateExtendedSecurity: 0x00080000,
+        NTLM_NegotiateIdentify: 0x00100000,
+        NTLM_Unknown5: 0x00200000,
+        NTLM_RequestNonNTSessionKey: 0x00400000,
+        NTLM_NegotiateTargetInfo: 0x00800000,
+        NTLM_Unknown4: 0x01000000,
+        NTLM_NegotiateVersion: 0x02000000,
+        NTLM_Unknown3: 0x04000000,
+        NTLM_Unknown2: 0x08000000,
+        NTLM_Unknown1: 0x10000000,
+        NTLM_Negotiate128: 0x20000000,
+        NTLM_NegotiateKeyExchange: 0x40000000,
+        NTLM_Negotiate56: 0x80000000
+    },
+
+    /**
+     * @note these are summed rather than OR-ed, and flags are cleared by subtraction rather than
+     * by `& ~`, because both totals exceed 2^31. JavaScript's bitwise operators coerce to int32,
+     * which would make these negative and cause `Buffer#writeUInt32LE` to throw ERR_OUT_OF_RANGE.
+     */
+    typeflags = {
+        NTLM_TYPE1_FLAGS: flags.NTLM_NegotiateUnicode +
+            flags.NTLM_NegotiateOEM +
+            flags.NTLM_RequestTarget +
+            flags.NTLM_NegotiateNTLM +
+            flags.NTLM_NegotiateOemDomainSupplied +
+            flags.NTLM_NegotiateOemWorkstationSupplied +
+            flags.NTLM_NegotiateAlwaysSign +
+            flags.NTLM_NegotiateExtendedSecurity +
+            flags.NTLM_NegotiateVersion +
+            flags.NTLM_Negotiate128 +
+            flags.NTLM_Negotiate56,
+
+        NTLM_TYPE2_FLAGS: flags.NTLM_NegotiateUnicode +
+            flags.NTLM_RequestTarget +
+            flags.NTLM_NegotiateNTLM +
+            flags.NTLM_NegotiateAlwaysSign +
+            flags.NTLM_NegotiateExtendedSecurity +
+            flags.NTLM_NegotiateTargetInfo +
+            flags.NTLM_NegotiateVersion +
+            flags.NTLM_Negotiate128 +
+            flags.NTLM_Negotiate56
+    };
+
+/**
+ * Expands a buffer into an array of bits, most significant first.
+ *
+ * @private
+ * @param {Buffer} buf - Bytes to expand
+ * @returns {Number[]} One element per bit, each 0 or 1
+ */
+function bytes2binaryArray (buf) {
+    var hexString = buf.toString('hex').toUpperCase(),
+        array = [];
+
+    for (let i = 0; i < hexString.length; i++) {
+        array = array.concat(HEX2BINARY[hexString.charAt(i)]);
+    }
+
+    return array;
+}
+
+/**
+ * Packs an array of bits back into a buffer. The input length is always a multiple of 8 here.
+ *
+ * @private
+ * @param {Number[]} array - One element per bit, each 0 or 1
+ * @returns {Buffer}
+ */
+function binaryArray2bytes (array) {
+    var bufArray = [],
+        binString1,
+        binString2;
+
+    for (let i = 0; i < array.length; i += 8) {
+        binString1 = `${array[i]}${array[i + 1]}${array[i + 2]}${array[i + 3]}`;
+        binString2 = `${array[i + 4]}${array[i + 5]}${array[i + 6]}${array[i + 7]}`;
+
+        bufArray.push(Buffer.from(`${BINARY2HEX[binString1]}${BINARY2HEX[binString2]}`, 'hex'));
+    }
+
+    return Buffer.concat(bufArray);
+}
+
+/**
+ * Turns a 7-byte block into the 8-byte parity-padded form DES expects as a key.
+ *
+ * @private
+ * @param {Buffer} buf - 7 bytes
+ * @returns {Buffer} 8 bytes
+ */
+function insertZerosEvery7Bits (buf) {
+    var binaryArray = bytes2binaryArray(buf),
+        newBinaryArray = [];
+
+    for (let i = 0; i < binaryArray.length; i++) {
+        newBinaryArray.push(binaryArray[i]);
+
+        if ((i + 1) % 7 === 0) {
+            newBinaryArray.push(0);
+        }
+    }
+
+    return binaryArray2bytes(newBinaryArray);
+}
+
+/**
+ * DES-encrypts the [MS-NLMP] magic constant using the given 7-byte block as the key.
+ *
+ * @private
+ * @param {Buffer} buf - 7 bytes of key material
+ * @returns {Buffer} 8 bytes of ciphertext
+ */
+function desEncryptMagicKey (buf) {
+    var des = desjs.DES.create({ type: 'encrypt', key: insertZerosEvery7Bits(buf) });
+
+    return Buffer.from(des.update(MAGIC_KEY));
+}
+
+/**
+ * Computes the LM hash (LMOWFv1) of a password.
+ *
+ * @private
+ * @param {String} password - Plaintext password
+ * @returns {Buffer} 16 bytes
+ */
+function create_LM_hashed_password_v1 (password) {
+    // fix the password length to 14 bytes
+    var passwordBytes = Buffer.from(password.toUpperCase(), 'ascii'),
+        passwordBytesPadded = Buffer.alloc(14),
+        sourceEnd = 14;
+
+    if (passwordBytes.length < 14) { sourceEnd = passwordBytes.length; }
+    passwordBytes.copy(passwordBytesPadded, 0, 0, sourceEnd);
+
+    // split into 2 parts of 7 bytes:
+    return Buffer.concat([
+        desEncryptMagicKey(passwordBytesPadded.subarray(0, 7)),
+        desEncryptMagicKey(passwordBytesPadded.subarray(7))
+    ]);
+}
+
+/**
+ * Computes the NT hash (NTOWFv1) of a password.
+ *
+ * @private
+ * @param {String} password - Plaintext password
+ * @returns {Buffer} 16 bytes
+ */
+function create_NT_hashed_password_v1 (password) {
+    var md4 = jsmd4.create();
+
+    md4.update(Buffer.from(password, 'utf16le'));
+
+    return Buffer.from(md4.digest());
+}
+
+/**
+ * Computes an NTLMv1 challenge response by DES-encrypting the server challenge under each of the
+ * three 7-byte slices of the zero-padded password hash.
+ *
+ * @private
+ * @param {Buffer} password_hash - LM or NT hash
+ * @param {Buffer} server_challenge - 8-byte challenge from the type 2 message
+ * @returns {Buffer} 24 bytes
+ */
+function calc_resp (password_hash, server_challenge) {
+    // padding with zeros to make the hash 21 bytes long
+    var passHashPadded = Buffer.alloc(21),
+        resArray = [],
+        des;
+
+    password_hash.copy(passHashPadded, 0, 0, password_hash.length);
+
+    des = desjs.DES.create({ type: 'encrypt', key: insertZerosEvery7Bits(passHashPadded.subarray(0, 7)) });
+    resArray.push(Buffer.from(des.update(server_challenge.subarray(0, 8))));
+
+    des = desjs.DES.create({ type: 'encrypt', key: insertZerosEvery7Bits(passHashPadded.subarray(7, 14)) });
+    resArray.push(Buffer.from(des.update(server_challenge.subarray(0, 8))));
+
+    des = desjs.DES.create({ type: 'encrypt', key: insertZerosEvery7Bits(passHashPadded.subarray(14, 21)) });
+    resArray.push(Buffer.from(des.update(server_challenge.subarray(0, 8))));
+
+    return Buffer.concat(resArray);
+}
+
+/**
+ * @private
+ * @param {Buffer} key - HMAC key
+ * @param {Buffer} data - Message to sign
+ * @returns {Buffer} 16 bytes
+ */
+function hmac_md5 (key, data) {
+    var hmac = crypto.createHmac('md5', key);
+
+    hmac.update(data);
+
+    return hmac.digest();
+}
+
+/**
+ * Computes the NTLMv1-with-extended-security (NTLM2 session response) challenge responses. Used
+ * when the server negotiates extended security but sends no target info.
+ *
+ * @private
+ * @param {Buffer} responseKeyNT - NT hash
+ * @param {Buffer} serverChallenge - 8 bytes
+ * @param {Buffer} clientChallenge - 8 bytes
+ * @returns {Object} `lmChallengeResponse` and `ntChallengeResponse` buffers
+ */
+function ntlm2sr_calc_resp (responseKeyNT, serverChallenge, clientChallenge) {
+    // padding with zeros to make the hash 16 bytes longer
+    var lmChallengeResponse = Buffer.alloc(clientChallenge.length + 16),
+        md5 = crypto.createHash('md5'),
+        ntChallengeResponse,
+        sess;
+
+    clientChallenge.copy(lmChallengeResponse, 0, 0, clientChallenge.length);
+
+    md5.update(Buffer.concat([serverChallenge, clientChallenge]));
+    sess = md5.digest();
+    ntChallengeResponse = calc_resp(responseKeyNT, sess.subarray(0, 8));
+
+    return {
+        lmChallengeResponse,
+        ntChallengeResponse
+    };
+}
+
+/**
+ * @private
+ * @param {Buffer} pwhash - NT hash
+ * @param {String} user - Username
+ * @param {String} domain - Domain name
+ * @returns {Buffer} 16 bytes
+ */
+function NTOWFv2 (pwhash, user, domain) {
+    return hmac_md5(pwhash, Buffer.from(user.toUpperCase() + domain, 'utf16le'));
+}
+
+/**
+ * Encodes a Unix timestamp as a little-endian FILETIME: 100-nanosecond intervals since 1601-01-01.
+ *
+ * @note Upstream uses `BigInt` plus `Buffer#writeBigUInt64LE`. Neither is available here: `BigInt`
+ * is outside this repo's configured lint environment, and browserify resolves `buffer` to 5.2.1,
+ * which has no `writeBigUInt64LE` — so the browser bundle's type 3 path throws today. Splitting the
+ * multiplication across two 32-bit words keeps every intermediate under 2^53 and is byte-identical
+ * to the BigInt arithmetic.
+ *
+ * @private
+ * @param {Number} now - Milliseconds since the Unix epoch
+ * @returns {Buffer} 8 bytes, little-endian
+ */
+function writeFileTime (now) {
+    // 11644473600000 = diff between 1970 and 1601
+    var intervals = now + 11644473600000,
+        lowProduct = (intervals % 4294967296) * 10000,
+        buf = Buffer.alloc(8);
+
+    buf.writeUInt32LE(lowProduct % 4294967296, 0);
+    buf.writeUInt32LE((Math.floor(intervals / 4294967296) * 10000 +
+        Math.floor(lowProduct / 4294967296)) % 4294967296, 4);
+
+    return buf;
+}
+
+/**
+ * Computes the NTLMv2 challenge responses.
+ *
+ * @private
+ * @param {Buffer} pwhash - NT hash
+ * @param {String} username - Username
+ * @param {String} domain - Domain name
+ * @param {Buffer} targetInfo - Target info blob from the type 2 message
+ * @param {Buffer} serverChallenge - 8 bytes
+ * @param {Buffer} clientChallenge - 8 bytes
+ * @returns {Object} `lmChallengeResponse` and `ntChallengeResponse` buffers
+ */
+function calc_ntlmv2_resp (pwhash, username, domain, targetInfo, serverChallenge, clientChallenge) {
+    var responseKeyNTLM = NTOWFv2(pwhash, username, domain),
+        zero32Bit = Buffer.alloc(4, 0),
+
+        lmV2ChallengeResponse = Buffer.concat([
+            hmac_md5(responseKeyNTLM, Buffer.concat([serverChallenge, clientChallenge])),
+            clientChallenge
+        ]),
+
+        temp = Buffer.concat([
+            // Version
+            Buffer.from([0x01, 0x01, 0x00, 0x00]),
+            zero32Bit,
+            writeFileTime(Date.now()),
+            clientChallenge,
+            zero32Bit,
+            targetInfo,
+            zero32Bit
+        ]),
+
+        proofString = hmac_md5(responseKeyNTLM, Buffer.concat([serverChallenge, temp]));
+
+    return {
+        lmChallengeResponse: lmV2ChallengeResponse,
+        ntChallengeResponse: Buffer.concat([proofString, temp])
+    };
+}
+
+/**
+ * Creates an NTLM negotiate (type 1) message.
+ *
+ * @param {Object} options -
+ * @param {String} [options.domain] - Domain name
+ * @param {String} [options.workstation] - Workstation name
+ * @returns {String} The value for an `Authorization` header
+ */
+function createType1Message (options) {
+    var BODY_LENGTH = 40,
+        domain,
+        workstation,
+        type1flags,
+        pos = 0,
+        buf;
+
+    if (!options.domain) { options.domain = ''; }
+    if (!options.workstation) { options.workstation = ''; }
+
+    // `escape` guarantees String#length equals the ascii byte length below, which is what keeps the
+    // buffer size and the offsets written into it consistent for non-ascii input
+    domain = escape(options.domain.toUpperCase());
+    workstation = escape(options.workstation.toUpperCase());
+
+    type1flags = typeflags.NTLM_TYPE1_FLAGS;
+
+    if (!domain || domain === '') {
+        type1flags -= flags.NTLM_NegotiateOemDomainSupplied;
+    }
+
+    buf = Buffer.alloc(BODY_LENGTH + domain.length + workstation.length);
+
+    buf.write(PROTOCOL, pos, PROTOCOL.length); pos += PROTOCOL.length; // protocol
+    buf.writeUInt32LE(1, pos); pos += 4; // type 1
+    buf.writeUInt32LE(type1flags, pos); pos += 4; // TYPE1 flag
+
+    buf.writeUInt16LE(domain.length, pos); pos += 2; // domain length
+    buf.writeUInt16LE(domain.length, pos); pos += 2; // domain max length
+    buf.writeUInt32LE(BODY_LENGTH + workstation.length, pos); pos += 4; // domain buffer offset
+
+    buf.writeUInt16LE(workstation.length, pos); pos += 2; // workstation length
+    buf.writeUInt16LE(workstation.length, pos); pos += 2; // workstation max length
+    buf.writeUInt32LE(BODY_LENGTH, pos); pos += 4; // workstation buffer offset
+
+    buf.writeUInt8(5, pos); pos += 1; // ProductMajorVersion
+    buf.writeUInt8(1, pos); pos += 1; // ProductMinorVersion
+    buf.writeUInt16LE(2600, pos); pos += 2; // ProductBuild
+
+    buf.writeUInt8(0, pos); pos += 1; // VersionReserved1
+    buf.writeUInt8(0, pos); pos += 1; // VersionReserved2
+    buf.writeUInt8(0, pos); pos += 1; // VersionReserved3
+    buf.writeUInt8(15, pos); pos += 1; // NTLMRevisionCurrent
+
+    // @note the length checks fix upstream issues #46 and possibly #57. The `pos` advance must stay
+    // outside the guard — it is a no-op when the length is zero, and moving it inside would leave
+    // the domain string overwriting the workstation string.
+    if (workstation.length !== 0) {
+        buf.write(workstation, pos, workstation.length, 'ascii'); // workstation string
+    }
+    pos += workstation.length;
+
+    if (domain.length !== 0) {
+        buf.write(domain, pos, domain.length, 'ascii'); // domain string
+    }
+    pos += domain.length;
+
+    return 'NTLM ' + buf.toString('base64');
+}
+
+/**
+ * Parses an NTLM challenge (type 2) message.
+ *
+ * @param {String} rawmsg - The raw `WWW-Authenticate` header value
+ * @param {Function} callback - Invoked with an `Error` when the message cannot be parsed
+ * @returns {Object|null} The parsed message, or `null` on failure
+ */
+function parseType2Message (rawmsg, callback) {
+    var match = rawmsg.match(/NTLM (.+)/),
+        msg = {},
+        buf;
+
+    if (!match) {
+        callback(new Error('Couldn\'t find NTLM in the message type2 coming from the server'));
+
+        return null;
+    }
+
+    buf = Buffer.from(match[1], 'base64');
+
+    msg.signature = buf.subarray(0, 8);
+    msg.type = buf.readInt16LE(8);
+
+    if (msg.type !== 2) {
+        callback(new Error('Server didn\'t return a type 2 message'));
+
+        return null;
+    }
+
+    msg.targetNameLen = buf.readInt16LE(12);
+    msg.targetNameMaxLen = buf.readInt16LE(14);
+    msg.targetNameOffset = buf.readInt32LE(16);
+    msg.targetName = buf.subarray(msg.targetNameOffset, msg.targetNameOffset + msg.targetNameMaxLen);
+
+    // @note read as signed, matching upstream. The flag masks below work regardless, and callers
+    // (including the mock server fixtures) observe this value.
+    msg.negotiateFlags = buf.readInt32LE(20);
+    msg.serverChallenge = buf.subarray(24, 32);
+    msg.reserved = buf.subarray(32, 40);
+
+    if (msg.negotiateFlags & flags.NTLM_NegotiateTargetInfo) {
+        msg.targetInfoLen = buf.readInt16LE(40);
+        msg.targetInfoMaxLen = buf.readInt16LE(42);
+        msg.targetInfoOffset = buf.readInt32LE(44);
+        msg.targetInfo = buf.subarray(msg.targetInfoOffset, msg.targetInfoOffset + msg.targetInfoLen);
+    }
+
+    return msg;
+}
+
+/**
+ * Creates an NTLM authenticate (type 3) message in response to a challenge.
+ *
+ * @param {Object} msg2 - A message parsed by {@link parseType2Message}
+ * @param {Object} options -
+ * @param {String} [options.domain] - Domain name
+ * @param {String} [options.workstation] - Workstation name
+ * @param {String} [options.username] - Username
+ * @param {String} [options.password] - Password
+ * @returns {String} The value for an `Authorization` header
+ */
+function createType3Message (msg2, options) {
+    var BODY_LENGTH = 72,
+        encryptedRandomSessionKey = '',
+        nonce = msg2.serverChallenge,
+        negotiateFlags = msg2.negotiateFlags,
+        isUnicode = negotiateFlags & flags.NTLM_NegotiateUnicode,
+        isNegotiateExtendedSecurity = negotiateFlags & flags.NTLM_NegotiateExtendedSecurity,
+        username,
+        password,
+        domainName,
+        workstation,
+        workstationBytes,
+        domainNameBytes,
+        usernameBytes,
+        encryptedRandomSessionKeyBytes,
+        lmChallengeResponse,
+        ntChallengeResponse,
+        pwhash,
+        clientChallengeBytes,
+        challenges,
+        flagsToWrite,
+        pos = 0,
+        buf;
+
+    if (!options.domain) { options.domain = ''; }
+    if (!options.workstation) { options.workstation = ''; }
+    if (!options.username) { options.username = ''; }
+    if (!options.password) { options.password = ''; }
+
+    username = options.username;
+    password = options.password;
+
+    // see the note in createType1Message
+    domainName = escape(options.domain.toUpperCase());
+    workstation = escape(options.workstation.toUpperCase());
+
+    if (isUnicode) {
+        workstationBytes = Buffer.from(workstation, 'utf16le');
+        domainNameBytes = Buffer.from(domainName, 'utf16le');
+        usernameBytes = Buffer.from(username, 'utf16le');
+        encryptedRandomSessionKeyBytes = Buffer.from(encryptedRandomSessionKey, 'utf16le');
+    }
+    else {
+        workstationBytes = Buffer.from(workstation, 'ascii');
+        domainNameBytes = Buffer.from(domainName, 'ascii');
+        usernameBytes = Buffer.from(username, 'ascii');
+        encryptedRandomSessionKeyBytes = Buffer.from(encryptedRandomSessionKey, 'ascii');
+    }
+
+    lmChallengeResponse = calc_resp(create_LM_hashed_password_v1(password), nonce);
+    ntChallengeResponse = calc_resp(create_NT_hashed_password_v1(password), nonce);
+
+    if (isNegotiateExtendedSecurity) {
+        /*
+         * NTLMv2 extended security is enabled. While this technically can mean NTLMv2 extended security with NTLMv1
+         * protocol, servers that support extended security likely also support NTLMv2, so use NTLMv2. This is also how
+         * curl implements NTLMv2 "detection". By using NTLMv2, this supports communication with servers that forbid
+         * the use of NTLMv1 (e.g. via windows policies)
+         *
+         * However, the target info is needed to construct the NTLMv2 response so if it can't be negotiated,
+         * fall back to NTLMv1 with NTLMv2 extended security.
+         */
+        pwhash = create_NT_hashed_password_v1(password);
+        clientChallengeBytes = crypto.randomBytes(8);
+
+        challenges = msg2.targetInfo ?
+            calc_ntlmv2_resp(pwhash, username, domainName, msg2.targetInfo, nonce, clientChallengeBytes) :
+            ntlm2sr_calc_resp(pwhash, nonce, clientChallengeBytes);
+
+        lmChallengeResponse = challenges.lmChallengeResponse;
+        ntChallengeResponse = challenges.ntChallengeResponse;
+    }
+
+    buf = Buffer.alloc(BODY_LENGTH + domainNameBytes.length + usernameBytes.length + workstationBytes.length +
+        lmChallengeResponse.length + ntChallengeResponse.length + encryptedRandomSessionKeyBytes.length);
+
+    buf.write(PROTOCOL, pos, PROTOCOL.length); pos += PROTOCOL.length;
+    buf.writeUInt32LE(3, pos); pos += 4; // type 3
+
+    buf.writeUInt16LE(lmChallengeResponse.length, pos); pos += 2; // LmChallengeResponseLen
+    buf.writeUInt16LE(lmChallengeResponse.length, pos); pos += 2; // LmChallengeResponseMaxLen
+
+    // LmChallengeResponseOffset
+    buf.writeUInt32LE(BODY_LENGTH + domainNameBytes.length + usernameBytes.length + workstationBytes.length, pos);
+    pos += 4;
+
+    buf.writeUInt16LE(ntChallengeResponse.length, pos); pos += 2; // NtChallengeResponseLen
+    buf.writeUInt16LE(ntChallengeResponse.length, pos); pos += 2; // NtChallengeResponseMaxLen
+
+    // NtChallengeResponseOffset
+    buf.writeUInt32LE(BODY_LENGTH + domainNameBytes.length + usernameBytes.length + workstationBytes.length +
+        lmChallengeResponse.length, pos);
+    pos += 4;
+
+    buf.writeUInt16LE(domainNameBytes.length, pos); pos += 2; // DomainNameLen
+    buf.writeUInt16LE(domainNameBytes.length, pos); pos += 2; // DomainNameMaxLen
+    buf.writeUInt32LE(BODY_LENGTH, pos); pos += 4; // DomainNameOffset
+
+    buf.writeUInt16LE(usernameBytes.length, pos); pos += 2; // UserNameLen
+    buf.writeUInt16LE(usernameBytes.length, pos); pos += 2; // UserNameMaxLen
+    buf.writeUInt32LE(BODY_LENGTH + domainNameBytes.length, pos); pos += 4; // UserNameOffset
+
+    buf.writeUInt16LE(workstationBytes.length, pos); pos += 2; // WorkstationLen
+    buf.writeUInt16LE(workstationBytes.length, pos); pos += 2; // WorkstationMaxLen
+
+    // WorkstationOffset
+    buf.writeUInt32LE(BODY_LENGTH + domainNameBytes.length + usernameBytes.length, pos);
+    pos += 4;
+
+    buf.writeUInt16LE(encryptedRandomSessionKeyBytes.length, pos); pos += 2; // EncryptedRandomSessionKeyLen
+    buf.writeUInt16LE(encryptedRandomSessionKeyBytes.length, pos); pos += 2; // EncryptedRandomSessionKeyMaxLen
+
+    // EncryptedRandomSessionKeyOffset
+    buf.writeUInt32LE(BODY_LENGTH + domainNameBytes.length + usernameBytes.length + workstationBytes.length +
+        lmChallengeResponse.length + ntChallengeResponse.length, pos);
+    pos += 4;
+
+    // see the note on `typeflags` for why this subtracts rather than masks
+    flagsToWrite = isUnicode ?
+        typeflags.NTLM_TYPE2_FLAGS :
+        typeflags.NTLM_TYPE2_FLAGS - flags.NTLM_NegotiateUnicode;
+
+    buf.writeUInt32LE(flagsToWrite, pos); pos += 4; // NegotiateFlags
+
+    buf.writeUInt8(5, pos); pos++; // ProductMajorVersion
+    buf.writeUInt8(1, pos); pos++; // ProductMinorVersion
+    buf.writeUInt16LE(2600, pos); pos += 2; // ProductBuild
+    buf.writeUInt8(0, pos); pos++; // VersionReserved1
+    buf.writeUInt8(0, pos); pos++; // VersionReserved2
+    buf.writeUInt8(0, pos); pos++; // VersionReserved3
+    buf.writeUInt8(15, pos); pos++; // NTLMRevisionCurrent
+
+    domainNameBytes.copy(buf, pos); pos += domainNameBytes.length;
+    usernameBytes.copy(buf, pos); pos += usernameBytes.length;
+    workstationBytes.copy(buf, pos); pos += workstationBytes.length;
+    lmChallengeResponse.copy(buf, pos); pos += lmChallengeResponse.length;
+    ntChallengeResponse.copy(buf, pos); pos += ntChallengeResponse.length;
+    encryptedRandomSessionKeyBytes.copy(buf, pos); pos += encryptedRandomSessionKeyBytes.length;
+
+    return 'NTLM ' + buf.toString('base64');
+}
+
+module.exports = {
+    createType1Message,
+    parseType2Message,
+    createType3Message
+};

--- a/lib/authorizer/ntlm.js
+++ b/lib/authorizer/ntlm.js
@@ -8,7 +8,7 @@
  * does _not_ implement those cases.
  */
 
-var ntlmUtil = require('httpntlm').ntlm,
+var ntlmUtil = require('./ntlm-message'),
     _ = require('lodash'),
 
     EMPTY = '',
@@ -243,12 +243,20 @@ module.exports = {
                 return resetStateAndStop(new Error('ntlm: server did not correctly process authentication request'));
             }
 
-            authenticateMessage = ntlmUtil.createType3Message(challengeMessage, {
-                domain,
-                workstation,
-                username,
-                password
-            });
+            // creating the type 3 message needs a cryptographic random source, which is unavailable
+            // in insecure browser contexts. `post` has no handler for synchronous throws, so route
+            // the failure through the auth error channel instead of letting it escape.
+            try {
+                authenticateMessage = ntlmUtil.createType3Message(challengeMessage, {
+                    domain,
+                    workstation,
+                    username,
+                    password
+                });
+            }
+            catch (error) {
+                return resetStateAndStop(error);
+            }
 
             // Now create the type 3 message, and add it to the request
             auth.set(NTLM_HEADER, authenticateMessage);

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,10 +12,11 @@
         "@postman/tough-cookie": "4.1.3-postman.1",
         "async": "3.2.6",
         "aws4": "1.13.2",
+        "des.js": "1.0.1",
         "handlebars": "4.7.9",
-        "httpntlm": "1.8.13",
         "ipaddr.js": "2.4.0",
         "jose": "5.10.0",
+        "js-md4": "0.3.2",
         "js-sha512": "0.9.0",
         "lodash": "4.18.1",
         "mime-types": "2.1.35",
@@ -47,6 +48,7 @@
         "eslint-plugin-security": "^2.1.1",
         "express": "^4.17.2",
         "graphql": "^16.10.0",
+        "httpntlm": "^1.8.13",
         "js-yaml": "^4.1.1",
         "karma": "^6.4.4",
         "karma-browserify": "^8.1.0",
@@ -5043,6 +5045,7 @@
       "version": "1.8.13",
       "resolved": "https://registry.npmjs.org/httpntlm/-/httpntlm-1.8.13.tgz",
       "integrity": "sha512-2F2FDPiWT4rewPzNMg3uPhNkP3NExENlUGADRUDPQvuftuUTGW98nLZtGemCIW3G40VhWZYgkIDcQFAwZ3mf2Q==",
+      "dev": true,
       "funding": [
         {
           "type": "paypal",
@@ -5067,6 +5070,7 @@
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/httpreq/-/httpreq-0.5.2.tgz",
       "integrity": "sha512-2Jm+x9WkExDOeFRrdBCBSpLPT5SokTcRHkunV3pjKmX/cx6av8zQ0WtHUMDrYb6O4hBFzNU6sxJEypvRUVYKnw==",
+      "dev": true,
       "engines": {
         "node": ">= 6.15.1"
       }
@@ -9767,9 +9771,11 @@
       }
     },
     "node_modules/underscore": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.12.1.tgz",
-      "integrity": "sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw=="
+      "version": "1.13.8",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
+      "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/universalify": {
       "version": "0.1.2",
@@ -14211,17 +14217,19 @@
       "version": "1.8.13",
       "resolved": "https://registry.npmjs.org/httpntlm/-/httpntlm-1.8.13.tgz",
       "integrity": "sha512-2F2FDPiWT4rewPzNMg3uPhNkP3NExENlUGADRUDPQvuftuUTGW98nLZtGemCIW3G40VhWZYgkIDcQFAwZ3mf2Q==",
+      "dev": true,
       "requires": {
         "des.js": "^1.0.1",
         "httpreq": ">=0.4.22",
         "js-md4": "^0.3.2",
-        "underscore": "~1.12.1"
+        "underscore": "1.13.8"
       }
     },
     "httpreq": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/httpreq/-/httpreq-0.5.2.tgz",
-      "integrity": "sha512-2Jm+x9WkExDOeFRrdBCBSpLPT5SokTcRHkunV3pjKmX/cx6av8zQ0WtHUMDrYb6O4hBFzNU6sxJEypvRUVYKnw=="
+      "integrity": "sha512-2Jm+x9WkExDOeFRrdBCBSpLPT5SokTcRHkunV3pjKmX/cx6av8zQ0WtHUMDrYb6O4hBFzNU6sxJEypvRUVYKnw==",
+      "dev": true
     },
     "https-browserify": {
       "version": "1.0.0",
@@ -17807,9 +17815,10 @@
       }
     },
     "underscore": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.12.1.tgz",
-      "integrity": "sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw=="
+      "version": "1.13.8",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
+      "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
+      "dev": true
     },
     "universalify": {
       "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -45,10 +45,11 @@
     "@postman/tough-cookie": "4.1.3-postman.1",
     "async": "3.2.6",
     "aws4": "1.13.2",
+    "des.js": "1.0.1",
     "handlebars": "4.7.9",
-    "httpntlm": "1.8.13",
     "ipaddr.js": "2.4.0",
     "jose": "5.10.0",
+    "js-md4": "0.3.2",
     "js-sha512": "0.9.0",
     "lodash": "4.18.1",
     "mime-types": "2.1.35",
@@ -80,6 +81,7 @@
     "eslint-plugin-security": "^2.1.1",
     "express": "^4.17.2",
     "graphql": "^16.10.0",
+    "httpntlm": "^1.8.13",
     "js-yaml": "^4.1.1",
     "karma": "^6.4.4",
     "karma-browserify": "^8.1.0",
@@ -100,6 +102,11 @@
     "tmp": "^0.2.3",
     "webpack": "^5.98.0",
     "yankee": "^1.0.8"
+  },
+  "overrides": {
+    "httpntlm": {
+      "underscore": "1.13.8"
+    }
   },
   "engines": {
     "node": ">=18"

--- a/test/unit/ntlm-message.test.js
+++ b/test/unit/ntlm-message.test.js
@@ -1,0 +1,286 @@
+var crypto = require('crypto'),
+    expect = require('chai').expect,
+    sinon = require('sinon'),
+
+    ntlm = require('../../lib/authorizer/ntlm-message'),
+
+    /**
+     * The type 2 challenge used by the mock NTLM server in test/fixtures/servers/_servers.js, which
+     * is also the one upstream's own unit tests use. Its negotiateFlags are
+     * Unicode | RequestTarget | NTLM | AlwaysSign | ExtendedSecurity | TargetInfo | Version | 128 | 56,
+     * and it carries a target info blob, so it drives the NTLMv2 path.
+     */
+    TYPE_2_MESSAGE = 'NTLM ' +
+        'TlRMTVNTUAACAAAAHgAeADgAAAAFgoqiBevywvJykjAAAAAAAAAAAJgAmABWAAAA' +
+        'CgC6RwAAAA9EAEUAUwBLAFQATwBQAC0ASgBTADQAVQBKAFQARAACAB4ARABFAFMA' +
+        'SwBUAE8AUAAtAEoAUwA0AFUASgBUAEQAAQAeAEQARQBTAEsAVABPAFAALQBKAFMA' +
+        'NABVAEoAVABEAAQAHgBEAEUAUwBLAFQATwBQAC0ASgBTADQAVQBKAFQARAADAB4A' +
+        'RABFAFMASwBUAE8AUAAtAEoAUwA0AFUASgBUAEQABwAIADmguzCHn9UBAAAAAA==',
+
+    // a fixed client challenge and clock, so the NTLMv2 responses are deterministic
+    FIXED_CLIENT_CHALLENGE = Buffer.alloc(8, 0xcf),
+    FIXED_NOW = 1679346960095,
+
+    OPTIONS = {
+        url: 'https://someurl.com',
+        username: 'm$',
+        password: 'stinks',
+        workstation: 'choose.something',
+        domain: ''
+    },
+
+    /**
+     * Golden vectors. Every one of these was produced by `httpntlm@1.8.13`, the package this module
+     * replaces — the first four and the next three are lifted verbatim from its own test suite
+     * (node_modules/httpntlm/test/unit.js), and the last two were generated from it to cover paths
+     * it does not publish a vector for. Upstream makes its output deterministic by stubbing
+     * `Math.random` to 0.8092 and `Date.now` to 1679346960095; `Math.floor(0.8092 * 256)` is 0xcf,
+     * which is why FIXED_CLIENT_CHALLENGE is a run of 0xcf bytes.
+     *
+     * These are the primary correctness gate for the port. The NTLM integration suite only compares
+     * message *prefixes* (test/fixtures/servers/_servers.js:613 and :627), so it never checks any of
+     * the cryptographic bytes.
+     */
+    VECTORS = {
+        type1: 'NTLM TlRMTVNTUAABAAAAB7IIogoACgA4AAAAEAAQACgAAAAFASgKAAAAD0NIT09TRS5TT01FVEhJTkdTT01FRE9NQUlO',
+        type1NoDomain: 'NTLM TlRMTVNTUAABAAAAB6IIogAAAAA4AAAAEAAQACgAAAAFASgKAAAAD0NIT09TRS5TT01FVEhJTkc=',
+        type1NoWorkstation: 'NTLM TlRMTVNTUAABAAAAB6IIogAAAAAoAAAAAAAAACgAAAAFASgKAAAADw==',
+
+        type3: 'NTLM TlRMTVNTUAADAAAAGAAYAGwAAADIAMgAhAAAAAAAAABIAAAABAAEAEgAAAAgACAATAAAAAAAAABMAQAABYKIogUBKAoAAA' +
+            'APbQAkAEMASABPAE8AUwBFAC4AUwBPAE0ARQBUAEgASQBOAEcA34OQvQRxhMrl/ZdqHfdXsc/Pz8/Pz8/PBRktHt+/zDBHvSp4tqm' +
+            'fpwEBAAAAAAAA8OZaK3Fb2QHPz8/Pz8/PzwAAAAACAB4ARABFAFMASwBUAE8AUAAtAEoAUwA0AFUASgBUAEQAAQAeAEQARQBTAEsA' +
+            'VABPAFAALQBKAFMANABVAEoAVABEAAQAHgBEAEUAUwBLAFQATwBQAC0ASgBTADQAVQBKAFQARAADAB4ARABFAFMASwBUAE8AUAAtA' +
+            'EoAUwA0AFUASgBUAEQABwAIADmguzCHn9UBAAAAAAAAAAA=',
+
+        // negotiateFlags of zero: no Unicode (so ascii encodings) and no extended security (so NTLMv1)
+        type3NtlmV1: 'NTLM TlRMTVNTUAADAAAAGAAYAFoAAAAYABgAcgAAAAAAAABIAAAAAgACAEgAAAAQABAASgAAAAAAAACKAAAABIKIogUB' +
+            'KAoAAAAPbSRDSE9PU0UuU09NRVRISU5HEBenAMbG/BJagLAbC+ssxjoV6DmoMZnLPnIxjabRKh2kis6avHJoHUvdnSQrhLYz',
+
+        type3EmptyOptions: 'NTLM TlRMTVNTUAADAAAAGAAYAEgAAADIAMgAYAAAAAAAAABIAAAAAAAAAEgAAAAAAAAASAAAAAAAAAAoAQAABYKI' +
+            'ogUBKAoAAAAPwARIPPqPB18BtDy2SiF1us/Pz8/Pz8/P52yYCH+rc7F7jUeUnayiPQEBAAAAAAAA8OZaK3Fb2QHPz8/Pz8/PzwAAA' +
+            'AACAB4ARABFAFMASwBUAE8AUAAtAEoAUwA0AFUASgBUAEQAAQAeAEQARQBTAEsAVABPAFAALQBKAFMANABVAEoAVABEAAQAHgBEAE' +
+            'UAUwBLAFQATwBQAC0ASgBTADQAVQBKAFQARAADAB4ARABFAFMASwBUAE8AUAAtAEoAUwA0AFUASgBUAEQABwAIADmguzCHn9UBAAA' +
+            'AAAAAAAA=',
+
+        // extended security negotiated, but no target info, which is the only route to NTLM2 session security
+        type3Ntlm2Session: 'NTLM TlRMTVNTUAADAAAAGAAYAGwAAAAYABgAhAAAAAAAAABIAAAABAAEAEgAAAAgACAATAAAAAAAAACcAAAABYKI' +
+            'ogUBKAoAAAAPbQAkAEMASABPAE8AUwBFAC4AUwBPAE0ARQBUAEgASQBOAEcAz8/Pz8/Pz88AAAAAAAAAAAAAAAAAAAAAK49WpD9h3' +
+            'WqhpVe+6oFLLDZWeV1/pTpR',
+
+        // NTLMv1 with a password longer than the 14 bytes the LM hash allows for
+        type3LongPassword: 'NTLM TlRMTVNTUAADAAAAGAAYAFoAAAAYABgAcgAAAAAAAABIAAAAAgACAEgAAAAQABAASgAAAAAAAACKAAAABIKI' +
+            'ogUBKAoAAAAPbSRDSE9PU0UuU09NRVRISU5HsHMvTjluyuPuICE/vHFXV5SeAUazQl7u9srSL4gQonp04PReoJjVT1nPMed1k5XN'
+    };
+
+/**
+ * Builds a type 2 message object, optionally overriding the negotiated flags or dropping the target
+ * info blob, to reach the code paths the mock server's fixed challenge never exercises.
+ *
+ * @param {Object} [overrides] - Properties to merge over the parsed message
+ * @param {Boolean} [dropTargetInfo] - Remove `targetInfo` from the result
+ * @returns {Object}
+ */
+function challenge (overrides, dropTargetInfo) {
+    var msg = { ...ntlm.parseType2Message(TYPE_2_MESSAGE, function () { /* noop */ }), ...overrides };
+
+    if (dropTargetInfo) { delete msg.targetInfo; }
+
+    return msg;
+}
+
+describe('ntlm message', function () {
+    describe('createType1Message', function () {
+        it('should build a negotiate message with a domain and a workstation', function () {
+            expect(ntlm.createType1Message({ ...OPTIONS, domain: 'someDomain' }))
+                .to.equal(VECTORS.type1);
+        });
+
+        it('should clear the OemDomainSupplied flag when there is no domain', function () {
+            expect(ntlm.createType1Message({ ...OPTIONS })).to.equal(VECTORS.type1NoDomain);
+        });
+
+        it('should build a negotiate message with no workstation', function () {
+            expect(ntlm.createType1Message({ ...OPTIONS, workstation: '' }))
+                .to.equal(VECTORS.type1NoWorkstation);
+        });
+
+        it('should default a missing domain and workstation to empty strings', function () {
+            expect(ntlm.createType1Message({})).to.equal(VECTORS.type1NoWorkstation);
+        });
+    });
+
+    describe('parseType2Message', function () {
+        it('should parse a challenge message', function () {
+            var parsed = ntlm.parseType2Message(TYPE_2_MESSAGE, function () { /* noop */ });
+
+            expect(parsed.type).to.equal(2);
+            expect(parsed.signature.toString('hex')).to.equal('4e544c4d53535000');
+            expect(parsed.negotiateFlags).to.equal(-1567981051);
+            expect(parsed.serverChallenge.toString('hex')).to.equal('05ebf2c2f2729230');
+            expect(parsed.reserved.toString('hex')).to.equal('0000000000000000');
+            expect(parsed.targetNameLen).to.equal(30);
+            expect(parsed.targetNameMaxLen).to.equal(30);
+            expect(parsed.targetNameOffset).to.equal(56);
+            expect(parsed.targetName.toString('utf16le')).to.equal('DESKTOP-JS4UJTD');
+            expect(parsed.targetInfoLen).to.equal(152);
+            expect(parsed.targetInfoMaxLen).to.equal(152);
+            expect(parsed.targetInfoOffset).to.equal(86);
+            expect(parsed.targetInfo).to.have.lengthOf(152);
+        });
+
+        it('should return null and report an error when the header has no NTLM payload', function () {
+            var err;
+
+            expect(ntlm.parseType2Message('Negotiate', function (error) { err = error; })).to.be.null;
+            expect(err).to.be.an.instanceOf(Error);
+            expect(err.message).to.equal('Couldn\'t find NTLM in the message type2 coming from the server');
+        });
+
+        it('should return null and report an error when the message is not type 2', function () {
+            var err,
+                type1 = ntlm.createType1Message({ domain: 'someDomain', workstation: 'choose.something' });
+
+            expect(ntlm.parseType2Message(type1, function (error) { err = error; })).to.be.null;
+            expect(err).to.be.an.instanceOf(Error);
+            expect(err.message).to.equal('Server didn\'t return a type 2 message');
+        });
+
+        it('should omit target info when the NegotiateTargetInfo flag is not set', function () {
+            // 0x00800000 is NTLM_NegotiateTargetInfo; clearing it should skip the target info fields
+            var raw = Buffer.from(TYPE_2_MESSAGE.slice('NTLM '.length), 'base64'),
+                parsed;
+
+            raw.writeInt32LE(raw.readInt32LE(20) & ~0x00800000, 20);
+            parsed = ntlm.parseType2Message('NTLM ' + raw.toString('base64'), function () { /* noop */ });
+
+            expect(parsed.type).to.equal(2);
+            expect(parsed.targetInfo).to.be.undefined;
+            expect(parsed.targetInfoLen).to.be.undefined;
+        });
+    });
+
+    describe('createType3Message', function () {
+        beforeEach(function () {
+            sinon.stub(crypto, 'randomBytes').returns(Buffer.from(FIXED_CLIENT_CHALLENGE));
+            sinon.stub(Date, 'now').returns(FIXED_NOW);
+        });
+
+        afterEach(function () {
+            sinon.restore();
+        });
+
+        it('should build an NTLMv2 authenticate message', function () {
+            expect(ntlm.createType3Message(challenge(), { ...OPTIONS })).to.equal(VECTORS.type3);
+        });
+
+        it('should fall back to NTLMv1 and ascii encoding when nothing is negotiated', function () {
+            expect(ntlm.createType3Message(challenge({ negotiateFlags: 0 }), { ...OPTIONS }))
+                .to.equal(VECTORS.type3NtlmV1);
+        });
+
+        it('should default missing credentials to empty strings', function () {
+            expect(ntlm.createType3Message(challenge(), {})).to.equal(VECTORS.type3EmptyOptions);
+        });
+
+        it('should use NTLM2 session security when extended security is negotiated without target info',
+            function () {
+                expect(ntlm.createType3Message(challenge(undefined, true), { ...OPTIONS }))
+                    .to.equal(VECTORS.type3Ntlm2Session);
+            });
+
+        it('should truncate a password longer than 14 bytes for the LM hash', function () {
+            expect(ntlm.createType3Message(challenge({ negotiateFlags: 0 }),
+                { ...OPTIONS, password: 'Azx123456Azx123456' }))
+                .to.equal(VECTORS.type3LongPassword);
+        });
+
+        it('should draw the client challenge from a cryptographic source', function () {
+            ntlm.createType3Message(challenge(), { ...OPTIONS });
+
+            expect(crypto.randomBytes.calledOnceWithExactly(8)).to.be.true;
+        });
+    });
+});
+
+/**
+ * `httpntlm` is retained as a devDependency purely so this suite can diff against it. Skipped in the
+ * browser: the bundle would pull `underscore` (the very package this change removes) back into the
+ * test bundle, and upstream's `Buffer#writeBigUInt64LE` does not exist in browserify's buffer shim.
+ */
+(typeof window === 'undefined' ? describe : describe.skip)('ntlm message vs httpntlm', function () {
+    // eslint-disable-next-line n/no-unpublished-require
+    var upstream = require('httpntlm').ntlm,
+        realMathRandom = Math.random,
+
+        FLAG_SETS = [
+            { name: 'unicode + extended security + target info', negotiateFlags: -1567981051 },
+            { name: 'nothing negotiated', negotiateFlags: 0 },
+            { name: 'unicode only', negotiateFlags: 0x00000001 },
+            { name: 'extended security only', negotiateFlags: 0x00080000 }
+        ],
+
+        OPTION_SETS = [
+            OPTIONS,
+            { username: 'someUsername', password: 'Azx123456', workstation: 'WS', domain: 'someDomain' },
+            { username: 'u', password: 'Azx123456Azx123456', workstation: '', domain: 'D' },
+            { username: '', password: '', workstation: '', domain: '' },
+            {}
+        ];
+
+    beforeEach(function () {
+        sinon.stub(crypto, 'randomBytes').returns(Buffer.from(FIXED_CLIENT_CHALLENGE));
+        sinon.stub(Date, 'now').returns(FIXED_NOW);
+
+        // upstream derives its client challenge from the global Math.random
+        Math.random = function () { return 0.8092; };
+    });
+
+    afterEach(function () {
+        sinon.restore();
+        Math.random = realMathRandom;
+    });
+
+    it('should parse challenge messages identically', function () {
+        expect(ntlm.parseType2Message(TYPE_2_MESSAGE, function () { /* noop */ }))
+            .to.eql(upstream.parseType2Message(TYPE_2_MESSAGE, function () { /* noop */ }));
+    });
+
+    OPTION_SETS.forEach(function (options, index) {
+        it(`should build identical negotiate messages for option set ${index}`, function () {
+            expect(ntlm.createType1Message({ ...options }))
+                .to.equal(upstream.createType1Message({ ...options }));
+        });
+    });
+
+    FLAG_SETS.forEach(function (flagSet) {
+        [false, true].forEach(function (dropTargetInfo) {
+            OPTION_SETS.forEach(function (options, index) {
+                var suffix = dropTargetInfo ? ', no target info' : '';
+
+                it(`should build identical authenticate messages for ${flagSet.name}${suffix}, ` +
+                    `option set ${index}`, function () {
+                    var msg2 = challenge({ negotiateFlags: flagSet.negotiateFlags }, dropTargetInfo);
+
+                    expect(ntlm.createType3Message({ ...msg2 }, { ...options }))
+                        .to.equal(upstream.createType3Message({ ...msg2 }, { ...options }));
+                });
+            });
+        });
+    });
+
+    it('should encode the FILETIME timestamp identically across a range of clock values', function () {
+        var msg2 = challenge(),
+            options = { ...OPTIONS },
+            timestamps = [0, 1, 1679346960095, 2147483647999, 4102444800000],
+            i;
+
+        // upstream uses BigInt arithmetic here; the vendored copy splits the multiply across two
+        // 32-bit words to stay usable under browserify's buffer shim
+        for (i = 0; i < timestamps.length; i++) {
+            Date.now.returns(timestamps[i]);
+
+            expect(ntlm.createType3Message({ ...msg2 }, { ...options }))
+                .to.equal(upstream.createType3Message({ ...msg2 }, { ...options }));
+        }
+    });
+});


### PR DESCRIPTION
`httpntlm` pins `underscore` to `~1.12.1`, so it can never resolve to `underscore@1.13.8`, the fix for [GHSA-qpx9-hpmf-5gmw](https://github.com/advisories/GHSA-qpx9-hpmf-5gmw). `1.8.13` is its latest release, so there is no upgrade path.

Only `httpntlm/ntlm.js` was ever used here, and that file doesn't depend on `underscore` at all — so it is now vendored into `lib/authorizer/ntlm-message.js`, dropping both `underscore` and `httpreq` from the production tree and from `dist/index.js`.

### Changes

- `lib/authorizer/ntlm-message.js` — the vendored message builder, restyled to house lint rules and trimmed to the three functions runtime uses.
- `httpntlm` moves to `devDependencies`; `des.js` and `js-md4` become direct dependencies at the versions already resolving transitively.
- `overrides` pins the dev tree's `underscore` to `1.13.8`.
- Two deliberate fixes while porting: the NTLMv2 client challenge now uses `crypto.randomBytes` instead of `Math.random`, and the FILETIME timestamp avoids `BigInt`/`Buffer#writeBigUInt64LE`, which browserify's buffer shim does not provide (the browser bundle's type 3 path threw before this).
- Legacy coverage floors in `.nycrc.js` lowered — that suite doesn't exercise the new file, so it only enlarges the denominator.

### Verification

Output is byte-identical to `httpntlm`. `test/unit/ntlm-message.test.js` asserts against golden vectors from upstream's own suite and diffs the vendored implementation against the `httpntlm` devDependency across 40 flag/option combinations, the parse path, and a range of clock values. The vendored file is at 100% coverage.

Lint clean; unit, integration, legacy-integration and browser suites all pass.