### PR TITLE
Expose performance test output reports to scripts

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,6 @@
 module.exports = {
     Runner: require('./runner'),
     Requester: require('./requester').Requester,
-    version: require('./version')
+    version: require('./version'),
+    features: Object.freeze({ performanceTestOutputReportV1: true })
 };

--- a/lib/runner/extensions/event.command.js
+++ b/lib/runner/extensions/event.command.js
@@ -12,7 +12,7 @@ var _ = require('lodash'),
 
     ASSERTION_FAILURE = 'AssertionFailure',
     SAFE_CONTEXT_VARIABLES = ['_variables', 'environment', 'globals', 'collectionVariables', 'cookies', 'data',
-        'request', 'response'],
+        'request', 'response', 'report'],
 
     EXECUTION_REQUEST_EVENT_BASE = 'execution.request.',
     EXECUTION_RUN_REQUEST_EVENT_BASE = 'execution.run_collection_request.',

--- a/lib/runner/extensions/item.command.js
+++ b/lib/runner/extensions/item.command.js
@@ -174,6 +174,12 @@ module.exports = {
                         _forbiddenSecretKeys: forbiddenSecretKeys
                     };
 
+                    // Performance output is immutable host-provided execution context, not a variable scope.
+                    // Preserve absence for ordinary runs so the Sandbox omits the entire pm.performanceTest API.
+                    if (_.has(self.options, 'script.performanceTest.output.report')) {
+                        ctxTemplate.report = self.options.script.performanceTest.output.report;
+                    }
+
                     // @todo make it less nested by coding Instruction.thenQueue
                     this.queue('event', {
                         name: 'prerequest',

--- a/lib/runner/index.js
+++ b/lib/runner/index.js
@@ -116,6 +116,9 @@ _.assign(Runner.prototype, {
      * `variable` array containing list of request-specific-collection variables and `event` with scripts to execute.
      * @param {Number} [options.maxInvokableNestedRequests] - The maximum nested depth
      * that a script can invoke via pm.execution.runRequest
+     * @param {Object|null} [options.script.performanceTest.output.report] - Optional JSON-safe, host-provided report
+     * exposed as `pm.performanceTest.output.report.json`. The option is presence-gated and inherited by nested
+     * `pm.execution.runRequest` executions.
      * @param {Number} [options.iterationCount] -
      * @param {CertificateList} [options.certificates] -
      * @param {ProxyConfigList} [options.proxies] -

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "postman-runtime",
-  "version": "7.56.1",
+  "version": "7.56.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "postman-runtime",
-      "version": "7.56.1",
+      "version": "7.56.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@postman/tough-cookie": "4.1.3-postman.1",
@@ -25,7 +25,7 @@
         "performance-now": "2.1.0",
         "postman-collection": "5.3.1",
         "postman-request": "2.88.1-postman.49",
-        "postman-sandbox": "6.7.4",
+        "postman-sandbox": "6.7.5",
         "postman-url-encoder": "3.0.8",
         "serialised-error": "1.1.3",
         "strip-json-comments": "3.1.1",
@@ -7984,9 +7984,9 @@
       }
     },
     "node_modules/postman-sandbox": {
-      "version": "6.7.4",
-      "resolved": "https://registry.npmjs.org/postman-sandbox/-/postman-sandbox-6.7.4.tgz",
-      "integrity": "sha512-gJqcrdbsSVpfCHvwindV5IUbZt9ThV77ChUVdhMvdtBLydxFhmvdnqiE3tTIPgLEqjAYVRHw8h7iobLNMVUMlQ==",
+      "version": "6.7.5",
+      "resolved": "https://registry.npmjs.org/postman-sandbox/-/postman-sandbox-6.7.5.tgz",
+      "integrity": "sha512-7OS80S5pzU/ZdzH5RNLvYKJEvb0O35P55LlrJfqM3cx7kKYhSXQu0Xo+Vb0L5q+N+1LkywNINyuKXAx0yte+mw==",
       "license": "Apache-2.0",
       "dependencies": {
         "lodash": "4.18.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postman-runtime",
-  "version": "7.56.1",
+  "version": "7.56.2",
   "description": "Underlying library of executing Postman Collections",
   "author": "Postman Inc.",
   "license": "Apache-2.0",
@@ -58,7 +58,7 @@
     "performance-now": "2.1.0",
     "postman-collection": "5.3.1",
     "postman-request": "2.88.1-postman.49",
-    "postman-sandbox": "6.7.4",
+    "postman-sandbox": "6.7.5",
     "postman-url-encoder": "3.0.8",
     "serialised-error": "1.1.3",
     "strip-json-comments": "3.1.1",

--- a/test/integration/runner-spec/run-collection-request.test.js
+++ b/test/integration/runner-spec/run-collection-request.test.js
@@ -3,6 +3,106 @@ const sdk = require('postman-collection'),
     collectionRunner = require('../../../lib/runner');
 
 describe('pm.execution.runRequest handling', function () {
+    it('should expose the same report to parent and nested request scripts', function (done) {
+        const report = {
+                spec: '0.1.0-alpha.1',
+                type: 'summary',
+                totals: { requests: 7 },
+                by_op: [{ name: 'GET /workload', count: 7 }]
+            },
+            assertionNames = [],
+            collection = new sdk.Collection({
+                item: [{
+                    id: 'root-request-id',
+                    event: [{
+                        listen: 'prerequest',
+                        script: {
+                            exec: `
+                                pm.test('parent report is available', function () {
+                                    pm.expect(
+                                        pm.performanceTest.output.report.json
+                                    ).to.deep.equal(${JSON.stringify(report)});
+                                });
+                                await pm.execution.runRequest('nested-request-id');
+                            `
+                        }
+                    }],
+                    request: { url: 'https://postman-echo.com/status/204', method: 'GET' }
+                }]
+            });
+
+        new collectionRunner().run(collection, {
+            script: {
+                performanceTest: { output: { report } },
+                requestResolver: function (_requestId, _nestedRequestContext, callback) {
+                    callback(null, {
+                        item: [{
+                            id: 'nested-request-id',
+                            event: [{
+                                listen: 'prerequest',
+                                script: {
+                                    exec: `
+                                        pm.test('nested report is available', function () {
+                                            pm.expect(
+                                                pm.performanceTest.output.report.json
+                                            ).to.deep.equal(${JSON.stringify(report)});
+                                        });
+                                    `
+                                }
+                            }],
+                            request: { url: 'https://postman-echo.com/status/204', method: 'GET' }
+                        }]
+                    });
+                }
+            }
+        }, function (_err, run) {
+            run.start({
+                assertion (_cursor, assertions) {
+                    assertions.forEach(function (assertion) {
+                        expect(assertion.passed).to.be.true;
+                        assertionNames.push(assertion.name);
+                    });
+                },
+                done (err) {
+                    expect(assertionNames).to.include.members([
+                        'parent report is available',
+                        'nested report is available'
+                    ]);
+                    done(err);
+                }
+            });
+        });
+    });
+
+    it('should leave pm.performanceTest undefined when the report option is absent', function (done) {
+        const collection = new sdk.Collection({
+            item: [{
+                event: [{
+                    listen: 'prerequest',
+                    script: {
+                        exec: `pm.test('report is absent', function () {
+                            pm.expect(typeof pm.performanceTest).to.equal('undefined');
+                        });`
+                    }
+                }],
+                request: { url: 'https://postman-echo.com/status/204', method: 'GET' }
+            }]
+        });
+
+        new collectionRunner().run(collection, {}, function (_err, run) {
+            run.start({
+                assertion (_cursor, assertions) {
+                    assertions.forEach(function (assertion) {
+                        expect(assertion.passed).to.be.true;
+                    });
+                },
+                done (err) {
+                    done(err);
+                }
+            });
+        });
+    });
+
     it('[overview] should receive calls from postman-sandbox, resolve a request using bridge & ' +
         'make an API call to return a response',
     function (done) {

--- a/test/unit/runtime-features.test.js
+++ b/test/unit/runtime-features.test.js
@@ -1,0 +1,9 @@
+var expect = require('chai').expect,
+    runtime = require('../..');
+
+describe('runtime features', function () {
+    it('should explicitly advertise native script report support', function () {
+        expect(runtime.features).to.deep.equal({ performanceTestOutputReportV1: true });
+        expect(Object.isFrozen(runtime.features)).to.be.true;
+    });
+});


### PR DESCRIPTION
## Summary

- propagate the host-provided performance test report through Runtime script contexts
- expose it as `pm.performanceTest.output.report.json` through the supporting Sandbox release
- preserve complete API absence when no report is supplied and inherit the context for nested requests
- advertise the native report capability for agent negotiation

## Verification

- 572 unit tests passing, 10 pending
- 1902 integration tests passing, 33 pending; one unrelated localhost:3000 environment-only failure
- focused parent, nested-request, absence, and capability tests passing
- lint and diff checks clean