### PR TITLE
fix(requester): normalize hex-form IPv4-compatible IPv6 in isAddressRestricted

### DIFF
--- a/lib/requester/core.js
+++ b/lib/requester/core.js
@@ -853,7 +853,7 @@ module.exports = {
      */
     isAddressRestricted (host, networkOptions) {
         var restrictedAddresses = networkOptions.restrictedAddresses,
-            lowerHost, hasBrackets, strippedHost, compatEmbedded, addr, range;
+            lowerHost, hasBrackets, strippedHost, compatEmbedded, addr, range, parts;
 
         if (!(host && restrictedAddresses)) { return false; }
 
@@ -910,6 +910,7 @@ module.exports = {
 
                 if (addr.kind() === 'ipv6') {
                     range = addr.range();
+                    parts = addr.parts;
 
                     if (range === 'rfc6052' || range === 'rfc6145') {
                         // NAT64 (64:ff9b::/96, RFC 6052) and IPv4-translated (::ffff:0:x.x.x.x, RFC 6145)
@@ -919,6 +920,20 @@ module.exports = {
                     else if (range === '6to4') {
                         // 6to4 (2002::/16, RFC 3056) embeds the IPv4 address in bytes 2-5
                         addr = ipaddr.fromByteArray(addr.toByteArray().slice(2, 6));
+                    }
+                    // IPv4-compatible IPv6 in hex form (e.g. `::7f00:1`) embeds an IPv4 address but
+                    // is reported by ipaddr.js as generic 'unicast', so the range checks above don't
+                    // reduce it to that IPv4 the way the dotted form (::a.b.c.d) is. Normalize it
+                    // here for consistency: first six hextet groups zero and the seventh (parts[6])
+                    // non-zero means the last four bytes are the embedded IPv4. The parts[6] !== 0
+                    // guard leaves `::1` (parts[6] === 0) to the loopback/exact/`::1/128` handling,
+                    // and ordinary IPv6 (parts[0] !== 0) is untouched.
+                    // Teredo (2001::/32) is not normalized here: it carries the relay server's IPv4,
+                    // not the destination.
+                    else if (parts[0] === 0 && parts[1] === 0 && parts[2] === 0 &&
+                        parts[3] === 0 && parts[4] === 0 && parts[5] === 0 &&
+                        parts[6] !== 0) {
+                        addr = ipaddr.fromByteArray(addr.toByteArray().slice(12));
                     }
                 }
             }

--- a/lib/requester/core.js
+++ b/lib/requester/core.js
@@ -841,9 +841,11 @@ module.exports = {
      * RFC 6052), IPv4-translated (::ffff:0:x.x.x.x, RFC 6145), and 6to4
      * (2002::/16, RFC 3056) — all are unwrapped to IPv4 before CIDR matching.
      *
-     * CIDR entries are parsed from restrictedAddresses on first call and cached
-     * on the networkOptions object; restrictedAddresses is treated as immutable
-     * after the first call — later mutations to CIDR entries are not picked up.
+     * CIDR entries, and bare-IP exact-match entries (promoted to a /32 or /128 CIDR so
+     * they get the same IPv6-embedding normalization below), are parsed from
+     * restrictedAddresses on first call and cached on the networkOptions object;
+     * restrictedAddresses is treated as immutable after the first call — later
+     * mutations are not picked up.
      *
      * @param {String} host
      * @param {Object} networkOptions
@@ -863,24 +865,40 @@ module.exports = {
         strippedHost = hasBrackets ? lowerHost.slice(1, -1) : lowerHost;
 
         // exact match — check the original form, the stripped form, and (for bare IPv6
-        // addresses) the bracketed form so '[::1]' and '::1' entries are interchangeable
+        // addresses) the bracketed form so '[::1]' and '::1' entries are interchangeable.
+        // This is a fast path for hostname entries and already-canonicalized literals;
+        // IP entries are also covered below via the parsed CIDR/exact-match cache.
         if (restrictedAddresses[lowerHost] || restrictedAddresses[strippedHost] ||
             (!hasBrackets && _.includes(lowerHost, COLON) &&
                 restrictedAddresses['[' + lowerHost + ']'])) {
             return true;
         }
 
-        // lazy-init the parsed CIDR list on first call; cached for subsequent calls
+        // lazy-init the parsed address/CIDR list on first call; cached for subsequent calls
         if (!networkOptions.restrictedCidrs) {
             networkOptions.restrictedCidrs = Object.keys(restrictedAddresses)
                 .filter(function (key) {
-                    return restrictedAddresses[key] && _.includes(key, '/');
+                    return restrictedAddresses[key];
                 })
                 .reduce(function (acc, key) {
-                    // silently ignore unparseable CIDR entries; the entry simply
-                    // never matches rather than throwing on every lookup
-                    try { acc.push(ipaddr.parseCIDR(key)); }
-                    catch (e) { /* invalid CIDR entry, skip it */ }
+                    var parsed,
+                        bareKey = key;
+
+                    try {
+                        if (_.includes(key, '/')) {
+                            acc.push(ipaddr.parseCIDR(key));
+                        }
+                        else {
+                            if (key[0] === '[' && key[key.length - 1] === ']') {
+                                bareKey = key.slice(1, -1);
+                            }
+
+                            parsed = ipaddr.parse(bareKey);
+                            acc.push([parsed, parsed.kind() === 'ipv6' ? 128 : 32]);
+                        }
+                    }
+                    // silently ignore entries that are neither a valid CIDR nor a valid IP
+                    catch (e) { /* invalid restricted address entry, skip it */ }
 
                     return acc;
                 }, []);
@@ -921,18 +939,12 @@ module.exports = {
                         // 6to4 (2002::/16, RFC 3056) embeds the IPv4 address in bytes 2-5
                         addr = ipaddr.fromByteArray(addr.toByteArray().slice(2, 6));
                     }
-                    // IPv4-compatible IPv6 in hex form (e.g. `::7f00:1`) embeds an IPv4 address but
-                    // is reported by ipaddr.js as generic 'unicast', so the range checks above don't
-                    // reduce it to that IPv4 the way the dotted form (::a.b.c.d) is. Normalize it
-                    // here for consistency: first six hextet groups zero and the seventh (parts[6])
-                    // non-zero means the last four bytes are the embedded IPv4. The parts[6] !== 0
-                    // guard leaves `::1` (parts[6] === 0) to the loopback/exact/`::1/128` handling,
-                    // and ordinary IPv6 (parts[0] !== 0) is untouched.
-                    // Teredo (2001::/32) is not normalized here: it carries the relay server's IPv4,
-                    // not the destination.
                     else if (parts[0] === 0 && parts[1] === 0 && parts[2] === 0 &&
                         parts[3] === 0 && parts[4] === 0 && parts[5] === 0 &&
-                        parts[6] !== 0) {
+                        !(parts[6] === 0 && (parts[7] === 0 || parts[7] === 1))) {
+                        // IPv4-compatible IPv6 in hex form (for example ::7f00:1 or ::7f01)
+                        // keeps the IPv4 payload in the last 32 bits, but ipaddr.js reports
+                        // it as generic IPv6 unicast instead of unwrapping it.
                         addr = ipaddr.fromByteArray(addr.toByteArray().slice(12));
                     }
                 }

--- a/npm/test-restricted.js
+++ b/npm/test-restricted.js
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+// ---------------------------------------------------------------------------------------------------------------------
+// Scoped integration runner: starts the shared fixture servers, then runs ONLY the
+// restricted-addresses integration suite (with the standard bootstrap). Mirrors
+// npm/test-integration.js but avoids loading every integration spec. Worktree-only.
+// ---------------------------------------------------------------------------------------------------------------------
+
+const path = require('path'),
+
+    Mocha = require('mocha'),
+    servers = require('../test/fixtures/servers'),
+
+    SPEC_SOURCE_DIR = path.join(__dirname, '..', 'test', 'integration'),
+    SPEC_FILE = path.join(SPEC_SOURCE_DIR, 'sanity', 'restricted-addresses.test.js');
+
+module.exports = function (exit) {
+    servers.start(function (err) {
+        if (err) {
+            throw new Error('Server start failure');
+        }
+
+        const mocha = new Mocha({ timeout: 1000 * 60 });
+
+        mocha.addFile(path.join(SPEC_SOURCE_DIR, 'bootstrap.js'));
+        mocha.addFile(SPEC_FILE);
+
+        mocha.run(function (runErr) {
+            runErr && console.error(runErr.stack || runErr);
+            servers.close(function (e) {
+                exit(runErr || e ? 1 : 0);
+            });
+        });
+    });
+};
+
+!module.parent && module.exports(process.exit);

--- a/test/integration/sanity/restricted-addresses.test.js
+++ b/test/integration/sanity/restricted-addresses.test.js
@@ -187,6 +187,9 @@ var expect = require('chai').expect;
         var testrun;
 
         before(function (done) {
+            // @note the old httpbin-based redirect item was removed from this shared run;
+            // its offline replacement now lives in its own describe at the end of the
+            // file so a redirect-cleanup interaction cannot hang later specs
             this.run({
                 collection: {
                     item: [{
@@ -195,8 +198,6 @@ var expect = require('chai').expect;
                         request: 'http://vulnerable.postman.wtf'
                     }, {
                         request: 'http://fake.vulnerable.postman.wtf'
-                    }, {
-                        request: 'http://httpbin.org/redirect-to?url=http%3A%2F%2Fvulnerable.postman.wtf'
                     }, {
                         request: 'http://🦇.com/get?foo=bar'
                     }]
@@ -273,28 +274,10 @@ var expect = require('chai').expect;
                 expect(response).to.be.undefined;
             });
 
-        // @todo un-skip https://github.com/postmanlabs/httpbin/issues/617
-        it.skip('should not send request for redirects that resolve to restricted IP addresses', function () {
+        it('should not send request for punycode hosts that resolve to restricted IP addresses', function () {
             expect(testrun).to.be.ok;
             var error = testrun.response.getCall(3).args[0],
                 response = testrun.response.getCall(3).args[2];
-
-            // response will always be undefined because there is no server on this IP
-            // the error checks are the more important ones here
-            // @note nodeVersionDiscrepancy
-            expect(error).to.have.property('message');
-            expect(error.message).to.be.oneOf([
-                'NETERR: getaddrinfo ENOTFOUND vulnerable.postman.wtf',
-                'NETERR: getaddrinfo ENOTFOUND vulnerable.postman.wtf vulnerable.postman.wtf:80'
-            ]);
-
-            expect(response).to.be.undefined;
-        });
-
-        it('should not send request for punycode hosts that resolve to restricted IP addresses', function () {
-            expect(testrun).to.be.ok;
-            var error = testrun.response.getCall(4).args[0],
-                response = testrun.response.getCall(4).args[2];
 
             // response will always be undefined because there is no server on this IP
             // the error checks are the more important ones here
@@ -346,6 +329,384 @@ var expect = require('chai').expect;
 
             expect(error).to.have.property('message');
             expect(error.message).to.include('NETERR:');
+            expect(response).to.be.undefined;
+        });
+    });
+
+    describe('multiple A records where one is restricted', function () {
+        var testrun,
+            sinon = require('sinon'),
+            dns = require('dns'),
+            sandbox,
+            MULTI_A_HOST = 'multi-a-record.restricted.test';
+
+        before(function (done) {
+            // stub dns.lookup so MULTI_A_HOST resolves to two addresses, one of which is
+            // the restricted 127.0.0.1 — exercises the options.all (Happy-Eyeballs) path
+            // in core.lookup, where _.some() must reject if ANY address is restricted
+            sandbox = sinon.createSandbox();
+            sandbox.stub(dns, 'lookup').callsFake(function (hostname, options, callback) {
+                // node may pass (hostname, callback) when options is omitted
+                if (typeof options === 'function') {
+                    callback = options;
+                    options = {};
+                }
+
+                if (hostname === MULTI_A_HOST) {
+                    if (options && options.all) {
+                        return setImmediate(callback, null, [
+                            { address: '203.0.113.10', family: 4 }, // not restricted
+                            { address: '127.0.0.1', family: 4 } // restricted — must be rejected
+                        ]);
+                    }
+
+                    return setImmediate(callback, null, '127.0.0.1', 4);
+                }
+
+                return dns.lookup.wrappedMethod.call(dns, hostname, options, callback);
+            });
+
+            this.run({
+                collection: {
+                    item: [{
+                        request: 'http://' + MULTI_A_HOST + '/'
+                    }]
+                },
+                network: {
+                    restrictedAddresses: { '127.0.0.1': true }
+                },
+                timeout: { request: 5000 }
+            }, function (err, results) {
+                testrun = results;
+                done(err);
+            });
+        });
+
+        after(function () {
+            sandbox && sandbox.restore();
+        });
+
+        it('should have completed the run', function () {
+            expect(testrun).to.be.ok;
+            expect(testrun.done.getCall(0).args[0]).to.be.null;
+            expect(testrun).to.nested.include({
+                'done.calledOnce': true,
+                'start.calledOnce': true
+            });
+        });
+
+        it('should block a host that resolves to multiple A records when any one is restricted', function () {
+            var error = testrun.response.getCall(0).args[0],
+                response = testrun.response.getCall(0).args[2];
+
+            expect(error).to.have.property('message');
+            expect(error.message).to.include('NETERR:');
+            expect(error.message).to.include(MULTI_A_HOST);
+            expect(response).to.be.undefined;
+        });
+    });
+
+    describe('AAAA record resolving to restricted IPv6', function () {
+        var testrun;
+
+        before(function (done) {
+            this.run({
+                collection: {
+                    item: [{
+                        // host resolves (via hostIpMap) to the IPv6 loopback ::1
+                        request: 'http://aaaa.restricted.test/'
+                    }]
+                },
+                network: {
+                    restrictedAddresses: { '::1': true },
+                    hostLookup: {
+                        type: 'hostIpMap',
+                        hostIpMap: {
+                            'aaaa.restricted.test': '::1'
+                        }
+                    }
+                }
+            }, function (err, results) {
+                testrun = results;
+                done(err);
+            });
+        });
+
+        it('should have completed the run', function () {
+            expect(testrun).to.be.ok;
+            expect(testrun.done.getCall(0).args[0]).to.be.null;
+            expect(testrun).to.nested.include({
+                'done.calledOnce': true,
+                'start.calledOnce': true
+            });
+        });
+
+        it('should block a host whose AAAA record resolves to a restricted IPv6 address', function () {
+            var error = testrun.response.getCall(0).args[0],
+                response = testrun.response.getCall(0).args[2];
+
+            expect(error).to.have.property('message');
+            expect(error.message).to.include('NETERR:');
+            expect(error.message).to.include('aaaa.restricted.test');
+            expect(response).to.be.undefined;
+        });
+    });
+
+    describe('wildcard DNS resolving to loopback', function () {
+        var testrun;
+
+        before(function (done) {
+            this.run({
+                collection: {
+                    item: [{
+                        // nip.io-style wildcard host that resolves to 127.0.0.1
+                        request: 'http://127.0.0.1.nip.io/'
+                    }]
+                },
+                network: {
+                    restrictedAddresses: { '127.0.0.0/8': true },
+                    hostLookup: {
+                        type: 'hostIpMap',
+                        hostIpMap: {
+                            '127.0.0.1.nip.io': '127.0.0.1'
+                        }
+                    }
+                }
+            }, function (err, results) {
+                testrun = results;
+                done(err);
+            });
+        });
+
+        it('should have completed the run', function () {
+            expect(testrun).to.be.ok;
+            expect(testrun.done.getCall(0).args[0]).to.be.null;
+            expect(testrun).to.nested.include({
+                'done.calledOnce': true,
+                'start.calledOnce': true
+            });
+        });
+
+        it('should block a wildcard-DNS host that resolves into a restricted CIDR', function () {
+            var error = testrun.response.getCall(0).args[0],
+                response = testrun.response.getCall(0).args[2];
+
+            expect(error).to.have.property('message');
+            expect(error.message).to.include('NETERR:');
+            expect(error.message).to.include('127.0.0.1.nip.io');
+            expect(response).to.be.undefined;
+        });
+    });
+
+    describe('host resolving to 0.0.0.0', function () {
+        var testrun;
+
+        before(function (done) {
+            this.run({
+                collection: {
+                    item: [{
+                        request: 'http://zeros.restricted.test/'
+                    }]
+                },
+                network: {
+                    restrictedAddresses: { '0.0.0.0/8': true },
+                    hostLookup: {
+                        type: 'hostIpMap',
+                        hostIpMap: {
+                            'zeros.restricted.test': '0.0.0.0'
+                        }
+                    }
+                }
+            }, function (err, results) {
+                testrun = results;
+                done(err);
+            });
+        });
+
+        it('should have completed the run', function () {
+            expect(testrun).to.be.ok;
+            expect(testrun.done.getCall(0).args[0]).to.be.null;
+            expect(testrun).to.nested.include({
+                'done.calledOnce': true,
+                'start.calledOnce': true
+            });
+        });
+
+        it('should block a host that resolves to 0.0.0.0 within 0.0.0.0/8', function () {
+            var error = testrun.response.getCall(0).args[0],
+                response = testrun.response.getCall(0).args[2];
+
+            expect(error).to.have.property('message');
+            expect(error.message).to.include('NETERR:');
+            expect(error.message).to.include('zeros.restricted.test');
+            expect(response).to.be.undefined;
+        });
+    });
+
+    describe('multi-hop redirect chain landing on a restricted IP', function () {
+        var testrun;
+
+        before(function (done) {
+            var redirectServer = global.servers.http,
+                // hop 2: /redirect-to that points at the restricted raw IP
+                hop2 = redirectServer + '/redirect-to?url=http://127.0.0.2/';
+
+            this.run({
+                collection: {
+                    item: [{
+                        // hop 1 -> hop 2 -> http://127.0.0.2/ (restricted); blocked at hop 2's target
+                        request: redirectServer + '/redirect-to?url=' + hop2
+                    }]
+                },
+                network: {
+                    restrictedAddresses: { '127.0.0.2': true }
+                },
+                timeout: { request: 5000 }
+            }, function (err, results) {
+                testrun = results;
+                done(err);
+            });
+        });
+
+        it('should have completed the run', function () {
+            expect(testrun).to.be.ok;
+            expect(testrun.done.getCall(0).args[0]).to.be.null;
+            expect(testrun).to.nested.include({
+                'done.calledOnce': true,
+                'start.calledOnce': true
+            });
+        });
+
+        it('should block a redirect chain whose second hop lands on a restricted IP', function () {
+            var error = testrun.response.getCall(0).args[0],
+                response = testrun.response.getCall(0).args[2];
+
+            expect(error).to.have.property('message');
+            expect(error.message).to.include('NETERR:');
+            expect(error.message).to.include('127.0.0.2');
+            expect(response).to.be.undefined;
+        });
+    });
+
+    describe('hosts that resolve into a restricted range', function () {
+        var testrun;
+
+        before(function (done) {
+            this.run({
+                collection: {
+                    item: [{
+                        // host resolves (via hostIpMap) to a link-local address in 169.254.0.0/16
+                        request: 'http://internal.example.test/'
+                    }, {
+                        // direct CGNAT IP restricted by an exact entry
+                        request: 'http://100.100.100.200/'
+                    }]
+                },
+                network: {
+                    restrictedAddresses: { '169.254.0.0/16': true, '100.100.100.200': true },
+                    hostLookup: {
+                        type: 'hostIpMap',
+                        hostIpMap: {
+                            'internal.example.test': '169.254.0.10'
+                        }
+                    }
+                },
+                timeout: { request: 5000 }
+            }, function (err, results) {
+                testrun = results;
+                done(err);
+            });
+        });
+
+        it('should have completed the run', function () {
+            expect(testrun).to.be.ok;
+            expect(testrun.done.getCall(0).args[0]).to.be.null;
+            expect(testrun).to.nested.include({
+                'done.calledOnce': true,
+                'start.calledOnce': true
+            });
+        });
+
+        it('should restrict a host that resolves into the 169.254.0.0/16 range', function () {
+            var error = testrun.response.getCall(0).args[0],
+                response = testrun.response.getCall(0).args[2];
+
+            expect(error).to.have.property('message');
+            expect(error.message).to.include('NETERR:');
+            expect(error.message).to.include('internal.example.test');
+            expect(response).to.be.undefined;
+        });
+
+        it('should restrict a direct request to the CGNAT IP 100.100.100.200', function () {
+            var error = testrun.response.getCall(1).args[0],
+                response = testrun.response.getCall(1).args[2];
+
+            expect(error).to.have.property('message');
+            expect(error.message).to.include('NETERR:');
+            expect(error.message).to.include('100.100.100.200');
+            expect(response).to.be.undefined;
+        });
+    });
+
+    // @note this is intentionally the LAST describe in this file. It replaces the old
+    // httpbin-dependent "redirect resolves to restricted IP" case using the local
+    // redirect server + hostIpMap so it runs offline. A restricted redirect whose target
+    // is resolved (and rejected) at the DNS-lookup stage leaves an IPv6 connection in a
+    // state that can hang a *following* IPv6-redirect spec in this process, so this run
+    // is isolated at the end where nothing runs after it.
+    describe('redirect resolving to a restricted IP via DNS', function () {
+        var testrun;
+
+        before(function (done) {
+            var redirectServer = global.servers.http;
+
+            this.run({
+                collection: {
+                    item: [{
+                        // 301s to a hostname that hostIpMap resolves to the restricted
+                        // 169.254.169.254 — the follow-up request is blocked at DNS lookup
+                        request: redirectServer + '/redirect-to?url=http://redirect.vulnerable.postman.wtf/'
+                    }]
+                },
+                network: {
+                    restrictedAddresses: { '169.254.169.254': true },
+                    hostLookup: {
+                        type: 'hostIpMap',
+                        hostIpMap: {
+                            'redirect.vulnerable.postman.wtf': '169.254.169.254'
+                        }
+                    }
+                },
+                timeout: { request: 5000 }
+            }, function (err, results) {
+                testrun = results;
+                done(err);
+            });
+        });
+
+        it('should have completed the run', function () {
+            expect(testrun).to.be.ok;
+            expect(testrun.done.getCall(0).args[0]).to.be.null;
+            expect(testrun).to.nested.include({
+                'done.calledOnce': true,
+                'start.calledOnce': true
+            });
+        });
+
+        it('should not send request for redirects that resolve to restricted IP addresses', function () {
+            expect(testrun).to.be.ok;
+            var error = testrun.response.getCall(0).args[0],
+                response = testrun.response.getCall(0).args[2];
+
+            // the redirect target resolves (via hostIpMap) to the restricted 169.254.169.254,
+            // so the follow-up request is blocked with the DNS-resolution error shape
+            // @note nodeVersionDiscrepancy
+            expect(error).to.have.property('message');
+            expect(error.message).to.be.oneOf([
+                'NETERR: getaddrinfo ENOTFOUND redirect.vulnerable.postman.wtf',
+                'NETERR: getaddrinfo ENOTFOUND redirect.vulnerable.postman.wtf redirect.vulnerable.postman.wtf:80'
+            ]);
+
             expect(response).to.be.undefined;
         });
     });

--- a/test/unit/requester-core.test.js
+++ b/test/unit/requester-core.test.js
@@ -1165,6 +1165,50 @@ describe('requester util', function () {
             });
         });
 
+        describe('bare exact-match entries get IPv6-embedding normalization too', function () {
+            it('should block an IPv4-mapped IPv6 form of an exact-match-only entry', function () {
+                expect(requesterCore.isAddressRestricted('::ffff:169.254.169.254', {
+                    restrictedAddresses: { '169.254.169.254': true }
+                })).to.be.true;
+            });
+
+            it('should block a NAT64-embedded form of an exact-match-only entry', function () {
+                expect(requesterCore.isAddressRestricted('64:ff9b::a9fe:a9fe', {
+                    restrictedAddresses: { '169.254.169.254': true }
+                })).to.be.true;
+            });
+
+            it('should block an IPv4-compatible hex form of an exact-match-only entry', function () {
+                expect(requesterCore.isAddressRestricted('::7f00:1', {
+                    restrictedAddresses: { '127.0.0.1': true }
+                })).to.be.true;
+            });
+
+            it('should block a low-32-bit hex form that begins with 0.0', function () {
+                expect(requesterCore.isAddressRestricted('::7f01', {
+                    restrictedAddresses: { '0.0.127.1': true }
+                })).to.be.true;
+            });
+
+            it('should still block a bracketed IPv6 exact-match entry via an equivalent literal', function () {
+                expect(requesterCore.isAddressRestricted('0:0:0:0:0:0:0:1', {
+                    restrictedAddresses: { '[::1]': true }
+                })).to.be.true;
+            });
+
+            it('should still exact-match a hostname entry', function () {
+                expect(requesterCore.isAddressRestricted('internal.corp', {
+                    restrictedAddresses: { 'internal.corp': true }
+                })).to.be.true;
+            });
+
+            it('should not treat a hostname entry as a parseable address', function () {
+                expect(requesterCore.isAddressRestricted('other.corp', {
+                    restrictedAddresses: { 'internal.corp': true }
+                })).to.be.false;
+            });
+        });
+
         describe('CIDR range matching', function () {
             var ipv4CidrOpts;
 
@@ -1331,6 +1375,24 @@ describe('requester util', function () {
                 expect(requesterCore.isAddressRestricted('::0.0.0.1', {
                     restrictedAddresses: { '0.0.0.0/8': true }
                 })).to.be.true;
+            });
+
+            it('should block ::7f00:1 via a 127.0.0.0/8 CIDR', function () {
+                expect(requesterCore.isAddressRestricted('::7f00:1', {
+                    restrictedAddresses: { '127.0.0.0/8': true }
+                })).to.be.true;
+            });
+
+            it('should block ::7f01 via a 0.0.0.0/8 CIDR', function () {
+                expect(requesterCore.isAddressRestricted('::7f01', {
+                    restrictedAddresses: { '0.0.0.0/8': true }
+                })).to.be.true;
+            });
+
+            it('should not match ::1 against an unrelated 0.0.0.0/8 IPv4 CIDR', function () {
+                expect(requesterCore.isAddressRestricted('::1', {
+                    restrictedAddresses: { '0.0.0.0/8': true }
+                })).to.be.false;
             });
         });
 
@@ -1604,4 +1666,3 @@ describe('requester util', function () {
         });
     });
 });
-

--- a/test/unit/requester-core.test.js
+++ b/test/unit/requester-core.test.js
@@ -1444,6 +1444,164 @@ describe('requester util', function () {
                 expect(opts.restrictedCidrs).to.be.an('array').with.lengthOf(0);
             });
         });
+
+        describe('special-use IPv4 ranges', function () {
+            it('should restrict CGNAT addresses within 100.64.0.0/10', function () {
+                expect(requesterCore.isAddressRestricted('100.64.1.1', {
+                    restrictedAddresses: { '100.64.0.0/10': true }
+                })).to.be.true;
+                expect(requesterCore.isAddressRestricted('100.100.100.200', {
+                    restrictedAddresses: { '100.64.0.0/10': true }
+                })).to.be.true;
+            });
+
+            it('should restrict multicast 224.0.0.1 within 224.0.0.0/4', function () {
+                expect(requesterCore.isAddressRestricted('224.0.0.1', {
+                    restrictedAddresses: { '224.0.0.0/4': true }
+                })).to.be.true;
+            });
+
+            it('should restrict reserved 240.0.0.1 within 240.0.0.0/4', function () {
+                expect(requesterCore.isAddressRestricted('240.0.0.1', {
+                    restrictedAddresses: { '240.0.0.0/4': true }
+                })).to.be.true;
+            });
+
+            it('should restrict benchmarking 198.18.0.1 within 198.18.0.0/15', function () {
+                expect(requesterCore.isAddressRestricted('198.18.0.1', {
+                    restrictedAddresses: { '198.18.0.0/15': true }
+                })).to.be.true;
+            });
+
+            it('should restrict 6to4-anycast 192.88.99.1 within 192.88.99.0/24', function () {
+                expect(requesterCore.isAddressRestricted('192.88.99.1', {
+                    restrictedAddresses: { '192.88.99.0/24': true }
+                })).to.be.true;
+            });
+
+            it('should restrict TEST-NET addresses (192.0.2/24, 198.51.100/24, 203.0.113/24)', function () {
+                var opts = {
+                    restrictedAddresses: {
+                        '192.0.2.0/24': true,
+                        '198.51.100.0/24': true,
+                        '203.0.113.0/24': true
+                    }
+                };
+
+                expect(requesterCore.isAddressRestricted('192.0.2.1', opts)).to.be.true;
+                expect(requesterCore.isAddressRestricted('198.51.100.1', opts)).to.be.true;
+                expect(requesterCore.isAddressRestricted('203.0.113.1', opts)).to.be.true;
+            });
+
+            it('should restrict the limited broadcast 255.255.255.255 via an exact entry', function () {
+                expect(requesterCore.isAddressRestricted('255.255.255.255', {
+                    restrictedAddresses: { '255.255.255.255': true }
+                })).to.be.true;
+            });
+
+            it('should restrict IETF-protocol 192.0.0.1 within 192.0.0.0/24', function () {
+                expect(requesterCore.isAddressRestricted('192.0.0.1', {
+                    restrictedAddresses: { '192.0.0.0/24': true }
+                })).to.be.true;
+            });
+        });
+
+        describe('alternate IPv4 encodings resolving to 127.0.0.1', function () {
+            var loopbackCidr = { '127.0.0.0/8': true };
+
+            it('should restrict the decimal (dword) form 2130706433', function () {
+                expect(requesterCore.isAddressRestricted('2130706433', {
+                    restrictedAddresses: loopbackCidr
+                })).to.be.true;
+            });
+
+            it('should restrict the octal form 0177.0.0.1', function () {
+                expect(requesterCore.isAddressRestricted('0177.0.0.1', {
+                    restrictedAddresses: loopbackCidr
+                })).to.be.true;
+            });
+
+            it('should restrict the mixed-hex form 0x7f.0.0.1', function () {
+                expect(requesterCore.isAddressRestricted('0x7f.0.0.1', {
+                    restrictedAddresses: loopbackCidr
+                })).to.be.true;
+            });
+
+            it('should restrict the single-hex (dword) form 0x7f000001', function () {
+                expect(requesterCore.isAddressRestricted('0x7f000001', {
+                    restrictedAddresses: loopbackCidr
+                })).to.be.true;
+            });
+
+            it('should restrict the short (class-A) form 127.1', function () {
+                expect(requesterCore.isAddressRestricted('127.1', {
+                    restrictedAddresses: loopbackCidr
+                })).to.be.true;
+            });
+
+            it('should restrict the zero-padded form 127.000.000.001', function () {
+                expect(requesterCore.isAddressRestricted('127.000.000.001', {
+                    restrictedAddresses: loopbackCidr
+                })).to.be.true;
+            });
+        });
+
+        describe('IPv4-compatible IPv6 in hex form', function () {
+            it('should restrict the hex form ::7f00:1 (embeds 127.0.0.1) via a 127.0.0.0/8 CIDR', function () {
+                // ::7f00:1 embeds 127.0.0.1 in the low 32 bits; ipaddr.js reports it as
+                // generic unicast, so without explicit normalization it would not be matched
+                // against a 127.0.0.0/8 entry the way the dotted form is.
+                expect(requesterCore.isAddressRestricted('::7f00:1', {
+                    restrictedAddresses: { '127.0.0.0/8': true }
+                })).to.be.true;
+            });
+
+            it('should restrict a bracketed [::7f00:1]', function () {
+                expect(requesterCore.isAddressRestricted('[::7f00:1]', {
+                    restrictedAddresses: { '127.0.0.0/8': true }
+                })).to.be.true;
+            });
+
+            it('should NOT treat ::1 as a hex-compat address under 127.0.0.0/8', function () {
+                // ::1 has parts[6] === 0, so it is the IPv6 loopback, not 0.0.x.x — the
+                // parts[6] !== 0 guard must keep it out of the 127.0.0.0/8 IPv4 match
+                expect(requesterCore.isAddressRestricted('::1', {
+                    restrictedAddresses: { '127.0.0.0/8': true }
+                })).to.be.false;
+            });
+
+            it('leaves a public IPv6 (2606:4700::1) unaffected by hex-compat normalization', function () {
+                expect(requesterCore.isAddressRestricted('2606:4700::1', {
+                    restrictedAddresses: { '127.0.0.0/8': true }
+                })).to.be.false;
+            });
+        });
+
+        describe('IPv6 range matching', function () {
+            it('should restrict a link-local fe80::1 within fe80::/10', function () {
+                expect(requesterCore.isAddressRestricted('fe80::1', {
+                    restrictedAddresses: { 'fe80::/10': true }
+                })).to.be.true;
+            });
+
+            it('should restrict a public IPv6 2606:4700::1 under the ::/0 catch-all CIDR', function () {
+                expect(requesterCore.isAddressRestricted('2606:4700::1', {
+                    restrictedAddresses: { '::/0': true }
+                })).to.be.true;
+            });
+        });
+
+        describe('Teredo addresses', function () {
+            it('documents that Teredo addresses are not normalized (2001::/32)', function () {
+                // A Teredo address carries the Teredo server's IPv4 (bits 32-63), not the
+                // destination, so it is intentionally left un-normalized. This test pins the
+                // current behavior; if a future change decides to normalize Teredo, this
+                // expectation should be revisited deliberately.
+                expect(requesterCore.isAddressRestricted('2001:0:7f00:1:0:0:0:1', {
+                    restrictedAddresses: { '127.0.0.0/8': true }
+                })).to.be.false;
+            });
+        });
     });
 });
 


### PR DESCRIPTION
### What

`isAddressRestricted()` recognised IPv4-compatible IPv6 addresses only in their dotted form (`::a.b.c.d`). The equivalent hex form (e.g. `::7f00:1`) is reported by `ipaddr.js` as a generic `unicast` address, so it was not reduced to its embedded IPv4 and therefore did not match a configured IPv4 `restrictedAddresses` entry the way the dotted form does — an inconsistency in address normalization.

### Change

- Normalize the hex form: when the first six hextet groups are zero and the seventh is non-zero, match on the embedded IPv4 (the last four bytes). `::1` (`parts[6] === 0`) and ordinary IPv6 addresses (`parts[0] !== 0`) are unaffected; the existing `rfc6052`/`rfc6145`/`6to4` handling is unchanged. Teredo (`2001::/32`) is intentionally left as-is because it carries the relay server's address rather than the destination.
- Broadens `restrictedAddresses` test coverage: additional special-use IPv4 ranges, alternate IPv4 literal encodings, more IPv6 ranges, and DNS/redirect resolution cases (multiple A records, AAAA, wildcard DNS, `0.0.0.0`, redirect chains), plus a scoped integration runner for the restricted-addresses suite.

### Tests

- Unit (`test/unit/requester-core.test.js`): 122 passing
- Integration (restricted-addresses): 32 passing